### PR TITLE
Added ExamineSearchInfo opcode and packet structure, ID'd CP and GP in PlayerStats packet structure

### DIFF
--- a/src/common/Common.h
+++ b/src/common/Common.h
@@ -24,6 +24,7 @@ namespace Sapphire::Common
   const uint16_t MAX_PLAYER_LEVEL = 80;
   const uint8_t CURRENT_EXPANSION_ID = 3;
 
+  const uint8_t CLASSJOB_TOTAL = 38;
   const uint8_t CLASSJOB_SLOTS = 28;
 
   /*!

--- a/src/common/Network/PacketDef/Ipcs.h
+++ b/src/common/Network/PacketDef/Ipcs.h
@@ -81,6 +81,7 @@ namespace Sapphire::Network::Packets
 
     SocialList = 0x010D, // updated 5.0
 
+    ExamineSearchInfo = 0x10F, // added 5.0
     UpdateSearchInfo = 0x0110, // updated 5.0
     InitSearchInfo = 0x0111, // updated 5.0
     ExamineSearchComment = 0x0102, // updated 4.1

--- a/src/common/Network/PacketDef/Ipcs.h
+++ b/src/common/Network/PacketDef/Ipcs.h
@@ -81,7 +81,7 @@ namespace Sapphire::Network::Packets
 
     SocialList = 0x010D, // updated 5.0
 
-    ExamineSearchInfo = 0x10F, // added 5.0
+    ExamineSearchInfo = 0x010F, // added 5.0
     UpdateSearchInfo = 0x0110, // updated 5.0
     InitSearchInfo = 0x0111, // updated 5.0
     ExamineSearchComment = 0x0102, // updated 4.1

--- a/src/common/Network/PacketDef/Zone/ServerZoneDef.h
+++ b/src/common/Network/PacketDef/Zone/ServerZoneDef.h
@@ -135,7 +135,7 @@ namespace Sapphire::Network::Packets::Server
     char fcName[24];
     uint8_t unknown7;
     uint16_t padding1;
-    uint16_t classJobIdLevel[Common::CLASSJOB_SLOTS * 2]; // Pairs of classJobId, classJobLevel
+    uint16_t classJobIdLevel[76]; // Pairs of classJobId, classJobLevel (38 * 2)
     /*
     Like this:
     uint16_t gldId; // 1

--- a/src/common/Network/PacketDef/Zone/ServerZoneDef.h
+++ b/src/common/Network/PacketDef/Zone/ServerZoneDef.h
@@ -120,6 +120,10 @@ namespace Sapphire::Network::Packets::Server
     PlayerEntry entries[10];
   };
 
+  struct FFXIVIpcExamineSearchInfo : FFXIVIpcBasePacket< ExamineSearchInfo >
+  {
+    
+  };
 
   struct FFXIVIpcSetSearchInfo : FFXIVIpcBasePacket< UpdateSearchInfo >
   {

--- a/src/common/Network/PacketDef/Zone/ServerZoneDef.h
+++ b/src/common/Network/PacketDef/Zone/ServerZoneDef.h
@@ -122,7 +122,95 @@ namespace Sapphire::Network::Packets::Server
 
   struct FFXIVIpcExamineSearchInfo : FFXIVIpcBasePacket< ExamineSearchInfo >
   {
-    
+    uint32_t unknown;
+    uint16_t unknown1;
+    uint16_t unknown2;
+    char padding[16];
+    uint32_t unknown3;
+    uint16_t unknown4;
+    uint16_t unknown5;
+    uint16_t unknown6;
+    uint8_t worldId;
+    char searchMessage[193];
+    char fcName[24];
+    uint8_t unknown7;
+    uint16_t padding1;
+    uint16_t gldId; // 1
+    uint16_t gldLevel;
+    uint16_t pglId; // 2
+    uint16_t pglLevel;
+    uint16_t mrdId; // 3
+    uint16_t mrdLevel;
+    uint16_t lncId; // 4
+    uint16_t lncLevel;
+    uint16_t arcId; // 5
+    uint16_t arcLevel;
+    uint16_t cnjId; // 6
+    uint16_t cnjLevel;
+    uint16_t thmId; // 7
+    uint16_t thmLevel;
+    uint16_t crpId; // 8
+    uint16_t crpLevel;
+    uint16_t bsmId; // 9
+    uint16_t bsmLevel;
+    uint16_t armId; // 10
+    uint16_t armLevel;
+    uint16_t gsmId; // 11
+    uint16_t gsmLevel;
+    uint16_t ltwId; // 12
+    uint16_t ltwLevel;
+    uint16_t wvrId; // 13
+    uint16_t wvrLevel;
+    uint16_t alcId; // 14
+    uint16_t alcLevel;
+    uint16_t culId; // 15
+    uint16_t culLevel;
+    uint16_t minId; // 16
+    uint16_t minLevel;
+    uint16_t btnId; // 17
+    uint16_t btnLevel;
+    uint16_t fshId; // 18
+    uint16_t fshLevel;
+    uint16_t culId; // 19
+    uint16_t culLevel;
+    uint16_t mnkId; // 20
+    uint16_t mnkLevel;
+    uint16_t warId; // 21
+    uint16_t warLevel;
+    uint16_t drgId; // 22
+    uint16_t drgLevel;
+    uint16_t brdId; // 23
+    uint16_t brdLevel;
+    uint16_t pldId; // 24
+    uint16_t pldLevel;
+    uint16_t blmId; // 25
+    uint16_t blmLevel;
+    uint16_t acnId; // 26
+    uint16_t acnLevel;
+    uint16_t schId; // 27
+    uint16_t schLevel;
+    uint16_t smnId; // 28
+    uint16_t smnLevel;
+    uint16_t rogId; // 29
+    uint16_t rogLevel;
+    uint16_t ninId; // 30
+    uint16_t ninLevel;
+    uint16_t mchId; // 31
+    uint16_t mchLevel;
+    uint16_t drkId; // 32
+    uint16_t drkLevel;
+    uint16_t astId; // 33
+    uint16_t astLevel;
+    uint16_t samId; // 34
+    uint16_t samLevel;
+    uint16_t rdmId; // 35
+    uint16_t rdmLevel;
+    uint16_t bluId; // 36
+    uint16_t bluLevel;
+    uint16_t gnbId; // 37
+    uint16_t gnbLevel;
+    uint16_t dncId; // 38
+    uint16_t dncLevel;
   };
 
   struct FFXIVIpcSetSearchInfo : FFXIVIpcBasePacket< UpdateSearchInfo >

--- a/src/common/Network/PacketDef/Zone/ServerZoneDef.h
+++ b/src/common/Network/PacketDef/Zone/ServerZoneDef.h
@@ -135,82 +135,14 @@ namespace Sapphire::Network::Packets::Server
     char fcName[24];
     uint8_t unknown7;
     uint16_t padding1;
+    uint16_t classJobIdLevel[38 * 2]; // Pairs of classJobId, classJobLevel
+    /*
+    Like this:
     uint16_t gldId; // 1
     uint16_t gldLevel;
-    uint16_t pglId; // 2
-    uint16_t pglLevel;
-    uint16_t mrdId; // 3
-    uint16_t mrdLevel;
-    uint16_t lncId; // 4
-    uint16_t lncLevel;
-    uint16_t arcId; // 5
-    uint16_t arcLevel;
-    uint16_t cnjId; // 6
-    uint16_t cnjLevel;
-    uint16_t thmId; // 7
-    uint16_t thmLevel;
-    uint16_t crpId; // 8
-    uint16_t crpLevel;
-    uint16_t bsmId; // 9
-    uint16_t bsmLevel;
-    uint16_t armId; // 10
-    uint16_t armLevel;
-    uint16_t gsmId; // 11
-    uint16_t gsmLevel;
-    uint16_t ltwId; // 12
-    uint16_t ltwLevel;
-    uint16_t wvrId; // 13
-    uint16_t wvrLevel;
-    uint16_t alcId; // 14
-    uint16_t alcLevel;
-    uint16_t culId; // 15
-    uint16_t culLevel;
-    uint16_t minId; // 16
-    uint16_t minLevel;
-    uint16_t btnId; // 17
-    uint16_t btnLevel;
-    uint16_t fshId; // 18
-    uint16_t fshLevel;
-    uint16_t culId; // 19
-    uint16_t culLevel;
-    uint16_t mnkId; // 20
-    uint16_t mnkLevel;
-    uint16_t warId; // 21
-    uint16_t warLevel;
-    uint16_t drgId; // 22
-    uint16_t drgLevel;
-    uint16_t brdId; // 23
-    uint16_t brdLevel;
-    uint16_t pldId; // 24
-    uint16_t pldLevel;
-    uint16_t blmId; // 25
-    uint16_t blmLevel;
-    uint16_t acnId; // 26
-    uint16_t acnLevel;
-    uint16_t schId; // 27
-    uint16_t schLevel;
-    uint16_t smnId; // 28
-    uint16_t smnLevel;
-    uint16_t rogId; // 29
-    uint16_t rogLevel;
-    uint16_t ninId; // 30
-    uint16_t ninLevel;
-    uint16_t mchId; // 31
-    uint16_t mchLevel;
-    uint16_t drkId; // 32
-    uint16_t drkLevel;
-    uint16_t astId; // 33
-    uint16_t astLevel;
-    uint16_t samId; // 34
-    uint16_t samLevel;
-    uint16_t rdmId; // 35
-    uint16_t rdmLevel;
-    uint16_t bluId; // 36
-    uint16_t bluLevel;
-    uint16_t gnbId; // 37
-    uint16_t gnbLevel;
-    uint16_t dncId; // 38
-    uint16_t dncLevel;
+    uint16_t pglId;
+    etc... through DNC
+    */
   };
 
   struct FFXIVIpcSetSearchInfo : FFXIVIpcBasePacket< UpdateSearchInfo >

--- a/src/common/Network/PacketDef/Zone/ServerZoneDef.h
+++ b/src/common/Network/PacketDef/Zone/ServerZoneDef.h
@@ -135,13 +135,13 @@ namespace Sapphire::Network::Packets::Server
     char fcName[24];
     uint8_t unknown7;
     uint16_t padding1;
-    uint16_t classJobIdLevel[38 * 2]; // Pairs of classJobId, classJobLevel
+    uint16_t classJobIdLevel[Common::CLASSJOB_SLOTS * 2]; // Pairs of classJobId, classJobLevel
     /*
     Like this:
     uint16_t gldId; // 1
     uint16_t gldLevel;
     uint16_t pglId;
-    etc... through DNC
+    etc... through DNC (38)
     */
   };
 

--- a/src/common/Network/PacketDef/Zone/ServerZoneDef.h
+++ b/src/common/Network/PacketDef/Zone/ServerZoneDef.h
@@ -959,8 +959,8 @@ namespace Sapphire::Network::Packets::Server
     uint32_t hp;
     uint32_t mp;
     uint32_t tp;
-    uint32_t unknown;
-    uint32_t unknown_1;
+    uint32_t gp; // Set to 10000 as non-gatherer for some reason
+    uint32_t cp;
     uint32_t unknown_2;
     uint32_t tenacity;
     uint32_t attack;

--- a/src/common/Network/PacketDef/Zone/ServerZoneDef.h
+++ b/src/common/Network/PacketDef/Zone/ServerZoneDef.h
@@ -135,14 +135,11 @@ namespace Sapphire::Network::Packets::Server
     char fcName[24];
     uint8_t unknown7;
     uint16_t padding1;
-    uint16_t classJobIdLevel[76]; // Pairs of classJobId, classJobLevel (38 * 2)
-    /*
-    Like this:
-    uint16_t gldId; // 1
-    uint16_t gldLevel;
-    uint16_t pglId;
-    etc... through DNC (38)
-    */
+    struct ClassJobEntry
+    {
+      uint16_t id;
+      uint16_t level;
+    } levelEntries[Common::CLASSJOB_TOTAL];
   };
 
   struct FFXIVIpcSetSearchInfo : FFXIVIpcBasePacket< UpdateSearchInfo >


### PR DESCRIPTION
Correction of https://github.com/SapphireServer/Sapphire/pull/571.

I believe everything is in order, this time? I also renamed a couple `unknown` properties in PlayerStats to CP and GP, after a bit of extra testing.

Also, I'm not sure if this is intentional, but `Common::CLASSJOB_SLOTS` is 28, when there are 38 classes and jobs in total. https://github.com/SapphireServer/Sapphire/commit/b0eba69733425103e0d2fb4719a00c013686a0d0 has all of them and their IDs, but I collapsed them into an array in https://github.com/SapphireServer/Sapphire/commit/fbf82c937e991659d56782a8491a913c68249d80.