### PR TITLE
Fix quest reward choice.

### DIFF
--- a/src/world/Actor/PlayerQuest.cpp
+++ b/src/world/Actor/PlayerQuest.cpp
@@ -1067,7 +1067,7 @@ bool Sapphire::Entity::Player::giveQuestRewards( uint32_t questId, uint32_t opti
 
   if( rewardItemCount > 0 )
   {
-    for( uint32_t i = 0; i < questInfo->itemReward0.size(); i++ )
+    for( uint32_t i = 0; i < rewardItemCount; i++ )
     {
       addItem( questInfo->itemReward0.at( i ), questInfo->itemCountReward0.at( i ) );
     }
@@ -1075,8 +1075,15 @@ bool Sapphire::Entity::Player::giveQuestRewards( uint32_t questId, uint32_t opti
 
   if( optionalItemCount > 0 )
   {
-    auto itemId = questInfo->itemReward1.at( optionalChoice );
-    addItem( itemId, questInfo->itemCountReward1.at( optionalChoice ) );
+    for( uint32_t i = 0; i < optionalItemCount; i++ )
+    {
+      auto itemId = questInfo->itemReward1.at( i );
+      if( itemId == optionalChoice )
+      {
+        addItem( itemId, questInfo->itemCountReward1.at( i ) );
+        break;
+      }
+    }
   }
 
   if( gilReward > 0 )


### PR DESCRIPTION
Quest scripts need to call player.giveQuestRewards( getId(), result.param3 ) for it to work.