### PR TITLE
MarketBoardItemListing updated opcode, reordered ServerZoneDef market structs

### DIFF
--- a/src/common/Network/PacketDef/Ipcs.h
+++ b/src/common/Network/PacketDef/Ipcs.h
@@ -106,7 +106,7 @@ namespace Sapphire::Network::Packets
     ReqMoogleMailLetter = 0x0139, // updated 5.0
     MailLetterNotification = 0x013A, // updated 5.0
 
-    MarketBoardItemListingCount = 0x0125, // updated 4.5
+    MarketBoardItemListingCount = 0x013B, // updated 5.0
     MarketBoardItemListing = 0x013C, // updated 5.0
     MarketBoardItemListingHistory = 0x012A, // updated 4.5
     MarketBoardSearchResult = 0x0139, // updated 4.5

--- a/src/common/Network/PacketDef/Ipcs.h
+++ b/src/common/Network/PacketDef/Ipcs.h
@@ -107,7 +107,7 @@ namespace Sapphire::Network::Packets
     MailLetterNotification = 0x013A, // updated 5.0
 
     MarketBoardItemListingCount = 0x0125, // updated 4.5
-    MarketBoardItemListing = 0x0126, // updated 4.5
+    MarketBoardItemListing = 0x013C, // updated 5.0
     MarketBoardItemListingHistory = 0x012A, // updated 4.5
     MarketBoardSearchResult = 0x0139, // updated 4.5
 

--- a/src/common/Network/PacketDef/Zone/ServerZoneDef.h
+++ b/src/common/Network/PacketDef/Zone/ServerZoneDef.h
@@ -313,11 +313,20 @@ namespace Sapphire::Network::Packets::Server
       uint32_t unknown9;
       uint32_t unknown10;
       uint32_t unknown11;
-      char padding2[16];
+      char unknown12[16]; // Materia? Doesn't seem to match any IDs
       char retainerName[64];
       bool hq;
-      uint16_t padding3;
-      uint8_t unknown12;
+      uint8_t materiaCount;
+      uint8_t padding3;
+      uint8_t retainerCity;
+      /**
+       * 0x01 Limsa Lominsa
+       * 0x02 Gridania
+       * 0x03 Ul'dah
+       * 0x04 Ishgard
+       * 0x07 Kugane
+       * 0x0A Crystarium
+       */
       uint64_t padding4;
     } listing[10]; // Multiple packets are sent if there are more than 10 search results.
     uint32_t unknown13;

--- a/src/common/Network/PacketDef/Zone/ServerZoneDef.h
+++ b/src/common/Network/PacketDef/Zone/ServerZoneDef.h
@@ -313,7 +313,7 @@ namespace Sapphire::Network::Packets::Server
       uint16_t unknown8;
       uint16_t unknown9;
       uint32_t unknown10;
-      uint16_t unknown11; // Always 30000
+      uint16_t durability;
       uint16_t padding3;
       uint16_t materiaValue[5];
       /**

--- a/src/common/Network/PacketDef/Zone/ServerZoneDef.h
+++ b/src/common/Network/PacketDef/Zone/ServerZoneDef.h
@@ -294,7 +294,7 @@ namespace Sapphire::Network::Packets::Server
 
   struct FFXIVIpcMarketBoardItemListing : FFXIVIpcBasePacket< MarketBoardItemListing >
   {
-    struct itemListing // 152 bytes each
+    struct ItemListing // 152 bytes each
     {
       uint32_t unknown; // Changes if multiple packets are sent for a single item
       uint8_t padding;
@@ -309,13 +309,18 @@ namespace Sapphire::Network::Packets::Server
       uint32_t pricePerUnit;
       uint32_t unknown7;
       uint32_t itemQuantity;
-      uint32_t itemID;
+      uint32_t itemId;
       uint16_t unknown8;
       uint16_t unknown9;
       uint32_t unknown10;
       uint16_t unknown11; // Always 30000
       uint16_t padding3;
-      uint16_t materiaValue[5]; // Materia ID = (materiaValue & 0xFF0) >> 4
+      uint16_t materiaValue[5];
+      /**
+       * auto materiaId = (i & 0xFF0) >> 4;
+       * auto index = i & 0xF;
+       * auto leftover = i >> 8;
+       */
       uint32_t padding4;
       char retainerName[64];
       bool hq;

--- a/src/common/Network/PacketDef/Zone/ServerZoneDef.h
+++ b/src/common/Network/PacketDef/Zone/ServerZoneDef.h
@@ -296,7 +296,7 @@ namespace Sapphire::Network::Packets::Server
   {
     struct itemListing // 152 bytes each
     {
-      uint32_t unknown;
+      uint32_t unknown; // Changes if multiple packets are sent for a single item
       uint8_t padding;
       uint16_t unknown1;
       uint8_t padding1;
@@ -309,15 +309,18 @@ namespace Sapphire::Network::Packets::Server
       uint32_t pricePerUnit;
       uint32_t unknown7;
       uint32_t itemQuantity;
-      uint32_t unknown8;
-      uint32_t unknown9;
+      uint32_t itemID;
+      uint16_t unknown8;
+      uint16_t unknown9;
       uint32_t unknown10;
-      uint32_t unknown11;
-      char unknown12[16]; // Materia? Doesn't seem to match any IDs
+      uint16_t unknown11; // Always 30000
+      uint16_t padding3;
+      uint16_t materiaValue[5]; // Materia ID = (materiaValue & 0xFF0) >> 4
+      uint32_t padding4;
       char retainerName[64];
       bool hq;
       uint8_t materiaCount;
-      uint8_t padding3;
+      uint8_t padding5;
       uint8_t retainerCity;
       /**
        * 0x01 Limsa Lominsa
@@ -327,16 +330,16 @@ namespace Sapphire::Network::Packets::Server
        * 0x07 Kugane
        * 0x0A Crystarium
        */
-      uint64_t padding4;
+      uint64_t padding6;
     } listing[10]; // Multiple packets are sent if there are more than 10 search results.
-    uint32_t unknown13;
-    char padding5[16];
+    uint32_t unknown12;
+    char padding7[16];
+    uint8_t unknown13;
+    uint16_t padding8;
     uint8_t unknown14;
-    uint16_t padding6;
-    uint8_t unknown15;
-    uint64_t padding7;
-    uint32_t unknown16;
-    uint32_t padding8;
+    uint64_t padding9;
+    uint32_t unknown15;
+    uint32_t padding10;
   };
 
   struct FFXIVIpcMarketBoardItemListingHistory : FFXIVIpcBasePacket< MarketBoardItemListingHistory >

--- a/src/common/Network/PacketDef/Zone/ServerZoneDef.h
+++ b/src/common/Network/PacketDef/Zone/ServerZoneDef.h
@@ -272,7 +272,7 @@ namespace Sapphire::Network::Packets::Server
   * Structural representation of the packet sent by the server
   * to show the mail delivery notification
   */
-  struct FFXIVIpcMailLetterNotificationt : FFXIVIpcBasePacket< MailLetterNotification >
+  struct FFXIVIpcMailLetterNotification : FFXIVIpcBasePacket< MailLetterNotification >
   {
     uint32_t sendbackCount; // The amount of letters sent back since you ran out of room (moogle dialog changes based on this)
     uint16_t friendLetters; // The amount of letters in the friends section of the letterbox
@@ -281,6 +281,88 @@ namespace Sapphire::Network::Packets::Server
     uint8_t isGmLetter; // Makes the letter notification flash red
     uint8_t isSupportDesk; // After setting this to 1 we can no longer update mail notifications (more research needed on the support desk)
     char unk2[0x4]; // This has probs something to do with the support desk (inquiry id?)
+  };
+
+  struct FFFXIVIpcMarketBoardItemListingCount : FFXIVIpcBasePacket< MarketBoardItemListingCount >
+  {
+    uint32_t itemCatalogId;
+    uint32_t unknown1; // does some shit if nonzero
+    uint16_t requestId;
+    uint16_t quantity; // high/low u8s read separately?
+    uint32_t unknown3;
+  };
+
+  struct FFXIVIpcMarketBoardItemListing : FFXIVIpcBasePacket< MarketBoardItemListing >
+  {
+    struct itemListing // 152 bytes each
+    {
+      uint32_t unknown;
+      uint8_t padding;
+      uint16_t unknown1;
+      uint8_t padding1;
+      struct unknown2
+      {
+        uint32_t unknown3;
+        uint16_t unknown4;
+        uint16_t unknown5;
+      } unknown6[3];
+      uint32_t pricePerUnit;
+      uint32_t unknown7;
+      uint32_t itemQuantity;
+      uint32_t unknown8;
+      uint32_t unknown9;
+      uint32_t unknown10;
+      uint32_t unknown11;
+      char padding2[16];
+      char retainerName[64];
+      bool hq;
+      uint16_t padding3;
+      uint8_t unknown12;
+      uint64_t padding4;
+    } listing[10]; // Multiple packets are sent if there are more than 10 search results.
+    uint32_t unknown13;
+    char padding5[16];
+    uint8_t unknown14;
+    uint16_t padding6;
+    uint8_t unknown15;
+    uint64_t padding7;
+    uint32_t unknown16;
+    uint32_t padding8;
+  };
+
+  struct FFXIVIpcMarketBoardItemListingHistory : FFXIVIpcBasePacket< MarketBoardItemListingHistory >
+  {
+    uint32_t itemCatalogId;
+    uint32_t itemCatalogId2;
+
+    struct MarketListing
+    {
+      uint32_t salePrice;
+      uint32_t purchaseTime;
+      uint32_t quantity;
+      uint8_t isHq;
+      uint8_t padding;
+      uint8_t onMannequin;
+
+      char buyerName[33];
+
+      uint32_t itemCatalogId;
+    } listing[20];
+  };
+
+  struct FFXIVIpcMarketBoardSearchResult : FFXIVIpcBasePacket< MarketBoardSearchResult >
+  {
+    struct MarketBoardItem
+    {
+      uint32_t itemCatalogId;
+      uint16_t quantity;
+      uint16_t demand;
+    } items[20];
+
+    uint32_t itemIndexEnd;
+    uint32_t padding1;
+    uint32_t itemIndexStart;
+    uint32_t requestId;
   };
 
   struct FFXIVIpcExamineFreeCompanyInfo : FFXIVIpcBasePacket< ExamineFreeCompanyInfo >
@@ -1887,50 +1969,6 @@ namespace Sapphire::Network::Packets::Server
     uint32_t otherActorId;
 
     char otherName[32];
-  };
-
-  struct FFXIVIpcMarketBoardSearchResult : FFXIVIpcBasePacket< MarketBoardSearchResult >
-  {
-      struct MarketBoardItem
-      {
-          uint32_t itemCatalogId;
-          uint16_t quantity;
-          uint16_t demand;
-      } items[20];
-
-      uint32_t itemIndexEnd;
-      uint32_t padding1;
-      uint32_t itemIndexStart;
-      uint32_t requestId;
-  };
-
-  struct FFFXIVIpcMarketBoardItemListingCount : FFXIVIpcBasePacket< MarketBoardItemListingCount >
-  {
-    uint32_t itemCatalogId;
-    uint32_t unknown1; // does some shit if nonzero
-    uint16_t requestId;
-    uint16_t quantity; // high/low u8s read separately?
-    uint32_t unknown3;
-  };
-
-  struct FFXIVIpcMarketBoardItemListingHistory : FFXIVIpcBasePacket< MarketBoardItemListingHistory >
-  {
-      uint32_t itemCatalogId;
-      uint32_t itemCatalogId2;
-
-      struct MarketListing
-      {
-          uint32_t salePrice;
-          uint32_t purchaseTime;
-          uint32_t quantity;
-          uint8_t isHq;
-          uint8_t padding;
-          uint8_t onMannequin;
-
-          char buyerName[33];
-
-          uint32_t itemCatalogId;
-      } listing[20];
   };
 
 }

--- a/src/common/Network/PacketDef/Zone/ServerZoneDef.h
+++ b/src/common/Network/PacketDef/Zone/ServerZoneDef.h
@@ -315,18 +315,17 @@ namespace Sapphire::Network::Packets::Server
       uint32_t unknown10;
       uint16_t durability;
       uint16_t padding3;
-      uint16_t materiaValue[5];
       /**
        * auto materiaId = (i & 0xFF0) >> 4;
        * auto index = i & 0xF;
        * auto leftover = i >> 8;
        */
+      uint16_t materiaValue[5];
       uint32_t padding4;
       char retainerName[64];
       bool hq;
       uint8_t materiaCount;
       uint8_t padding5;
-      uint8_t retainerCity;
       /**
        * 0x01 Limsa Lominsa
        * 0x02 Gridania
@@ -335,6 +334,7 @@ namespace Sapphire::Network::Packets::Server
        * 0x07 Kugane
        * 0x0A Crystarium
        */
+      uint8_t retainerCity;
       uint64_t padding6;
     } listing[10]; // Multiple packets are sent if there are more than 10 search results.
     uint32_t unknown12;


### PR DESCRIPTION
The structs in ServerZoneDef didn't match Ipcs.h and everything else did :v There was also a typo in there.

As for the MarketBoardItemListing struct, the reason for the nested `unknown2` struct being looped is because it always contains the same data 1-3 times.