### PR TITLE
Solve the mystery of second quest not showing in gridania or limsa.

### DIFF
--- a/src/common/Network/PacketDef/Zone/ServerZoneDef.h
+++ b/src/common/Network/PacketDef/Zone/ServerZoneDef.h
@@ -973,6 +973,7 @@ namespace Sapphire::Network::Packets::Server
     unsigned char expansion;
     unsigned char unknown76;
     unsigned char unknown77;
+    unsigned char very_unknown;
     unsigned char race;
     unsigned char tribe;
     unsigned char gender;
@@ -999,7 +1000,7 @@ namespace Sapphire::Network::Packets::Server
     unsigned char craftingMasterMask;
     unsigned char unknown95[9];
     unsigned char unknown9F[2];
-    unsigned char unknownA1[3];
+    unsigned char unknownA1[6];
     unsigned int exp[Common::CLASSJOB_SLOTS];
     unsigned int unknown108;
     unsigned int pvpTotalExp;
@@ -1020,7 +1021,7 @@ namespace Sapphire::Network::Packets::Server
     unsigned char companionDefRank;
     unsigned char companionAttRank;
     unsigned char companionHealRank;
-    unsigned char u19[13];
+    unsigned char u19[9];
     unsigned char mountGuideMask[22];
     char name[32];
     unsigned char unknownOword[16];


### PR DESCRIPTION
I didn't bother trying to fix those offset values in the names of unknown fields. At this point this packet is just so broken. Well at least I tried to line up important stuff like levels, exp and player name.