### PR TITLE
Avoid Cmake that create C++14 build with C++17 installed

### DIFF
--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -9,6 +9,14 @@ else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHc")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
+  
+  if (MSVC_VERSION GREATER_EQUAL "1900")
+    include(CheckCXXCompilerFlag)
+    CHECK_CXX_COMPILER_FLAG("/std:c++latest" _cpp_latest_flag_supported)
+    if (_cpp_latest_flag_supported)
+        add_compile_options("/std:c++latest")
+    endif()
+  endif()
 
   if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     # disabling SAFESEH


### PR DESCRIPTION
At my second time with this problem I found the reason that VS didn't let me compile build.

For some weird reason, Cmake did a build with standard std::c++14 (And Im full able to use std::c++17).