### PR TITLE
Want to avoid a client crash on ManFst004

### DIFF
--- a/src/servers/Scripts/quest/ManFst004.cpp
+++ b/src/servers/Scripts/quest/ManFst004.cpp
@@ -223,10 +223,10 @@ private:
                       [ & ]( Entity::Player& player, const Event::SceneResult& result )
                       {
                         // accepting quest "close to home"
-                        player.updateQuest( getId(), 1 );
+                        player.updateQuest( getId(), Seq1 );
                         player.setQuestUI8CH( getId(), 1 ); // receive key item
                         // event is done, need to teleport to real zone.
-                        player.setZone( 132 );
+                        player.forceZoneing( Territorytype0 );
                         //player.setZone(183); back to starting griania for debug purpose
                       } );
   }


### PR DESCRIPTION
The function setZone caused a client crash with call.
Changed with forceZoneing and now the quest work properly! :smile: 