### PR TITLE
ActorControl, OpCode and NpcSpawn findings. Also added worldId to Examine and PlayerSpawn

### DIFF
--- a/src/common/Network/CommonActorControl.h
+++ b/src/common/Network/CommonActorControl.h
@@ -77,7 +77,7 @@ enum ActorControlType : uint16_t
     TreasureScreenMsg = 0x57,
     SetOwnerId = 0x59,
     ItemRepairMsg = 0x5C,
-    BluActionLearn = 0x63, // Displays "Action Learned!" animation. Only used for visual, doesn't actually unlock it. param1: actionId. param2: 0 = text only, 1 = text+animation
+    BluActionLearn = 0x63, // Displays "Action Learned!" animation. Only used for visual, doesn't actually unlock it. param1: actionId. param2: 0 = text only, 1 = text+animation. Verification needed
 
     DirectorInit = 0x64,
     DirectorClear = 0x65,

--- a/src/common/Network/CommonActorControl.h
+++ b/src/common/Network/CommonActorControl.h
@@ -77,6 +77,7 @@ enum ActorControlType : uint16_t
     TreasureScreenMsg = 0x57,
     SetOwnerId = 0x59,
     ItemRepairMsg = 0x5C,
+    BluActionLearn = 0x63, // Triggers the "Action Learned!" animation and tells which action is learned. Any action ID may be used
 
     DirectorInit = 0x64,
     DirectorClear = 0x65,
@@ -287,6 +288,8 @@ enum ActorControlType : uint16_t
     SetDutyActionHud = 0x5E9, // disable/enable
     SetDutyActionActive = 0x5EA,
     SetDutyActionRemaining = 0x5EB,
+
+    EurekaStep = 0x73A, // alters the Eureka maps depending on the progress of the player
   };
 
   enum ClientTriggerType

--- a/src/common/Network/CommonActorControl.h
+++ b/src/common/Network/CommonActorControl.h
@@ -289,7 +289,7 @@ enum ActorControlType : uint16_t
     SetDutyActionActive = 0x5EA,
     SetDutyActionRemaining = 0x5EB,
 
-    EurekaStep = 0x73A, // alters the Eureka maps depending on the progress of the player
+    EurekaStep = 0x73A, // alters the progress of the player on Eureka (is used for all the eureka zones)
   };
 
   enum ClientTriggerType

--- a/src/common/Network/CommonActorControl.h
+++ b/src/common/Network/CommonActorControl.h
@@ -77,7 +77,7 @@ enum ActorControlType : uint16_t
     TreasureScreenMsg = 0x57,
     SetOwnerId = 0x59,
     ItemRepairMsg = 0x5C,
-    BluActionLearn = 0x63, // Triggers the "Action Learned!" animation and tells which action is learned. Any action ID may be used
+    BluActionLearn = 0x63, // Displays "Action Learned!" animation. Only used for visual, doesn't actually unlock it. param1: actionId. param2: 0 = text only, 1 = text+animation
 
     DirectorInit = 0x64,
     DirectorClear = 0x65,

--- a/src/common/Network/PacketDef/Ipcs.h
+++ b/src/common/Network/PacketDef/Ipcs.h
@@ -182,6 +182,7 @@ namespace Sapphire::Network::Packets
     Mount = 0x01E8, // updated 4.5
 
     DirectorVars = 0x01EA, // updated 4.5
+    DirectorPopUp = 0x01F5, // display dialogue pop-ups in duties and FATEs, for example, Teraflare's countdown
 
     CFAvailableContents = 0xF1FD, // updated 4.2
 

--- a/src/common/Network/PacketDef/Zone/ServerZoneDef.h
+++ b/src/common/Network/PacketDef/Zone/ServerZoneDef.h
@@ -610,7 +610,8 @@ namespace Sapphire::Network::Packets::Server
     uint8_t mountFeet;
     uint8_t mountColor;
     uint8_t scale;
-    uint32_t u29b;
+    uint16_t elementalLevel; // Eureka
+    uint16_t element; // Eureka
     uint32_t u30b;
     Common::StatusEffect effect[30];
     Common::FFXIVARR_POSITION3 pos;

--- a/src/common/Network/PacketDef/Zone/ServerZoneDef.h
+++ b/src/common/Network/PacketDef/Zone/ServerZoneDef.h
@@ -1039,7 +1039,9 @@ namespace Sapphire::Network::Packets::Server
     char padding1[8];
     uint64_t mainWeaponModel;
     uint64_t secWeaponModel;
-    char unknown2[16];
+    uint8_t unknown2;
+    uint16_t worldId;
+    char unknown3[12];
     struct ItemData
     {
       uint32_t catalogId;

--- a/src/world/Network/PacketWrappers/ExaminePacket.h
+++ b/src/world/Network/PacketWrappers/ExaminePacket.h
@@ -49,6 +49,8 @@ namespace Sapphire::Network::Packets::Server
         m_data.mainWeaponModel = pTarget->getModelMainWeapon();
         m_data.secWeaponModel = pTarget->getModelSubWeapon();
 
+        m_data.worldId = 67; // TODO: world id from server
+
         memcpy( m_data.look, pTarget->getLookArray(), sizeof( m_data.look ) );
 
         m_data.models[ Common::GearModelSlot::ModelHead ] = pTarget->getModelForSlot( Common::GearModelSlot::ModelHead );

--- a/src/world/Network/PacketWrappers/PlayerSpawnPacket.h
+++ b/src/world/Network/PacketWrappers/PlayerSpawnPacket.h
@@ -31,6 +31,10 @@ namespace Sapphire::Network::Packets::Server
       m_data.classJob = static_cast< uint8_t >( player.getClass() );
       //m_data.status = static_cast< uint8_t >( pPlayer->getStatus() );
 
+// TODO: world id from server
+      m_data.currentWorldId = 67;
+      m_data.homeWorldId = 67;
+
       m_data.hPCurr = player.getHp();
       m_data.mPCurr = player.getMp();
       m_data.tPCurr = player.getTp();


### PR DESCRIPTION
Adding the worldId to Examine fixed the World Name appearing as "Unknown" when examining a player.
Adding it to PlayerSpawn fixed the World Name not showing up in the HUD, and fixed right-clicking a player to send a /tell.