### PR TITLE
Fix quest completion for questId > 2047 (67583)

### DIFF
--- a/src/world/Actor/Player.h
+++ b/src/world/Actor/Player.h
@@ -1070,7 +1070,7 @@ namespace Sapphire::Entity
     uint8_t m_homePoint;
     uint8_t m_startTown;
     uint16_t m_townWarpFstFlags;
-    uint8_t m_questCompleteFlags[476];
+    uint8_t m_questCompleteFlags[487];
     uint8_t m_discovery[445];
     uint32_t m_playTime;
 

--- a/src/world/Actor/PlayerQuest.cpp
+++ b/src/world/Actor/PlayerQuest.cpp
@@ -1015,7 +1015,7 @@ Sapphire::Entity::Player::sendQuestMessage( uint32_t questId, int8_t msgId, uint
 
 void Sapphire::Entity::Player::updateQuestsCompleted( uint32_t questId )
 {
-  uint8_t index = questId / 8;
+  uint16_t index = questId / 8;
   uint8_t bitIndex = ( questId ) % 8;
 
   uint8_t value = 0x80 >> bitIndex;
@@ -1025,7 +1025,7 @@ void Sapphire::Entity::Player::updateQuestsCompleted( uint32_t questId )
 
 void Sapphire::Entity::Player::removeQuestsCompleted( uint32_t questId )
 {
-  uint8_t index = questId / 8;
+  uint16_t index = questId / 8;
   uint8_t bitIndex = ( questId ) % 8;
 
   uint8_t value = 0x80 >> bitIndex;


### PR DESCRIPTION
It's currently impossible to permanently store quest completion flags for quests beyond questId 2047 (67583) due to the code using a type that's too small. This manifests in the correct quest completion packet being sent, but as soon as you move to another zone the quest disappears from the journal (and is probably replaced by another quest you didn't ask for).

This fixes the issue by using an appropriately-sized index variable, and also increases the flag storage so that all currently-available quests can be stored.