### PR TITLE
EventItems support (standard, non-AoE) + quest SubFst000 (Incense and Sensibility)

### DIFF
--- a/src/common/Common.h
+++ b/src/common/Common.h
@@ -908,6 +908,7 @@ namespace Sapphire::Common
   {
     Normal = 0x1,
     ItemAction = 0x2,
+    EventItem = 0x3,
     MountSkill = 0xD,
   };
 

--- a/src/scripts/quest/subquest/gridania/SubFst000.cpp
+++ b/src/scripts/quest/subquest/gridania/SubFst000.cpp
@@ -1,0 +1,216 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubFst000_00020
+// Quest Name: Incense and Sensibility
+// Quest ID: 65556
+// Start NPC: 1000786
+// End NPC: 1000705
+
+using namespace Sapphire;
+
+class SubFst000 : public Sapphire::ScriptAPI::EventScript
+{
+  private:
+    // Basic quest information
+    // Quest vars / flags used
+    // GetQuestBitFlag8
+    // GetQuestUI8AL
+    // GetQuestUI8BH
+
+    // Steps in this quest ( 0 is before accepting,
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      Seq1 = 1,
+      Seq2 = 2,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1000786;
+    static constexpr auto Actor1 = 1000705;
+    static constexpr auto Eobject0 = 2000070;
+    static constexpr auto Eobject1 = 2000071;
+    static constexpr auto Item0 = 2000101;
+    static constexpr auto Seq0Actor0 = 0;
+    static constexpr auto Seq1Actor1 = 1;
+    static constexpr auto Seq2Eobject0 = 2;
+    static constexpr auto Seq2Eobject0Useitemno = 99;
+    static constexpr auto Seq2Eobject0Useitemok = 100;
+    static constexpr auto Seq2Eobject1 = 3;
+    static constexpr auto Seq2Eobject1Useitemno = 97;
+    static constexpr auto Seq2Eobject1Useitemok = 98;
+    static constexpr auto Seq3Actor1 = 4;
+
+  public:
+    SubFst000() : Sapphire::ScriptAPI::EventScript( 65556 ){};
+    ~SubFst000() = default;
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( uint32_t eventId, Entity::Player& player, uint64_t actorId ) override
+  {
+    auto& eventMgr = Common::Service< World::Manager::EventMgr >::ref();
+    auto actor = eventMgr.mapEventActorToRealActor( static_cast< uint32_t >( actorId ) );
+
+    if ( actor == Actor0 )
+      Scene00000( player );
+    else if ( actor == Actor1 && player.getQuestSeq( getId() ) == Seq1 )
+      Scene00001( player );
+    else if ( actor == Actor1 && player.getQuestSeq( getId() ) == SeqFinish )
+      Scene00004( player );
+    else if ( actor == Eobject0 )
+      Scene00002( player );
+    else if ( actor == Eobject1 )
+      Scene00003( player );
+  }
+
+  void onEventItem( Entity::Player& player, uint32_t eventId,
+                    uint32_t eventItemId, uint64_t actorId ) override
+  {
+    auto& eventMgr = Common::Service< World::Manager::EventMgr >::ref();
+    auto actor = eventMgr.mapEventActorToRealActor( static_cast< uint32_t >( actorId ) );
+
+    player.sendDebug( "onEventItem called for this quest: eventId={0}, eventItemId={1}, actor={2}", eventId, eventItemId, actor );
+
+    if ( actor == Eobject0 )
+      Scene00100( player );
+    else if ( actor == Eobject1 )
+      Scene00098( player );
+  }
+
+  private:
+
+  void checkQuestCompletion( Entity::Player& player )
+  {
+    auto currentUsed  = player.getQuestUI8AL( getId() );
+    auto currentItems = player.getQuestUI8BH( getId() );
+
+    player.sendQuestMessage( getId(), 1, 2, currentUsed + 1, 2 );
+
+    if( currentUsed + 1 >= 2 )
+    {
+      player.updateQuest( getId(), SeqFinish );
+    }
+    else
+    {
+      player.setQuestUI8AL( getId(), currentUsed  + 1 );
+      player.setQuestUI8BH( getId(), currentItems - 1 );
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  void Scene00000( Entity::Player& player )
+  {
+    auto callback = [ & ]( Entity::Player& player, const Event::SceneResult& result )
+    {
+      if ( result.param2 == 1 ) // accept quest
+      {
+        player.updateQuest( getId(), Seq1 );
+      }
+    };
+
+    player.playScene( getId(), 0, HIDE_HOTBAR, callback );
+  }
+
+  void Scene00001( Entity::Player& player )
+  {
+    auto callback = [ & ]( Entity::Player& player, const Event::SceneResult& result )
+    {
+      player.setQuestUI8AL( getId(), 0 ); // number of censers used
+      player.setQuestUI8BH( getId(), 2 ); // Azeyma Rose Oil key item
+      player.sendQuestMessage( getId(), 0, 0, 0, 0 );
+      player.updateQuest( getId(), Seq2 );
+    };
+
+    player.playScene( getId(), 1, HIDE_HOTBAR, callback );
+  }
+
+  void Scene00002( Entity::Player& player )
+  {
+    auto callback = [ & ]( Entity::Player& player, const Event::SceneResult& result )
+    {
+    };
+
+    player.playScene( getId(), 2, NO_DEFAULT_CAMERA, callback );
+  }
+
+  void Scene00003( Entity::Player& player )
+  {
+    auto callback = [ & ]( Entity::Player& player, const Event::SceneResult& result )
+    {
+    };
+
+    player.playScene( getId(), 3, NO_DEFAULT_CAMERA, callback );
+  }
+
+  void Scene00004( Entity::Player& player )
+  {
+    auto callback = [ & ]( Entity::Player& player, const Event::SceneResult& result )
+    {
+      if( result.param2 == 1 )
+      {
+        if( player.giveQuestRewards( getId(), 0 ) )
+        {
+          player.setQuestUI8AL( getId(), 0 );
+          player.setQuestUI8BH( getId(), 0 );
+          player.finishQuest( getId() );
+        }
+      }
+    };
+
+    player.playScene( getId(), 4, NONE, callback );
+  }
+
+  void Scene00097( Entity::Player& player )
+  {
+    auto callback = [ & ]( Entity::Player& player, const Event::SceneResult& result )
+    {
+    };
+
+    player.playScene( getId(), 97, NONE, callback );
+  }
+
+  void Scene00098( Entity::Player& player )
+  {
+    auto callback = [ & ]( Entity::Player& player, const Event::SceneResult& result )
+    {
+      checkQuestCompletion( player );
+      player.setQuestBitFlag8( getId(), 2, true );
+    };
+
+    player.playScene( getId(), 98, NONE, callback );
+  }
+
+  void Scene00099( Entity::Player& player )
+  {
+    auto callback = [ & ]( Entity::Player& player, const Event::SceneResult& result )
+    {
+    };
+
+    player.playScene( getId(), 99, NONE, callback );
+  }
+
+  void Scene00100( Entity::Player& player )
+  {
+    auto callback = [ & ]( Entity::Player& player, const Event::SceneResult& result )
+    {
+      checkQuestCompletion( player );
+      player.setQuestBitFlag8( getId(), 1, true );
+    };
+
+    player.playScene( getId(), 100, NONE, callback );
+  }
+
+};
+
+EXPOSE_SCRIPT( SubFst000 );

--- a/src/world/Action/EventItemAction.cpp
+++ b/src/world/Action/EventItemAction.cpp
@@ -1,0 +1,144 @@
+#include <Util/Util.h>
+#include <Logging/Logger.h>
+#include <Exd/ExdDataGenerated.h>
+#include <Network/CommonActorControl.h>
+#include <Service.h>
+
+#include "Network/PacketWrappers/ActorControlPacket.h"
+#include "Network/PacketWrappers/ActorControlSelfPacket.h"
+
+#include "Actor/Player.h"
+
+#include "EventItemAction.h"
+
+using namespace Sapphire;
+using namespace Sapphire::World;
+using namespace Sapphire::Common;
+using namespace Sapphire::Network;
+using namespace Sapphire::Network::Packets;
+using namespace Sapphire::Network::Packets::Server;
+using namespace Sapphire::Network::ActorControl;
+
+Action::EventItemAction::EventItemAction( Entity::CharaPtr pActor, uint32_t eventId, uint32_t eventItemId,
+                                          EventItemActionCallback finishRef, ActionCallback interruptRef, uint64_t targetId )
+{
+  m_eventId = eventId;
+  m_id = eventItemId;
+  m_targetId = targetId;
+  auto& exdData = Common::Service< Data::ExdDataGenerated >::ref();
+  m_castTimeMs = exdData.get< Sapphire::Data::EventItem >( eventItemId )->castTime * 1000; // TODO: Add security checks.
+  m_onActionFinishClb = std::move( finishRef );
+  m_onActionInterruptClb = std::move( interruptRef );
+  m_pSource = std::move( pActor );
+  m_interruptType = Common::ActionInterruptType::None;
+
+  // SPH: Debug
+  Logger::warn("EventItemAction constructor: eventId={0}, eventItemId={1}, targetId={2}", eventId, eventItemId, targetId);
+}
+
+Action::EventItemAction::~EventItemAction() = default;
+
+void Action::EventItemAction::start()
+{
+  if( !m_pSource )
+    return;
+  // SPH: Debug
+  Logger::warn("EventItemAction::start()");
+  // SPH: Debug
+
+  m_startTime = Common::Util::getTimeMs();
+
+  auto control = makeActorControl( m_pSource->getId(), ActorControlType::CastStart, 1, m_id, 0x4000004E );   // SPH: Does CastStart here have to change?
+
+  if( m_pSource->isPlayer() )
+  {
+    m_pSource->sendToInRangeSet( control, true );
+    if( m_pSource->getAsPlayer()->hasStateFlag( PlayerStateFlag::InNpcEvent ) )
+      m_pSource->getAsPlayer()->unsetStateFlag( PlayerStateFlag::InNpcEvent );
+  }
+  else
+    m_pSource->sendToInRangeSet( control );
+}
+
+void Action::EventItemAction::execute()
+{
+  if( !m_pSource )
+    return;
+  // SPH: Debug
+  Logger::warn("EventItemAction::execute()");
+  // SPH: Debug
+
+  try
+  {
+/*
+    auto pEvent = m_pSource->getAsPlayer()->getEvent( m_eventId );
+
+    pEvent->setPlayedScene( false );
+*/
+    if( m_onActionFinishClb )
+      m_onActionFinishClb( *m_pSource->getAsPlayer(), m_eventId, m_id, m_targetId );
+
+    auto control = makeActorControl( m_pSource->getId(), ActorControlType::CastStart, 0, m_id );
+
+/*
+    if( !pEvent->hasPlayedScene() )
+      m_pSource->getAsPlayer()->eventFinish( m_eventId, 1 );
+    else
+      pEvent->setPlayedScene( false );
+*/
+
+    if( m_pSource->isPlayer() )
+    {
+      //m_pSource->getAsPlayer()->unsetStateFlag( PlayerStateFlag::Occupied2 );
+      m_pSource->sendToInRangeSet( control, true );
+    }
+    else
+      m_pSource->sendToInRangeSet( control );
+  }
+  catch( std::exception& e )
+  {
+    Logger::error( e.what() );
+  }
+
+}
+
+void Action::EventItemAction::interrupt()
+{
+  if( !m_pSource )
+    return;
+  // SPH: Debug
+  Logger::warn("EventItemAction::interrupt()");
+  // SPH: Debug
+
+  try
+  {
+
+    auto control = makeActorControl( m_pSource->getId(), ActorControlType::CastInterrupt, 0x219, 0x04, m_id );
+
+    if( m_pSource->isPlayer() )
+    {
+      auto control1 = makeActorControlSelf( m_pSource->getId(), ActorControlType::FreeEventPos, m_eventId );
+
+      //m_pSource->getAsPlayer()->unsetStateFlag( PlayerStateFlag::NoCombat );
+      //m_pSource->getAsPlayer()->unsetStateFlag( PlayerStateFlag::Occupied1 );
+      m_pSource->sendToInRangeSet( control );
+      m_pSource->sendToInRangeSet( control1 );
+
+      m_pSource->getAsPlayer()->queuePacket( control1 );
+      m_pSource->getAsPlayer()->queuePacket( control );
+      m_pSource->getAsPlayer()->eventFinish( m_eventId, 1 );
+
+    }
+    else
+      m_pSource->sendToInRangeSet( control );
+
+    if( m_onActionInterruptClb )
+      m_onActionInterruptClb( *m_pSource->getAsPlayer(), m_eventId, 0 );
+
+  }
+  catch( std::exception& e )
+  {
+    Logger::error( e.what() );
+  }
+
+}

--- a/src/world/Action/EventItemAction.h
+++ b/src/world/Action/EventItemAction.h
@@ -1,0 +1,38 @@
+#ifndef _EVENTITEMACTION_H_
+#define _EVENTITEMACTION_H_
+
+#include <Common.h>
+
+#include "ForwardsZone.h"
+#include "Action.h"
+
+namespace Sapphire::World::Action
+{
+
+class EventItemAction : public Action
+{
+
+public:
+  virtual ~EventItemAction();
+
+  EventItemAction( Entity::CharaPtr pActor, uint32_t eventId, uint32_t eventItemId,
+                   EventItemActionCallback finishRef, ActionCallback interruptRef, uint64_t targetId );
+
+  void start() override;
+
+  void execute() override;
+
+  void interrupt() override;
+
+private:
+  uint32_t m_eventId;
+  uint64_t m_targetId;
+
+  EventItemActionCallback m_onActionFinishClb;
+  ActionCallback m_onActionInterruptClb;
+
+};
+
+}
+
+#endif

--- a/src/world/Actor/Player.h
+++ b/src/world/Actor/Player.h
@@ -64,8 +64,8 @@ namespace Sapphire::Entity
                            World::Action::ActionCallback interruptCallback, uint64_t additional );
 
     /*! start an event item action */
-    void eventItemActionStart( uint32_t eventId, uint32_t action, World::Action::ActionCallback finishCallback,
-                               World::Action::ActionCallback interruptCallback, uint64_t additional );
+    void eventItemActionStart( uint32_t eventId, uint32_t eventItemId, World::Action::EventItemActionCallback finishCallback,
+                               World::Action::ActionCallback interruptCallback, uint64_t targetId );
 
     /*! start/register a normal event */
     void eventStart( uint64_t actorId, uint32_t eventId, Event::EventHandler::EventType eventParam, uint8_t eventParam1,

--- a/src/world/Actor/PlayerEvent.cpp
+++ b/src/world/Actor/PlayerEvent.cpp
@@ -17,6 +17,7 @@
 #include "ServerMgr.h"
 
 #include "Action/EventAction.h"
+#include "Action/EventItemAction.h"
 
 using namespace Sapphire::Common;
 using namespace Sapphire::Network::Packets;
@@ -355,17 +356,35 @@ void Sapphire::Entity::Player::eventActionStart( uint32_t eventId,
 
 
 void Sapphire::Entity::Player::eventItemActionStart( uint32_t eventId,
-                                                     uint32_t action,
-                                                     World::Action::ActionCallback finishCallback,
+                                                     uint32_t eventItemId,
+                                                     World::Action::EventItemActionCallback finishCallback,
                                                      World::Action::ActionCallback interruptCallback,
-                                                     uint64_t additional )
+                                                     uint64_t targetId )
 {
-//  Action::ActionPtr pEventItemAction = Action::make_EventItemAction( getAsChara(), eventId, action,
-//                                                                     finishCallback, interruptCallback, additional );
-//
-//  setCurrentAction( pEventItemAction );
-//
-//  pEventItemAction->onStart();
+  auto pEventItemAction = World::Action::make_EventItemAction( getAsChara(), eventId, eventItemId,
+                                                               finishCallback, interruptCallback, targetId );
+
+/*
+  auto pEvent = getEvent( eventId );
+
+  if( !pEvent && getEventCount() )
+  {
+    // We're trying to play a nested event, need to start it first.
+    eventStart( getId(), eventId, Event::EventHandler::Nest, 0, 0 );
+    pEvent = getEvent( eventId );
+  }
+  else if( !pEvent )
+  {
+    Logger::error( "Could not find event #{0}, event has not been started!", eventId );
+    return;
+  }
+
+  if( pEvent )
+    pEvent->setPlayedScene( true );
+
+*/
+  setCurrentAction( pEventItemAction );
+  pEventItemAction->start();
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/world/ForwardsZone.h
+++ b/src/world/ForwardsZone.h
@@ -85,12 +85,14 @@ namespace World::Action
 {
 TYPE_FORWARD( Action );
 TYPE_FORWARD( EventAction );
+TYPE_FORWARD( EventItemAction );
 TYPE_FORWARD( ItemAction );
 TYPE_FORWARD( MountAction );
 TYPE_FORWARD( EffectBuilder );
 TYPE_FORWARD( EffectResult );
 
 using ActionCallback = std::function< void( Entity::Player&, uint32_t, uint64_t ) >;
+using EventItemActionCallback = std::function< void( Entity::Player&, uint32_t, uint32_t, uint64_t ) >;
 }
 
 namespace Network

--- a/src/world/Manager/ActionMgr.cpp
+++ b/src/world/Manager/ActionMgr.cpp
@@ -10,6 +10,8 @@
 
 #include <Network/PacketWrappers/EffectPacket.h>
 
+#include <Service.h>
+
 using namespace Sapphire;
 
 void World::Manager::ActionMgr::handlePlacedPlayerAction( Entity::Player& player, uint32_t actionId,
@@ -70,6 +72,22 @@ void World::Manager::ActionMgr::handleItemAction( Sapphire::Entity::Player& play
 
   // todo: item actions don't have cast times? if so we can just start it and we're good
   action->start();
+}
+
+void World::Manager::ActionMgr::handleEventItemAction( Sapphire::Entity::Player& player, uint32_t eventItemId,
+                                                       uint32_t eventId, uint64_t targetId )
+{
+  player.sendDebug( "got eventitem act: {0}, eventId: {1}", eventItemId, eventId );
+
+  player.eventItemActionStart( eventId, eventItemId,
+    [ & ]( Entity::Player& player, uint32_t eventId, uint32_t eventItemId, uint64_t actorId )
+    {
+      player.sendDebug( "finishcallback called: eventId={0}, eventItemId={1}, actorId={2} ", eventId, eventItemId, actorId);
+      auto& scriptMgr = Common::Service< Scripting::ScriptMgr >::ref();
+      scriptMgr.onEventItem( player, eventId, eventItemId, actorId );
+
+      player.checkEvent( eventId );
+    }, nullptr, targetId );
 }
 
 void World::Manager::ActionMgr::handleMountAction( Entity::Player& player, uint16_t mountId,

--- a/src/world/Manager/ActionMgr.h
+++ b/src/world/Manager/ActionMgr.h
@@ -27,6 +27,7 @@ namespace Sapphire::World::Manager
 
     void handleItemAction( Entity::Player& player, uint32_t itemId, Data::ItemActionPtr itemActionData,
                            uint16_t itemSourceSlot, uint16_t itemSourceContainer );
+    void handleEventItemAction( Entity::Player& player, uint32_t eventItemId, uint32_t eventId, uint64_t targetId );
 
     void handleMountAction( Entity::Player& player, uint16_t mountId,
                             Data::ActionPtr actionData, uint64_t targetId, uint16_t sequence );

--- a/src/world/Network/Handlers/ActionHandler.cpp
+++ b/src/world/Network/Handlers/ActionHandler.cpp
@@ -10,6 +10,7 @@
 #include "Network/GameConnection.h"
 
 #include "Manager/ActionMgr.h"
+#include "Script/ScriptMgr.h"
 
 using namespace Sapphire::Common;
 using namespace Sapphire::Network::Packets;
@@ -63,6 +64,35 @@ void Sapphire::Network::GameConnection::actionHandler( const Packets::FFXIVARR_P
         return;
 
       actionMgr.handleItemAction( player, actionId, itemAction, itemSourceSlot, itemSourceContainer );
+
+      break;
+    }
+
+    case Common::SkillType::EventItem:
+    {
+      auto eitem = exdData.get< Data::EventItem >( actionId );
+      if ( !eitem )
+        return;
+
+      if ( itemSourceSlot != 0 || itemSourceContainer != 0 ) {
+        // possible unimplemented functionality but continue anyway
+        player.sendDebug( "itemSourceSlot = {0}, itemSourceSlot = {1}: Unexpected deviance from 0, possible unimplemented functionality", itemSourceSlot, itemSourceContainer );
+      }
+
+      if ( eitem->action == 0 )
+        return;
+
+      if ( eitem->action != 1 )
+      {
+        player.sendDebug( "EventItem action {0} is not handled", eitem->action );
+        return;
+      }
+
+      auto eventId = eitem->quest;
+
+      player.sendDebug( "Using EventItem '{0}', eventId {1}", eitem->name, eventId );
+
+      actionMgr.handleEventItemAction( player, actionId, eventId, targetId );
 
       break;
     }

--- a/src/world/Script/NativeScriptApi.cpp
+++ b/src/world/Script/NativeScriptApi.cpp
@@ -120,8 +120,7 @@ namespace Sapphire::ScriptAPI
   {
   }
 
-  void EventScript::onEventItem( Entity::Player& player, uint32_t eventItemId, uint32_t eventId, uint32_t castTime,
-                                 uint64_t targetId )
+  void EventScript::onEventItem( Entity::Player& player, uint32_t eventId, uint32_t eventItemId, uint64_t actorId )
   {
   }
 

--- a/src/world/Script/NativeScriptApi.h
+++ b/src/world/Script/NativeScriptApi.h
@@ -159,8 +159,7 @@ namespace Sapphire::ScriptAPI
 
     virtual void onOutsideRange( Sapphire::Entity::Player& player, uint32_t eventId, uint32_t param1, float x, float y, float z );
 
-    virtual void onEventItem( Sapphire::Entity::Player& player, uint32_t eventItemId, uint32_t eventId, uint32_t castTime,
-                              uint64_t targetId );
+    virtual void onEventItem( Sapphire::Entity::Player& player, uint32_t eventId, uint32_t eventItemId, uint64_t actorId );
 
     virtual void onEventHandlerTradeReturn( Sapphire::Entity::Player& player, uint32_t eventId, uint16_t subEvent, uint16_t param,
                                             uint32_t catalogId );

--- a/src/world/Script/ScriptMgr.cpp
+++ b/src/world/Script/ScriptMgr.cpp
@@ -252,8 +252,8 @@ bool Sapphire::Scripting::ScriptMgr::onEventHandlerTradeReturn( Entity::Player& 
   return false;
 }
 
-bool Sapphire::Scripting::ScriptMgr::onEventItem( Entity::Player& player, uint32_t eventItemId,
-                                                  uint32_t eventId, uint32_t castTime, uint64_t targetId )
+bool Sapphire::Scripting::ScriptMgr::onEventItem( Entity::Player& player, uint32_t eventId,
+                                                  uint32_t eventItemId, uint64_t actorId )
 {
   auto& eventMgr = Common::Service< World::Manager::EventMgr >::ref();
 
@@ -264,9 +264,9 @@ bool Sapphire::Scripting::ScriptMgr::onEventItem( Entity::Player& player, uint32
   auto script = m_nativeScriptMgr->getScript< Sapphire::ScriptAPI::EventScript >( eventId );
   if( script )
   {
-    player.eventStart( targetId, eventId, Event::EventHandler::Item, 0, 0 );
+    player.eventStart( actorId, eventId, Event::EventHandler::Item, 0, eventItemId );
 
-    script->onEventItem( player, eventItemId, eventId, castTime, targetId );
+    script->onEventItem( player, eventId, eventItemId, actorId );
     return true;
   }
 

--- a/src/world/Script/ScriptMgr.h
+++ b/src/world/Script/ScriptMgr.h
@@ -64,8 +64,7 @@ namespace Sapphire::Scripting
 
     bool onEmote( Entity::Player& player, uint64_t actorId, uint32_t eventId, uint8_t emoteId );
 
-    bool onEventItem( Entity::Player& player, uint32_t eventItemId, uint32_t eventId, uint32_t castTime,
-                      uint64_t targetId );
+    bool onEventItem( Entity::Player& player, uint32_t eventId, uint32_t eventItemId, uint64_t actorId );
 
     bool onBNpcKill( Entity::Player& player, uint16_t nameId );
 


### PR DESCRIPTION
I've been working on getting EventItem support working so that key items can be used in quests. This isn't nearly ready to be merged yet, but it 'works' (for varying values of 'works') and at this point I'd love to get some eyes on this and a code review, if possible.

At this point, with this branch you can run the quest "Incense and Sensibility" (SubFst000, quest 65556) solo from start to finish. (I have not tested this with or implemented any other quests.) This only works solo; if another player is logged in close to the player doing the quest, that player's client will crash after the player taking the quest uses the key item on a censer. (I suspect that my code is not sending EventStart/EventPlay packets properly.)

It is possible that this is due to the decision I made to only call the quest script once the "using key item" animation finishes. (The animation is automatically started client-side.) I did this because I figured it would simplify the quest code, but I'm not sure if this was the right decision or not. Honestly I'm not sure at all how I should proceed with this so I wanted to open it up to you and learn exactly what I can do better.

Note that AoE EventItems, such as the one you get during the quest "Stash Saboteur" (GaiUsa209, quest 66268), are not handled by this code as their use packets arrive using the AoESkillHandler opcode.

This is my first major project on Sapphire so I have probably made a lot of mistakes - please bear with me!