### PR TITLE
Add support for residential ward house listing packets

### DIFF
--- a/src/common/Network/PacketDef/Ipcs.h
+++ b/src/common/Network/PacketDef/Ipcs.h
@@ -255,6 +255,7 @@ namespace Sapphire::Network::Packets
 
     LandSetMap = 0x025B, // updated 4.5
 
+    ResidentialWardHouseListing = 0x0096,   // added 5.4
     //////////////////////////////////////////////////
 
     DuelChallenge = 0x0277, // 4.2; this is responsible for opening the ui

--- a/src/common/Network/PacketDef/Zone/ServerZoneDef.h
+++ b/src/common/Network/PacketDef/Zone/ServerZoneDef.h
@@ -1936,6 +1936,32 @@ namespace Sapphire::Network::Packets::Server
     } entry[3];
   };
 
+  /**
+* Structural representation of the packet sent by the server
+* when viewing a Ward in the Residential District menu
+*/
+  struct FFXIVIpcResidentialWardHouseListing : FFXIVIpcBasePacket< ResidentialWardHouseListing >
+  {
+    uint8_t unknown0;
+    uint8_t unknown1;
+    uint8_t wardId;     // 0 offset
+    uint8_t unknown3;
+    uint32_t unknown4;
+
+    // 60 listings per packet, 40 bytes each
+    // In sequential order based on housing plot number
+    struct houseListing 
+    {     
+      uint32_t housePrice;   // the last byte of the housing price is also the house size
+      //uint8_t houseSize;   //  0=S, 1=M, 2=L
+      uint8_t unknown5;
+      Common::HousingAppeal houseTag1;
+      Common::HousingAppeal houseTag2;
+      Common::HousingAppeal houseTag3;
+      char ownerName[32];    // if the house is for the sale this will be all null bytes
+    } listing[60]; 
+  };
+
   struct FFXIVIpcMSQTrackerProgress : FFXIVIpcBasePacket< MSQTrackerProgress >
   {
     uint32_t id;


### PR DESCRIPTION
These are the packets sent when viewing a ward in the residential district menu.  Unfortunately I do not have a way to test the struct but it should build at least...  I have tested an equivalent struct in python and nodejs though.  Also I wasn't sure how to handle the houseSize byte because it's also needed for the housePrice uint32... 

This is my first attempt at this, please be gentle!