### PR TITLE
Update opcodes for 5.58 hotfix and fix CFCommenceHandler

### DIFF
--- a/src/common/Network/PacketDef/Ipcs.h
+++ b/src/common/Network/PacketDef/Ipcs.h
@@ -5,7 +5,7 @@
  
 namespace Sapphire::Network::Packets
 {
- 
+
   ////////////////////////////////////////////////////////////////////////////////
   /// Lobby Connection IPC Codes
   /**
@@ -20,9 +20,9 @@ namespace Sapphire::Network::Packets
     LobbyEnterWorld = 0x000F,
     LobbyServerList = 0x0015,
     LobbyRetainerList = 0x0017,
- 
+
   };
- 
+
   /**
   * Client IPC Lobby Type Codes.
   */
@@ -31,11 +31,11 @@ namespace Sapphire::Network::Packets
     ReqCharList = 0x0003,
     ReqEnterWorld = 0x0004,
     ClientVersionInfo = 0x0005,
- 
+
     ReqCharDelete = 0x000A,
     ReqCharCreate = 0x000B,
   };
- 
+
   ////////////////////////////////////////////////////////////////////////////////
   /// Zone Connection IPC Codes
   /**
@@ -45,22 +45,22 @@ namespace Sapphire::Network::Packets
   {
     Ping = 0x02A8, // updated 5.58 hotfix
     Init = 0x013C, // updated 5.58 hotfix
- 
+
     ActorFreeSpawn = 0x00B5, // updated 5.58 hotfix
     InitZone = 0x0320, // updated 5.58 hotfix
- 
+
     EffectResult = 0x0387, // updated 5.58 hotfix
     ActorControl = 0x00B0, // updated 5.58 hotfix
     ActorControlSelf = 0x02B6, // updated 5.58 hotfix
     ActorControlTarget = 0x03C5, // updated 5.58 hotfix
- 
+
     /*!
      * @brief Used when resting
      */
     UpdateHpMpTp = 0x01A7, // updated 5.58 hotfix
- 
+
     ///////////////////////////////////////////////////
- 
+
     ChatBanned = 0xF06B,
     Playtime = 0x0179, // updated 5.58 hotfix
     Logout = 0x0214, // updated 5.58 hotfix
@@ -71,61 +71,61 @@ namespace Sapphire::Network::Packets
     CFPreferredRole = 0x024B, // updated 5.58 hotfix
     CFCancel = 0x01AC, // updated 5.58 hotfix
     SocialRequestError = 0xF0AD,
- 
+
     CFRegistered = 0x029F, // updated 5.58 hotfix
     SocialRequestResponse = 0x0082, // updated 5.58 hotfix
     SocialMessage = 0x03CB, // updated 5.58 hotfix
     SocialMessage2 = 0x01D7, // updated 5.58 hotfix
     CancelAllianceForming = 0xF0C6, // updated 4.2
- 
+
     LogMessage = 0x0118, // updated 5.58 hotfix
- 
+
     Chat = 0x00FE, // updated 5.58 hotfix
     PartyChat = 0x0065,
- 
+
     WorldVisitList = 0xF0FE, // added 4.5
- 
+
     SocialList = 0x015F, // updated 5.58 hotfix
- 
+
     ExamineSearchInfo = 0x0133, // updated 5.58 hotfix
     UpdateSearchInfo = 0x03E5, // updated 5.58 hotfix
     InitSearchInfo = 0x0321, // updated 5.58 hotfix
     ExamineSearchComment = 0x03AD, // updated 5.58 hotfix
- 
+
     ServerNoticeShort = 0x0333, // updated 5.58 hotfix
     ServerNotice = 0x0171, // updated 5.58 hotfix
     SetOnlineStatus = 0x037B, // updated 5.58 hotfix
- 
+
     CountdownInitiate = 0x0111, // updated 5.58 hotfix
     CountdownCancel = 0x0231, // updated 5.58 hotfix
- 
+
     PlayerAddedToBlacklist = 0x024E, // updated 5.58 hotfix
     PlayerRemovedFromBlacklist = 0x011D, // updated 5.58 hotfix
     BlackList = 0x03C0, // updated 5.58 hotfix
- 
+
     LinkshellList = 0x02E2, // updated 5.58 hotfix
- 
+
     MailDeleteRequest = 0xF12B, // updated 5.0
- 
+
     // 12D - 137 - constant gap between 4.5x -> 5.0
     ReqMoogleMailList = 0xF138, // updated 5.0
     ReqMoogleMailLetter = 0xF139, // updated 5.0
     MailLetterNotification = 0x013A, // updated 5.0
- 
+
     MarketTaxRates = 0x01F8, // updated 5.35 hotfix
- 
+
     MarketBoardSearchResult = 0x01F1, // updated 5.58 hotfix
     MarketBoardItemListingCount = 0x0068, // updated 5.58 hotfix
     MarketBoardItemListingHistory = 0x01BA, // updated 5.58 hotfix
     MarketBoardItemListing = 0x0076, // updated 5.58 hotfix
- 
+
     CharaFreeCompanyTag = 0x013B, // updated 4.5
     FreeCompanyBoardMsg = 0x03DB, // updated 5.58 hotfix
     FreeCompanyInfo = 0x01F7, // updated 5.58 hotfix
     ExamineFreeCompanyInfo = 0x0324, // updated 5.58 hotfix
- 
+
     FreeCompanyUpdateShortMessage = 0xF157, // added 5.0
- 
+
     StatusEffectList = 0x0074, // updated 5.58 hotfix
     EurekaStatusEffectList = 0x0167, // updated 5.18
     BossStatusEffectList = 0x0312, // added 5.1
@@ -135,19 +135,19 @@ namespace Sapphire::Network::Packets
     AoeEffect24 = 0x0339, // updated 5.58 hotfix
     AoeEffect32 = 0x023C, // updated 5.58 hotfix
     PersistantEffect = 0x025D, // updated 5.58 hotfix
- 
+
     GCAffiliation = 0x0094, // updated 5.58 hotfix
- 
+
     PlayerSpawn = 0x01D8, // updated 5.58 hotfix
     NpcSpawn = 0x00D2, // updated 5.58 hotfix
     NpcSpawn2 = 0x01CB, // ( Bigger statuseffectlist? ) updated 5.3
     ActorMove = 0x00F8, // updated 5.58 hotfix
- 
+
     ActorSetPos = 0x0299, // updated 5.58 hotfix
- 
+
     ActorCast = 0x015D, // updated 5.58 hotfix
     SomeCustomiseChangePacketProbably = 0x00CD, // added 5.18
- 
+
     PartyList = 0x0349, // updated 5.58 hotfix
     PartyMessage = 0x00A4, // updated 5.58 hotfix
     HateRank = 0x0150, // updated 5.58 hotfix
@@ -162,29 +162,29 @@ namespace Sapphire::Network::Packets
     PlayerStateFlags = 0x03BF, // updated 5.58 hotfix
     PlayerClassInfo = 0x0131, // updated 5.58 hotfix
     CharaVisualEffect = 0x0292, // updated 5.58 hotfix
- 
+
     ModelEquip = 0x03A2, // updated 5.58 hotfix
     Examine = 0x0365, // updated 5.58 hotfix
     CharaNameReq = 0x01F0, // updated 5.58 hotfix
- 
+
     // nb: see #565 on github
     UpdateRetainerItemSalePrice = 0xF19F, // updated 5.0
     RetainerSaleHistory = 0x03CE, // updated 5.58 hotfix
     RetainerInformation = 0x022F, // updated 5.58 hotfix
- 
+
     SetLevelSync = 0x1186, // not updated for 4.4, not sure what it is anymore
- 
+
     ItemInfo = 0x01CC, // updated 5.58 hotfix
     ContainerInfo = 0x025C, // updated 5.58 hotfix
     InventoryTransactionFinish = 0x0176, // updated 5.58 hotfix
     InventoryTransaction = 0x027F, // updated 5.58 hotfix
     CurrencyCrystalInfo = 0x0345, // updated 5.58 hotfix
- 
+
     InventoryActionAck = 0x03B8, // updated 5.58 hotfix
     UpdateInventorySlot = 0x02F7, // updated 5.58 hotfix
- 
+
     HuntingLogEntry = 0x01D9, // updated 5.58 hotfix
- 
+
     EventPlay = 0x016B, // updated 5.58 hotfix
     EventPlay4 = 0x010A, // updated 5.58 hotfix
     EventPlay8 = 0x0337, // updated 5.58 hotfix
@@ -193,28 +193,28 @@ namespace Sapphire::Network::Packets
     EventPlay64 = 0x00DE, // updated 5.58 hotfix
     EventPlay128 = 0x02D0, // updated 5.58 hotfix
     EventPlay255 = 0x0362, // updated 5.58 hotfix
- 
+
     EventContinue = 0x00B6, // updated 5.58 hotfix
- 
+
     EventStart = 0x02DA, // updated 5.58 hotfix
     EventFinish = 0x0235, // updated 5.58 hotfix
- 
+
     EventLinkshell = 0x1169,
- 
+
     QuestActiveList = 0x0097, // updated 5.58 hotfix
     QuestUpdate = 0x01B2, // updated 5.58 hotfix
     QuestCompleteList = 0x006D, // updated 5.58 hotfix
- 
+
     QuestFinish = 0x021B, // updated 5.58 hotfix
     MSQTrackerComplete = 0x0348, // updated 5.58 hotfix
     MSQTrackerProgress = 0xF1CD, // updated 4.5 ? this actually looks like the two opcodes have been combined, see #474
- 
+
     QuestMessage = 0x0220, // updated 5.58 hotfix
- 
+
     QuestTracker = 0x00D8, // updated 5.58 hotfix
- 
+
     Mount = 0x01E1, // updated 5.58 hotfix
- 
+
     DirectorVars = 0x0154, // updated 5.58 hotfix
     SomeDirectorUnk1 = 0x0084, // updated 5.18
     SomeDirectorUnk2 = 0xF0C1, // updated 5.18
@@ -224,25 +224,25 @@ namespace Sapphire::Network::Packets
     DirectorPopUp = 0x03DF, // updated 5.58 hotfix
     DirectorPopUp4 = 0x019B, // updated 5.58 hotfix
     DirectorPopUp8 = 0x0271, // updated 5.58 hotfix
- 
+
     CFAvailableContents = 0xF1FD, // updated 4.2
- 
+
     WeatherChange = 0x0323, // updated 5.58 hotfix
     PlayerTitleList = 0x014E, // updated 5.58 hotfix
     Discovery = 0x01C2, // updated 5.58 hotfix
- 
+
     EorzeaTimeOffset = 0x0070, // updated 5.58 hotfix
- 
+
     EquipDisplayFlags = 0x02C6, // updated 5.58 hotfix
- 
+
     MiniCactpotInit = 0x0286, // added 5.31
     ShopMessage = 0x0287, // updated 5.58 hotfix
     LootMessage = 0x0383, // updated 5.58 hotfix
     ResultDialog = 0x0273, // updated 5.58 hotfix
     DesynthResult = 0x0238, // updated 5.58 hotfix
- 
+
     /// Housing //////////////////////////////////////
- 
+
     LandSetInitialize = 0x0159, // updated 5.58 hotfix
     LandUpdate = 0x0228, // updated 5.58 hotfix
     YardObjectSpawn = 0x023D, // updated 5.58 hotfix
@@ -254,34 +254,34 @@ namespace Sapphire::Network::Packets
     HousingUpdateLandFlagsSlot = 0x0157, // updated 5.58 hotfix
     HousingLandFlags = 0x03B1, // updated 5.58 hotfix
     HousingShowEstateGuestAccess = 0x00CC, // updated 5.58 hotfix
- 
+
     HousingObjectInitialize = 0x0112, // updated 5.58 hotfix
     HousingInternalObjectSpawn = 0x02C8, // updated 5.58 hotfix
- 
+
     HousingWardInfo = 0x012A, // updated 5.58 hotfix
     HousingObjectMove = 0x0265, // updated 5.58 hotfix
- 
+
     SharedEstateSettingsResponse = 0x030E, // updated 5.58 hotfix
- 
+
     LandUpdateHouseName = 0x017C, // updated 5.58 hotfix
- 
+
     LandSetMap = 0x02E5, // updated 5.58 hotfix
- 
+
     CeremonySetActorAppearance = 0x02ED, // updated 5.58 hotfix
- 
+
     //////////////////////////////////////////////////
- 
+
     DuelChallenge = 0x0277, // 4.2; this is responsible for opening the ui
     PerformNote = 0x0127, // updated 5.58 hotfix
- 
+
     PrepareZoning = 0x02AB, // updated 5.58 hotfix
     ActorGauge = 0x01C1, // updated 5.58 hotfix
     DutyGauge = 0x02E5, // updated 5.58 hotfix
- 
+
     // daily quest info -> without them sent,  login will take longer...
     DailyQuests = 0x02D6, // updated 5.58 hotfix
     DailyQuestRepeatFlags = 0x01AB, // updated 5.58 hotfix
- 
+
     MapUpdate = 0x0394, // updated 5.58 hotfix
     MapUpdate4 = 0x036F, // updated 5.58 hotfix
     MapUpdate8 = 0x0311, // updated 5.58 hotfix
@@ -289,7 +289,7 @@ namespace Sapphire::Network::Packets
     MapUpdate32 = 0x007A, // updated 5.58 hotfix
     MapUpdate64 = 0x02A0, // updated 5.58 hotfix
     MapUpdate128 = 0x0303, // updated 5.58 hotfix
- 
+
     /// Doman Mahjong //////////////////////////////////////
     MahjongOpenGui = 0x02A4, // only available in mahjong instance
     MahjongNextRound = 0x02BD, // initial hands(baipai), # of riichi(wat), winds, honba, score and stuff
@@ -301,7 +301,7 @@ namespace Sapphire::Network::Packets
     // 2C3 and 2C4 are currently unknown
     MahjongEndRoundDraw = 0x02C5, // self explanatory
     MahjongEndGame = 0x02C6, // finished oorasu(all-last) round; shows a result screen.
- 
+
     /// Airship & Submarine //////////////////////////////////////
     AirshipExplorationResult = 0x0203, // updated 5.58 hotfix
     AirshipStatus = 0x030C, // updated 5.58 hotfix
@@ -312,7 +312,7 @@ namespace Sapphire::Network::Packets
     SubmarineStatusList = 0x01EF, // updated 5.58 hotfix
     SubmarineTimers = 0x0247, // updated 5.58 hotfix
   };
- 
+
   /**
   * Client IPC Zone Type Codes.
   */
@@ -320,11 +320,11 @@ namespace Sapphire::Network::Packets
   {
     PingHandler = 0x0288, // updated 5.58 hotfix
     InitHandler = 0x02EB, // updated 5.58 hotfix
- 
+
     FinishLoadingHandler = 0x013C, // updated 5.58 hotfix
- 
+
     CFCommenceHandler = 0x0381, // updated 5.58 hotfix
- 
+
     CFCancelHandler = 0x02B2, // updated 5.58 hotfix
     CFRegisterDuty = 0x01BD, // updated 5.58 hotfix
     CFRegisterRoulette = 0x037A, // updated 5.58 hotfix
@@ -332,66 +332,66 @@ namespace Sapphire::Network::Packets
     LogoutHandler = 0x00A0, // updated 5.58 hotfix
     CancelLogout = 0x01AC, // updated 5.58 hotfix
     CFDutyInfoHandler = 0xF078, // updated 4.2
- 
+
     SocialReqSendHandler = 0x00D7, // updated 5.58 hotfix
     SocialResponseHandler = 0x023B, // updated 5.58 hotfix
     CreateCrossWorldLS = 0x035D, // updated 5.58 hotfix
- 
+
     ChatHandler = 0x03B0, // updated 5.58 hotfix
     PartyChatHandler = 0x0065,
     PartySetLeaderHandler = 0x036C, // updated 5.58 hotfix
     LeavePartyHandler = 0x019D, // updated 5.58 hotfix
     KickPartyMemberHandler = 0x0262, // updated 5.58 hotfix
     DisbandPartyHandler = 0x0276, // updated 5.58 hotfix
- 
+
     SocialListHandler = 0x01CA, // updated 5.58 hotfix
     SetSearchInfoHandler = 0x01D4, // updated 5.58 hotfix
     ReqSearchInfoHandler = 0x014F, // updated 5.58 hotfix
     ReqExamineSearchCommentHandler = 0x00E7, // updated 5.0
- 
+
     ReqRemovePlayerFromBlacklist = 0x00B4, // updated 5.58 hotfix
     BlackListHandler = 0x00F2, // updated 5.58 hotfix
     PlayerSearchHandler = 0x037D, // updated 5.58 hotfix
- 
+
     LinkshellListHandler = 0x03B6, // updated 5.58 hotfix
- 
+
     MarketBoardRequestItemListingInfo = 0x00F4, // updated 5.58 hotfix
     MarketBoardRequestItemListings = 0x0122, // updated 5.58 hotfix
     MarketBoardSearch = 0x0082, // updated 5.58 hotfix
- 
+
     ReqExamineFcInfo = 0x037B, // updated 5.58 hotfix
- 
+
     FcInfoReqHandler = 0x03D4, // updated 5.58 hotfix
- 
+
     FreeCompanyUpdateShortMessageHandler = 0x0123, // added 5.0
- 
+
     ReqMarketWishList = 0x00C3, // updated 5.58 hotfix
- 
+
     ReqJoinNoviceNetwork = 0x0129, // updated 4.2
- 
+
     ReqCountdownInitiate = 0x02EC, // updated 5.58 hotfix
     ReqCountdownCancel = 0x0068, // updated 5.58 hotfix
- 
+
     ZoneLineHandler = 0x008D, // updated 5.58 hotfix
     ClientTrigger = 0x03DB, // updated 5.58 hotfix
     DiscoveryHandler = 0x038B, // updated 5.58 hotfix
- 
+
     PlaceFieldMarkerPreset = 0x026D, // updated 5.58 hotfix
     PlaceFieldMarker = 0x0371, // updated 5.58 hotfix
     SkillHandler = 0x02DC, // updated 5.58 hotfix
     GMCommand1 = 0x0272, // updated 5.58 hotfix
     GMCommand2 = 0x00E9, // updated 5.58 hotfix
     AoESkillHandler = 0x0152, // updated 5.58 hotfix
- 
+
     UpdatePositionHandler = 0x01AF, // updated 5.58 hotfix
- 
+
     InventoryModifyHandler = 0x029E, // updated 5.58 hotfix
- 
+
     InventoryEquipRecommendedItems = 0x01C9, // updated 5.58 hotfix
- 
+
     ReqPlaceHousingItem = 0x02D4, // updated 5.58 hotfix
     BuildPresetHandler = 0x0223, // updated 5.58 hotfix
- 
+
     TalkEventHandler = 0x0387, // updated 5.58 hotfix
     EmoteEventHandler = 0x00B0, // updated 5.58 hotfix
     WithinRangeEventHandler = 0x02B6, // updated 5.58 hotfix
@@ -403,28 +403,28 @@ namespace Sapphire::Network::Packets
     TradeReturnEventHandler2 = 0x023C, // updated 5.58 hotfix
     EventYield2Handler = 0x021D, // updated 5.58 hotfix
     EventYield16Handler = 0x0207, // updated 5.58 hotfix
- 
+
     LinkshellEventHandler = 0x016B, // updated 4.5
     LinkshellEventHandler1 = 0x016C, // updated 4.5
- 
+
     ReqEquipDisplayFlagsChange = 0x02A5, // updated 5.58 hotfix
- 
+
     LandRenameHandler = 0x028E, // updated 5.58 hotfix
     HousingUpdateHouseGreeting = 0x0343, // updated 5.58 hotfix
     HousingUpdateObjectPosition = 0x012C, // updated 5.58 hotfix
     HousingEditExterior = 0x027B, // updated 5.58 hotfix
     HousingEditInterior = 0x02E3, // updated 5.58 hotfix
- 
+
     SetSharedEstateSettings = 0x00D2, // updated 5.58 hotfix
- 
+
     UpdatePositionInstance = 0x00F8, // updated 5.58 hotfix
- 
+
     PerformNoteHandler = 0x0243, // updated 5.58 hotfix
- 
+
     WorldInteractionHandler = 0x0274, // updated 5.58 hotfix
     Dive = 0x0320, // updated 5.58 hotfix
   };
- 
+
   ////////////////////////////////////////////////////////////////////////////////
   /// Chat Connection IPC Codes
   /**
@@ -435,10 +435,10 @@ namespace Sapphire::Network::Packets
     Tell = 0x0064, // updated for sb
     PublicContentTell = 0x00FB, // added 4.5, this is used when receiving a /tell in PublicContent instances such as Eureka or Bozja
     TellErrNotFound = 0x0066,
- 
+
     FreeCompanyEvent = 0x012C, // added 5.0
   };
- 
+
   /**
   * Client IPC Chat Type Codes.
   */
@@ -447,8 +447,8 @@ namespace Sapphire::Network::Packets
     TellReq = 0x0064,
     PublicContentTellReq = 0x0326, // updated 5.35 hotfix, this is used when sending a /tell in PublicContent instances such as Eureka or Bozja
   };
- 
- 
+
+
 }
  
 #endif /*_CORE_NETWORK_PACKETS_IPCS_H*/

--- a/src/common/Network/PacketDef/Ipcs.h
+++ b/src/common/Network/PacketDef/Ipcs.h
@@ -1,11 +1,11 @@
 #ifndef _CORE_NETWORK_PACKETS_IPCS_H
 #define _CORE_NETWORK_PACKETS_IPCS_H
-
+ 
 #include <stdint.h>
-
+ 
 namespace Sapphire::Network::Packets
 {
-
+ 
   ////////////////////////////////////////////////////////////////////////////////
   /// Lobby Connection IPC Codes
   /**
@@ -20,9 +20,9 @@ namespace Sapphire::Network::Packets
     LobbyEnterWorld = 0x000F,
     LobbyServerList = 0x0015,
     LobbyRetainerList = 0x0017,
-
+ 
   };
-
+ 
   /**
   * Client IPC Lobby Type Codes.
   */
@@ -31,11 +31,11 @@ namespace Sapphire::Network::Packets
     ReqCharList = 0x0003,
     ReqEnterWorld = 0x0004,
     ClientVersionInfo = 0x0005,
-
+ 
     ReqCharDelete = 0x000A,
     ReqCharCreate = 0x000B,
   };
-
+ 
   ////////////////////////////////////////////////////////////////////////////////
   /// Zone Connection IPC Codes
   /**
@@ -43,253 +43,253 @@ namespace Sapphire::Network::Packets
   */
   enum ServerZoneIpcType : uint16_t
   {
-    Ping = 0x02CB, // updated 5.58
-    Init = 0x02A8, // updated 5.58
-
-    ActorFreeSpawn = 0x0210, // updated 5.58
-    InitZone = 0x0100, // updated 5.58
-
-    EffectResult = 0x0151, // updated 5.58
-    ActorControl = 0x0264, // updated 5.58
-    ActorControlSelf = 0x0314, // updated 5.58
-    ActorControlTarget = 0x00FC, // updated 5.58
-
+    Ping = 0x02A8, // updated 5.58 hotfix
+    Init = 0x013C, // updated 5.58 hotfix
+ 
+    ActorFreeSpawn = 0x00B5, // updated 5.58 hotfix
+    InitZone = 0x0320, // updated 5.58 hotfix
+ 
+    EffectResult = 0x0387, // updated 5.58 hotfix
+    ActorControl = 0x00B0, // updated 5.58 hotfix
+    ActorControlSelf = 0x02B6, // updated 5.58 hotfix
+    ActorControlTarget = 0x03C5, // updated 5.58 hotfix
+ 
     /*!
      * @brief Used when resting
      */
-    UpdateHpMpTp = 0x039B, // updated 5.58
-
+    UpdateHpMpTp = 0x01A7, // updated 5.58 hotfix
+ 
     ///////////////////////////////////////////////////
-
+ 
     ChatBanned = 0xF06B,
-    Playtime = 0x02BE, // updated 5.58
-    Logout = 0x0297, // updated 5.58
-    CFNotify = 0x01AC, // updated 5.58
+    Playtime = 0x0179, // updated 5.58 hotfix
+    Logout = 0x0214, // updated 5.58 hotfix
+    CFNotify = 0x0327, // updated 5.58 hotfix
     CFMemberStatus = 0x0079,
-    CFDutyInfo = 0x0083, // updated 5.58
+    CFDutyInfo = 0x03AA, // updated 5.58 hotfix
     CFPlayerInNeed = 0xF07F,
-    CFPreferredRole = 0x02FB, // updated 5.58
-    CFCancel = 0x0135, // updated 5.58
+    CFPreferredRole = 0x024B, // updated 5.58 hotfix
+    CFCancel = 0x01AC, // updated 5.58 hotfix
     SocialRequestError = 0xF0AD,
-
-    CFRegistered = 0x037E, // updated 5.58
-    SocialRequestResponse = 0x0254, // updated 5.58
-    SocialMessage = 0x02F2, // updated 5.58
-    SocialMessage2 = 0x017A, // updated 5.58
+ 
+    CFRegistered = 0x029F, // updated 5.58 hotfix
+    SocialRequestResponse = 0x0082, // updated 5.58 hotfix
+    SocialMessage = 0x03CB, // updated 5.58 hotfix
+    SocialMessage2 = 0x01D7, // updated 5.58 hotfix
     CancelAllianceForming = 0xF0C6, // updated 4.2
-
-    LogMessage = 0x020F, // updated 5.58
-
-    Chat = 0x0220, // updated 5.58
+ 
+    LogMessage = 0x0118, // updated 5.58 hotfix
+ 
+    Chat = 0x00FE, // updated 5.58 hotfix
     PartyChat = 0x0065,
-
+ 
     WorldVisitList = 0xF0FE, // added 4.5
-
-    SocialList = 0x0396, // updated 5.58
-
-    ExamineSearchInfo = 0x031F, // updated 5.58
-    UpdateSearchInfo = 0x0219, // updated 5.58
-    InitSearchInfo = 0x01A0, // updated 5.58
-    ExamineSearchComment = 0x0315, // updated 5.58
-
-    ServerNoticeShort = 0x0211, // updated 5.58
-    ServerNotice = 0x03B9, // updated 5.58
-    SetOnlineStatus = 0x0163, // updated 5.58
-
-    CountdownInitiate = 0x01F9, // updated 5.58
-    CountdownCancel = 0x0206, // updated 5.58
-
-    PlayerAddedToBlacklist = 0x01FE, // updated 5.58
-    PlayerRemovedFromBlacklist = 0x02D6, // updated 5.58
-    BlackList = 0x028A, // updated 5.58
-
-    LinkshellList = 0x02DD, // updated 5.58
-
+ 
+    SocialList = 0x015F, // updated 5.58 hotfix
+ 
+    ExamineSearchInfo = 0x0133, // updated 5.58 hotfix
+    UpdateSearchInfo = 0x03E5, // updated 5.58 hotfix
+    InitSearchInfo = 0x0321, // updated 5.58 hotfix
+    ExamineSearchComment = 0x03AD, // updated 5.58 hotfix
+ 
+    ServerNoticeShort = 0x0333, // updated 5.58 hotfix
+    ServerNotice = 0x0171, // updated 5.58 hotfix
+    SetOnlineStatus = 0x037B, // updated 5.58 hotfix
+ 
+    CountdownInitiate = 0x0111, // updated 5.58 hotfix
+    CountdownCancel = 0x0231, // updated 5.58 hotfix
+ 
+    PlayerAddedToBlacklist = 0x024E, // updated 5.58 hotfix
+    PlayerRemovedFromBlacklist = 0x011D, // updated 5.58 hotfix
+    BlackList = 0x03C0, // updated 5.58 hotfix
+ 
+    LinkshellList = 0x02E2, // updated 5.58 hotfix
+ 
     MailDeleteRequest = 0xF12B, // updated 5.0
-
+ 
     // 12D - 137 - constant gap between 4.5x -> 5.0
     ReqMoogleMailList = 0xF138, // updated 5.0
     ReqMoogleMailLetter = 0xF139, // updated 5.0
     MailLetterNotification = 0x013A, // updated 5.0
-
+ 
     MarketTaxRates = 0x01F8, // updated 5.35 hotfix
-
-    MarketBoardSearchResult = 0x0355, // updated 5.58
-    MarketBoardItemListingCount = 0x0275, // updated 5.58
-    MarketBoardItemListingHistory = 0x0112, // updated 5.58
-    MarketBoardItemListing = 0x00F5, // updated 5.58
-    
+ 
+    MarketBoardSearchResult = 0x01F1, // updated 5.58 hotfix
+    MarketBoardItemListingCount = 0x0068, // updated 5.58 hotfix
+    MarketBoardItemListingHistory = 0x01BA, // updated 5.58 hotfix
+    MarketBoardItemListing = 0x0076, // updated 5.58 hotfix
+ 
     CharaFreeCompanyTag = 0x013B, // updated 4.5
-    FreeCompanyBoardMsg = 0x028D, // updated 5.58
-    FreeCompanyInfo = 0x0346, // updated 5.58
-    ExamineFreeCompanyInfo = 0x00B7, // updated 5.58
-
+    FreeCompanyBoardMsg = 0x03DB, // updated 5.58 hotfix
+    FreeCompanyInfo = 0x01F7, // updated 5.58 hotfix
+    ExamineFreeCompanyInfo = 0x0324, // updated 5.58 hotfix
+ 
     FreeCompanyUpdateShortMessage = 0xF157, // added 5.0
-
-    StatusEffectList = 0x01C5, // updated 5.58
+ 
+    StatusEffectList = 0x0074, // updated 5.58 hotfix
     EurekaStatusEffectList = 0x0167, // updated 5.18
     BossStatusEffectList = 0x0312, // added 5.1
-    Effect = 0x0102, // updated 5.58
-    AoeEffect8 = 0x0345, // updated 5.58
-    AoeEffect16 = 0x02B6, // updated 5.58
-    AoeEffect24 = 0x0298, // updated 5.58
-    AoeEffect32 = 0x03A4, // updated 5.58
-    PersistantEffect = 0x008D, // updated 5.58
-
-    GCAffiliation = 0x02B1, // updated 5.58
-
-    PlayerSpawn = 0x0249, // updated 5.58
-    NpcSpawn = 0x014B, // updated 5.58
+    Effect = 0x03CA, // updated 5.58 hotfix
+    AoeEffect8 = 0x03C4, // updated 5.58 hotfix
+    AoeEffect16 = 0x00FA, // updated 5.58 hotfix
+    AoeEffect24 = 0x0339, // updated 5.58 hotfix
+    AoeEffect32 = 0x023C, // updated 5.58 hotfix
+    PersistantEffect = 0x025D, // updated 5.58 hotfix
+ 
+    GCAffiliation = 0x0094, // updated 5.58 hotfix
+ 
+    PlayerSpawn = 0x01D8, // updated 5.58 hotfix
+    NpcSpawn = 0x00D2, // updated 5.58 hotfix
     NpcSpawn2 = 0x01CB, // ( Bigger statuseffectlist? ) updated 5.3
-    ActorMove = 0x023D, // updated 5.58
-
-    ActorSetPos = 0x0280, // updated 5.58
-
-    ActorCast = 0x02A7, // updated 5.58
+    ActorMove = 0x00F8, // updated 5.58 hotfix
+ 
+    ActorSetPos = 0x0299, // updated 5.58 hotfix
+ 
+    ActorCast = 0x015D, // updated 5.58 hotfix
     SomeCustomiseChangePacketProbably = 0x00CD, // added 5.18
-
-    PartyList = 0x02BD, // updated 5.58
-    PartyMessage = 0x0318, // updated 5.58
-    HateRank = 0x02C0, // updated 5.58
-    HateList = 0x01B4, // updated 5.58
-    ObjectSpawn = 0x0104, // updated 5.58
-    ObjectDespawn = 0x030D, // updated 5.58
-    UpdateClassInfo = 0x0198, // updated 5.58
+ 
+    PartyList = 0x0349, // updated 5.58 hotfix
+    PartyMessage = 0x00A4, // updated 5.58 hotfix
+    HateRank = 0x0150, // updated 5.58 hotfix
+    HateList = 0x0243, // updated 5.58 hotfix
+    ObjectSpawn = 0x0125, // updated 5.58 hotfix
+    ObjectDespawn = 0x0148, // updated 5.58 hotfix
+    UpdateClassInfo = 0x0084, // updated 5.58 hotfix
     SilentSetClassJob = 0xF18E, // updated 5.0 - seems to be the case, not sure if it's actually used for anything
-    PlayerSetup = 0x0296, // updated 5.58
-    PlayerStats = 0x00D5, // updated 5.58
-    ActorOwner = 0x00AE, // updated 5.58
-    PlayerStateFlags = 0x022A, // updated 5.58
-    PlayerClassInfo = 0x02DF, // updated 5.58
-    CharaVisualEffect = 0x0134, // updated 5.58
-
-    ModelEquip = 0x0312, // updated 5.58
-    Examine = 0x00D3, // updated 5.58
-    CharaNameReq = 0x031C, // updated 5.58
-
+    PlayerSetup = 0x01D5, // updated 5.58 hotfix
+    PlayerStats = 0x0295, // updated 5.58 hotfix
+    ActorOwner = 0x0260, // updated 5.58 hotfix
+    PlayerStateFlags = 0x03BF, // updated 5.58 hotfix
+    PlayerClassInfo = 0x0131, // updated 5.58 hotfix
+    CharaVisualEffect = 0x0292, // updated 5.58 hotfix
+ 
+    ModelEquip = 0x03A2, // updated 5.58 hotfix
+    Examine = 0x0365, // updated 5.58 hotfix
+    CharaNameReq = 0x01F0, // updated 5.58 hotfix
+ 
     // nb: see #565 on github
     UpdateRetainerItemSalePrice = 0xF19F, // updated 5.0
-    RetainerSaleHistory = 0x01D3, // updated 5.58
-    RetainerInformation = 0x0069, // updated 5.58
-
+    RetainerSaleHistory = 0x03CE, // updated 5.58 hotfix
+    RetainerInformation = 0x022F, // updated 5.58 hotfix
+ 
     SetLevelSync = 0x1186, // not updated for 4.4, not sure what it is anymore
-
-    ItemInfo = 0x00A7, // updated 5.58
-    ContainerInfo = 0x0208, // updated 5.58
-    InventoryTransactionFinish = 0x01A3, // updated 5.58
-    InventoryTransaction = 0x03AC, // updated 5.58
-    CurrencyCrystalInfo = 0x0394, // updated 5.58
-
-    InventoryActionAck = 0x0305, // updated 5.58
-    UpdateInventorySlot = 0x0200, // updated 5.58
-
-    HuntingLogEntry = 0x00C5, // updated 5.58
-
-    EventPlay = 0x01EF, // updated 5.58
-    EventPlay4 = 0x021C, // updated 5.58
-    EventPlay8 = 0x0337, // updated 5.58
-    EventPlay16 = 0x0319, // updated 5.58
-    EventPlay32 = 0x01E2, // updated 5.58
-    EventPlay64 = 0x02FD, // updated 5.58
-    EventPlay128 = 0x026E, // updated 5.58
-    EventPlay255 = 0x039E, // updated 5.58
-
-    EventContinue = 0x0123, // updated 5.58
-
-    EventStart = 0x01CC, // updated 5.58
-    EventFinish = 0x0180, // updated 5.58
-
+ 
+    ItemInfo = 0x01CC, // updated 5.58 hotfix
+    ContainerInfo = 0x025C, // updated 5.58 hotfix
+    InventoryTransactionFinish = 0x0176, // updated 5.58 hotfix
+    InventoryTransaction = 0x027F, // updated 5.58 hotfix
+    CurrencyCrystalInfo = 0x0345, // updated 5.58 hotfix
+ 
+    InventoryActionAck = 0x03B8, // updated 5.58 hotfix
+    UpdateInventorySlot = 0x02F7, // updated 5.58 hotfix
+ 
+    HuntingLogEntry = 0x01D9, // updated 5.58 hotfix
+ 
+    EventPlay = 0x016B, // updated 5.58 hotfix
+    EventPlay4 = 0x010A, // updated 5.58 hotfix
+    EventPlay8 = 0x0337, // updated 5.58 hotfix
+    EventPlay16 = 0x0269, // updated 5.58 hotfix
+    EventPlay32 = 0x023E, // updated 5.58 hotfix
+    EventPlay64 = 0x00DE, // updated 5.58 hotfix
+    EventPlay128 = 0x02D0, // updated 5.58 hotfix
+    EventPlay255 = 0x0362, // updated 5.58 hotfix
+ 
+    EventContinue = 0x00B6, // updated 5.58 hotfix
+ 
+    EventStart = 0x02DA, // updated 5.58 hotfix
+    EventFinish = 0x0235, // updated 5.58 hotfix
+ 
     EventLinkshell = 0x1169,
-
-    QuestActiveList = 0x035D, // updated 5.58
-    QuestUpdate = 0x029A, // updated 5.58
-    QuestCompleteList = 0x03C5, // updated 5.58
-
-    QuestFinish = 0x0274, // updated 5.58
-    MSQTrackerComplete = 0x01C1, // updated 5.58
+ 
+    QuestActiveList = 0x0097, // updated 5.58 hotfix
+    QuestUpdate = 0x01B2, // updated 5.58 hotfix
+    QuestCompleteList = 0x006D, // updated 5.58 hotfix
+ 
+    QuestFinish = 0x021B, // updated 5.58 hotfix
+    MSQTrackerComplete = 0x0348, // updated 5.58 hotfix
     MSQTrackerProgress = 0xF1CD, // updated 4.5 ? this actually looks like the two opcodes have been combined, see #474
-
-    QuestMessage = 0x0128, // updated 5.58
-
-    QuestTracker = 0x038E, // updated 5.58
-
-    Mount = 0x03C2, // updated 5.58
-
-    DirectorVars = 0x01ED, // updated 5.58
+ 
+    QuestMessage = 0x0220, // updated 5.58 hotfix
+ 
+    QuestTracker = 0x00D8, // updated 5.58 hotfix
+ 
+    Mount = 0x01E1, // updated 5.58 hotfix
+ 
+    DirectorVars = 0x0154, // updated 5.58 hotfix
     SomeDirectorUnk1 = 0x0084, // updated 5.18
     SomeDirectorUnk2 = 0xF0C1, // updated 5.18
-    SomeDirectorUnk4 = 0x01BD, // updated 5.58
+    SomeDirectorUnk4 = 0x03DD, // updated 5.58 hotfix
     SomeDirectorUnk8 = 0x028A, // updated 5.18
     SomeDirectorUnk16 = 0x028C, // updated 5.18
-    DirectorPopUp = 0x02E3, // updated 5.58
-    DirectorPopUp4 = 0x01DC, // updated 5.58
-    DirectorPopUp8 = 0x011D, // updated 5.58
-
+    DirectorPopUp = 0x03DF, // updated 5.58 hotfix
+    DirectorPopUp4 = 0x019B, // updated 5.58 hotfix
+    DirectorPopUp8 = 0x0271, // updated 5.58 hotfix
+ 
     CFAvailableContents = 0xF1FD, // updated 4.2
-
-    WeatherChange = 0x01B1, // updated 5.58
-    PlayerTitleList = 0x02B4, // updated 5.58
-    Discovery = 0x00B8, // updated 5.58
-
-    EorzeaTimeOffset = 0x03D9, // updated 5.58
-
-    EquipDisplayFlags = 0x0199, // updated 5.58
-
+ 
+    WeatherChange = 0x0323, // updated 5.58 hotfix
+    PlayerTitleList = 0x014E, // updated 5.58 hotfix
+    Discovery = 0x01C2, // updated 5.58 hotfix
+ 
+    EorzeaTimeOffset = 0x0070, // updated 5.58 hotfix
+ 
+    EquipDisplayFlags = 0x02C6, // updated 5.58 hotfix
+ 
     MiniCactpotInit = 0x0286, // added 5.31
-    ShopMessage = 0x00D0, // updated 5.58
-    LootMessage = 0x038C, // updated 5.58
-    ResultDialog = 0x00DF, // updated 5.58
-    DesynthResult = 0x038F, // updated 5.58
-
+    ShopMessage = 0x0287, // updated 5.58 hotfix
+    LootMessage = 0x0383, // updated 5.58 hotfix
+    ResultDialog = 0x0273, // updated 5.58 hotfix
+    DesynthResult = 0x0238, // updated 5.58 hotfix
+ 
     /// Housing //////////////////////////////////////
-
-    LandSetInitialize = 0x03E3, // updated 5.58
-    LandUpdate = 0x029E, // updated 5.58
-    YardObjectSpawn = 0x0367, // updated 5.58
-    HousingIndoorInitialize = 0x02A6, // updated 5.58
-    LandPriceUpdate = 0x0143, // updated 5.58
-    LandInfoSign = 0x0269, // updated 5.58
-    LandRename = 0x0107, // updated 5.58
-    HousingEstateGreeting = 0x0340, // updated 5.58
-    HousingUpdateLandFlagsSlot = 0x02D2, // updated 5.58
-    HousingLandFlags = 0x0156, // updated 5.58
-    HousingShowEstateGuestAccess = 0x015C, // updated 5.58
-
-    HousingObjectInitialize = 0x0245, // updated 5.58
-    HousingInternalObjectSpawn = 0x0194, // updated 5.58
-
-    HousingWardInfo = 0x00A4, // updated 5.58
-    HousingObjectMove = 0x01AE, // updated 5.58
-
-    SharedEstateSettingsResponse = 0x0378, // updated 5.58
-
-    LandUpdateHouseName = 0x034B, // updated 5.58
-
-    LandSetMap = 0x02F6, // updated 5.58
-
-    CeremonySetActorAppearance = 0x00EB, // updated 5.58
-
+ 
+    LandSetInitialize = 0x0159, // updated 5.58 hotfix
+    LandUpdate = 0x0228, // updated 5.58 hotfix
+    YardObjectSpawn = 0x023D, // updated 5.58 hotfix
+    HousingIndoorInitialize = 0x0210, // updated 5.58 hotfix
+    LandPriceUpdate = 0x0300, // updated 5.58 hotfix
+    LandInfoSign = 0x03E7, // updated 5.58 hotfix
+    LandRename = 0x01BF, // updated 5.58 hotfix
+    HousingEstateGreeting = 0x0126, // updated 5.58 hotfix
+    HousingUpdateLandFlagsSlot = 0x0157, // updated 5.58 hotfix
+    HousingLandFlags = 0x03B1, // updated 5.58 hotfix
+    HousingShowEstateGuestAccess = 0x00CC, // updated 5.58 hotfix
+ 
+    HousingObjectInitialize = 0x0112, // updated 5.58 hotfix
+    HousingInternalObjectSpawn = 0x02C8, // updated 5.58 hotfix
+ 
+    HousingWardInfo = 0x012A, // updated 5.58 hotfix
+    HousingObjectMove = 0x0265, // updated 5.58 hotfix
+ 
+    SharedEstateSettingsResponse = 0x030E, // updated 5.58 hotfix
+ 
+    LandUpdateHouseName = 0x017C, // updated 5.58 hotfix
+ 
+    LandSetMap = 0x02E5, // updated 5.58 hotfix
+ 
+    CeremonySetActorAppearance = 0x02ED, // updated 5.58 hotfix
+ 
     //////////////////////////////////////////////////
-
+ 
     DuelChallenge = 0x0277, // 4.2; this is responsible for opening the ui
-    PerformNote = 0x00BE, // updated 5.58
-
-    PrepareZoning = 0x0171, // updated 5.58
-    ActorGauge = 0x0335, // updated 5.58
-    DutyGauge = 0x02F6, // updated 5.58
-
+    PerformNote = 0x0127, // updated 5.58 hotfix
+ 
+    PrepareZoning = 0x02AB, // updated 5.58 hotfix
+    ActorGauge = 0x01C1, // updated 5.58 hotfix
+    DutyGauge = 0x02E5, // updated 5.58 hotfix
+ 
     // daily quest info -> without them sent,  login will take longer...
-    DailyQuests = 0x0331, // updated 5.58
-    DailyQuestRepeatFlags = 0x01D1, // updated 5.58
-
-    MapUpdate = 0x03A2, // updated 5.58
-    MapUpdate4 = 0x0284, // updated 5.58
-    MapUpdate8 = 0x01BC, // updated 5.58
-    MapUpdate16 = 0x02D1, // updated 5.58
-    MapUpdate32 = 0x00DB, // updated 5.58
-    MapUpdate64 = 0x0368, // updated 5.58
-    MapUpdate128 = 0x0349, // updated 5.58
-
+    DailyQuests = 0x02D6, // updated 5.58 hotfix
+    DailyQuestRepeatFlags = 0x01AB, // updated 5.58 hotfix
+ 
+    MapUpdate = 0x0394, // updated 5.58 hotfix
+    MapUpdate4 = 0x036F, // updated 5.58 hotfix
+    MapUpdate8 = 0x0311, // updated 5.58 hotfix
+    MapUpdate16 = 0x0108, // updated 5.58 hotfix
+    MapUpdate32 = 0x007A, // updated 5.58 hotfix
+    MapUpdate64 = 0x02A0, // updated 5.58 hotfix
+    MapUpdate128 = 0x0303, // updated 5.58 hotfix
+ 
     /// Doman Mahjong //////////////////////////////////////
     MahjongOpenGui = 0x02A4, // only available in mahjong instance
     MahjongNextRound = 0x02BD, // initial hands(baipai), # of riichi(wat), winds, honba, score and stuff
@@ -301,130 +301,130 @@ namespace Sapphire::Network::Packets
     // 2C3 and 2C4 are currently unknown
     MahjongEndRoundDraw = 0x02C5, // self explanatory
     MahjongEndGame = 0x02C6, // finished oorasu(all-last) round; shows a result screen.
-
+ 
     /// Airship & Submarine //////////////////////////////////////
-    AirshipExplorationResult = 0x036C, // updated 5.58
-    AirshipStatus = 0x021F, // updated 5.58
-    AirshipStatusList = 0x0073, // updated 5.58
-    AirshipTimers = 0x0250, // updated 5.58
-    SubmarineExplorationResult = 0x01D0, // updated 5.58
-    SubmarineProgressionStatus = 0x0377, // updated 5.58
-    SubmarineStatusList = 0x0338, // updated 5.58
-    SubmarineTimers = 0x0292, // updated 5.58
+    AirshipExplorationResult = 0x0203, // updated 5.58 hotfix
+    AirshipStatus = 0x030C, // updated 5.58 hotfix
+    AirshipStatusList = 0x02FE, // updated 5.58 hotfix
+    AirshipTimers = 0x0166, // updated 5.58 hotfix
+    SubmarineExplorationResult = 0x00AA, // updated 5.58 hotfix
+    SubmarineProgressionStatus = 0x0357, // updated 5.58 hotfix
+    SubmarineStatusList = 0x01EF, // updated 5.58 hotfix
+    SubmarineTimers = 0x0247, // updated 5.58 hotfix
   };
-
+ 
   /**
   * Client IPC Zone Type Codes.
   */
   enum ClientZoneIpcType : uint16_t
   {
-    PingHandler = 0x03A3, // updated 5.58
-    InitHandler = 0x03B3, // updated 5.58
-
-    FinishLoadingHandler = 0x0217, // updated 5.58
-
-    CFCommenceHandler = 0x02A3, // updated 5.58
-
-    CFCancelHandler = 0x00A9, // updated 5.58
-    CFRegisterDuty = 0x036A, // updated 5.58
-    CFRegisterRoulette = 0x038C, // updated 5.58
-    PlayTimeHandler = 0x01A8, // updated 5.58
-    LogoutHandler = 0x02A5, // updated 5.58
-    CancelLogout = 0x03CC, // updated 5.58
+    PingHandler = 0x0288, // updated 5.58 hotfix
+    InitHandler = 0x02EB, // updated 5.58 hotfix
+ 
+    FinishLoadingHandler = 0x013C, // updated 5.58 hotfix
+ 
+    CFCommenceHandler = 0x0381, // updated 5.58 hotfix
+ 
+    CFCancelHandler = 0x02B2, // updated 5.58 hotfix
+    CFRegisterDuty = 0x01BD, // updated 5.58 hotfix
+    CFRegisterRoulette = 0x037A, // updated 5.58 hotfix
+    PlayTimeHandler = 0x02B7, // updated 5.58 hotfix
+    LogoutHandler = 0x00A0, // updated 5.58 hotfix
+    CancelLogout = 0x01AC, // updated 5.58 hotfix
     CFDutyInfoHandler = 0xF078, // updated 4.2
-
-    SocialReqSendHandler = 0x0366, // updated 5.58
-    SocialResponseHandler = 0x0311, // updated 5.58
-    CreateCrossWorldLS = 0x0125, // updated 5.58
-
-    ChatHandler = 0x02F4, // updated 5.58
+ 
+    SocialReqSendHandler = 0x00D7, // updated 5.58 hotfix
+    SocialResponseHandler = 0x023B, // updated 5.58 hotfix
+    CreateCrossWorldLS = 0x035D, // updated 5.58 hotfix
+ 
+    ChatHandler = 0x03B0, // updated 5.58 hotfix
     PartyChatHandler = 0x0065,
-    PartySetLeaderHandler = 0x03C2, // updated 5.58
-    LeavePartyHandler = 0x028A, // updated 5.58
-    KickPartyMemberHandler = 0x01D1, // updated 5.58
-    DisbandPartyHandler = 0x032B, // updated 5.58
-
-    SocialListHandler = 0x006E, // updated 5.58
-    SetSearchInfoHandler = 0x010A, // updated 5.58
-    ReqSearchInfoHandler = 0x0255, // updated 5.58
+    PartySetLeaderHandler = 0x036C, // updated 5.58 hotfix
+    LeavePartyHandler = 0x019D, // updated 5.58 hotfix
+    KickPartyMemberHandler = 0x0262, // updated 5.58 hotfix
+    DisbandPartyHandler = 0x0276, // updated 5.58 hotfix
+ 
+    SocialListHandler = 0x01CA, // updated 5.58 hotfix
+    SetSearchInfoHandler = 0x01D4, // updated 5.58 hotfix
+    ReqSearchInfoHandler = 0x014F, // updated 5.58 hotfix
     ReqExamineSearchCommentHandler = 0x00E7, // updated 5.0
-
-    ReqRemovePlayerFromBlacklist = 0x015A, // updated 5.58
-    BlackListHandler = 0x02C5, // updated 5.58
-    PlayerSearchHandler = 0x0259, // updated 5.58
-
-    LinkshellListHandler = 0x01F0, // updated 5.58
-
-    MarketBoardRequestItemListingInfo = 0x02D3, // updated 5.58
-    MarketBoardRequestItemListings = 0x00AD, // updated 5.58
-    MarketBoardSearch = 0x00D6, // updated 5.58
-
-    ReqExamineFcInfo = 0x0359, // updated 5.58
-
-    FcInfoReqHandler = 0x0078, // updated 5.58
-
+ 
+    ReqRemovePlayerFromBlacklist = 0x00B4, // updated 5.58 hotfix
+    BlackListHandler = 0x00F2, // updated 5.58 hotfix
+    PlayerSearchHandler = 0x037D, // updated 5.58 hotfix
+ 
+    LinkshellListHandler = 0x03B6, // updated 5.58 hotfix
+ 
+    MarketBoardRequestItemListingInfo = 0x00F4, // updated 5.58 hotfix
+    MarketBoardRequestItemListings = 0x0122, // updated 5.58 hotfix
+    MarketBoardSearch = 0x0082, // updated 5.58 hotfix
+ 
+    ReqExamineFcInfo = 0x037B, // updated 5.58 hotfix
+ 
+    FcInfoReqHandler = 0x03D4, // updated 5.58 hotfix
+ 
     FreeCompanyUpdateShortMessageHandler = 0x0123, // added 5.0
-
-    ReqMarketWishList = 0x0364, // updated 5.58
-
+ 
+    ReqMarketWishList = 0x00C3, // updated 5.58 hotfix
+ 
     ReqJoinNoviceNetwork = 0x0129, // updated 4.2
-
-    ReqCountdownInitiate = 0x020E, // updated 5.58
-    ReqCountdownCancel = 0x03BE, // updated 5.58
-
-    ZoneLineHandler = 0x00B0, // updated 5.58
-    ClientTrigger = 0x008B, // updated 5.58
-    DiscoveryHandler = 0x01B4, // updated 5.58
-
-    PlaceFieldMarkerPreset = 0x03B0, // updated 5.58
-    PlaceFieldMarker = 0x011A, // updated 5.58
-    SkillHandler = 0x0175, // updated 5.58
-    GMCommand1 = 0x0353, // updated 5.58
-    GMCommand2 = 0x03E7, // updated 5.58
-    AoESkillHandler = 0x021D, // updated 5.58
-
-    UpdatePositionHandler = 0x0212, // updated 5.58
-
-    InventoryModifyHandler = 0x014A, // updated 5.58
-    
-    InventoryEquipRecommendedItems = 0x01D7, // updated 5.58
-
-    ReqPlaceHousingItem = 0x0354, // updated 5.58
-    BuildPresetHandler = 0x00DC, // updated 5.58
-
-    TalkEventHandler = 0x012D, // updated 5.58
-    EmoteEventHandler = 0x039E, // updated 5.58
-    WithinRangeEventHandler = 0x022C, // updated 5.58
-    OutOfRangeEventHandler = 0x0294, // updated 5.58
-    EnterTeriEventHandler = 0x00C1, // updated 5.58
-    ShopEventHandler = 0x02B8, // updated 5.58
-    EventYieldHandler = 0x03A2, // updated 5.58
-    ReturnEventHandler = 0x0333, // updated 5.58
-    TradeReturnEventHandler = 0x0179, // updated 5.58
-    TradeReturnEventHandler2 = 0x02E1, // updated 5.58
-    EventYield16Handler = 0x03D7, // updated 5.58
-
+ 
+    ReqCountdownInitiate = 0x02EC, // updated 5.58 hotfix
+    ReqCountdownCancel = 0x0068, // updated 5.58 hotfix
+ 
+    ZoneLineHandler = 0x008D, // updated 5.58 hotfix
+    ClientTrigger = 0x03DB, // updated 5.58 hotfix
+    DiscoveryHandler = 0x038B, // updated 5.58 hotfix
+ 
+    PlaceFieldMarkerPreset = 0x026D, // updated 5.58 hotfix
+    PlaceFieldMarker = 0x0371, // updated 5.58 hotfix
+    SkillHandler = 0x02DC, // updated 5.58 hotfix
+    GMCommand1 = 0x0272, // updated 5.58 hotfix
+    GMCommand2 = 0x00E9, // updated 5.58 hotfix
+    AoESkillHandler = 0x0152, // updated 5.58 hotfix
+ 
+    UpdatePositionHandler = 0x01AF, // updated 5.58 hotfix
+ 
+    InventoryModifyHandler = 0x029E, // updated 5.58 hotfix
+ 
+    InventoryEquipRecommendedItems = 0x01C9, // updated 5.58 hotfix
+ 
+    ReqPlaceHousingItem = 0x02D4, // updated 5.58 hotfix
+    BuildPresetHandler = 0x0223, // updated 5.58 hotfix
+ 
+    TalkEventHandler = 0x0387, // updated 5.58 hotfix
+    EmoteEventHandler = 0x00B0, // updated 5.58 hotfix
+    WithinRangeEventHandler = 0x02B6, // updated 5.58 hotfix
+    OutOfRangeEventHandler = 0x03C5, // updated 5.58 hotfix
+    EnterTeriEventHandler = 0x01A7, // updated 5.58 hotfix
+    ShopEventHandler = 0x0384, // updated 5.58 hotfix
+    ReturnEventHandler = 0x00FA, // updated 5.58 hotfix
+    TradeReturnEventHandler = 0x0339, // updated 5.58 hotfix
+    TradeReturnEventHandler2 = 0x023C, // updated 5.58 hotfix
+    EventYield2Handler = 0x021D, // updated 5.58 hotfix
+    EventYield16Handler = 0x0207, // updated 5.58 hotfix
+ 
     LinkshellEventHandler = 0x016B, // updated 4.5
     LinkshellEventHandler1 = 0x016C, // updated 4.5
-
-    ReqEquipDisplayFlagsChange = 0x01AD, // updated 5.58
-
-    LandRenameHandler = 0x0083, // updated 5.58
-    HousingUpdateHouseGreeting = 0x031A, // updated 5.58
-    HousingUpdateObjectPosition = 0x010E, // updated 5.58
-    HousingEditExterior = 0x0324, // updated 5.58
-    HousingEditInterior = 0x02F7, // updated 5.58
-
-    SetSharedEstateSettings = 0x0342, // updated 5.58
-
-    UpdatePositionInstance = 0x01A3, // updated 5.58
-
-    PerformNoteHandler = 0x015E, // updated 5.58
-
-    WorldInteractionHandler = 0x03CE, // updated 5.58
-    Dive = 0x034C, // updated 5.58
+ 
+    ReqEquipDisplayFlagsChange = 0x02A5, // updated 5.58 hotfix
+ 
+    LandRenameHandler = 0x028E, // updated 5.58 hotfix
+    HousingUpdateHouseGreeting = 0x0343, // updated 5.58 hotfix
+    HousingUpdateObjectPosition = 0x012C, // updated 5.58 hotfix
+    HousingEditExterior = 0x027B, // updated 5.58 hotfix
+    HousingEditInterior = 0x02E3, // updated 5.58 hotfix
+ 
+    SetSharedEstateSettings = 0x00D2, // updated 5.58 hotfix
+ 
+    UpdatePositionInstance = 0x00F8, // updated 5.58 hotfix
+ 
+    PerformNoteHandler = 0x0243, // updated 5.58 hotfix
+ 
+    WorldInteractionHandler = 0x0274, // updated 5.58 hotfix
+    Dive = 0x0320, // updated 5.58 hotfix
   };
-
+ 
   ////////////////////////////////////////////////////////////////////////////////
   /// Chat Connection IPC Codes
   /**
@@ -435,10 +435,10 @@ namespace Sapphire::Network::Packets
     Tell = 0x0064, // updated for sb
     PublicContentTell = 0x00FB, // added 4.5, this is used when receiving a /tell in PublicContent instances such as Eureka or Bozja
     TellErrNotFound = 0x0066,
-
+ 
     FreeCompanyEvent = 0x012C, // added 5.0
   };
-
+ 
   /**
   * Client IPC Chat Type Codes.
   */
@@ -447,8 +447,8 @@ namespace Sapphire::Network::Packets
     TellReq = 0x0064,
     PublicContentTellReq = 0x0326, // updated 5.35 hotfix, this is used when sending a /tell in PublicContent instances such as Eureka or Bozja
   };
-
-
+ 
+ 
 }
-
+ 
 #endif /*_CORE_NETWORK_PACKETS_IPCS_H*/

--- a/src/common/Network/PacketDef/Zone/ClientZoneDef.h
+++ b/src/common/Network/PacketDef/Zone/ClientZoneDef.h
@@ -447,7 +447,7 @@ struct FFXIVIpcHousingEditInterior :
 };
 
 struct FFXIVIpcEventYieldHandler :
-  FFXIVIpcBasePacket< EventYieldHandler >
+  FFXIVIpcBasePacket< EventYield2Handler >
 {
   uint32_t eventId;
   uint16_t scene;
@@ -467,7 +467,8 @@ struct FFXIVIpcEventYield16Handler :
 struct FFXIVIpcCFCommenceHandler :
   FFXIVIpcBasePacket< CFCommenceHandler >
 {
-  uint64_t param;
+  uint8_t param;
+  uint8_t dummy[7];
 };
 
 }

--- a/src/world/Network/GameConnection.cpp
+++ b/src/world/Network/GameConnection.cpp
@@ -106,7 +106,7 @@ Sapphire::Network::GameConnection::GameConnection( Sapphire::Network::HivePtr pH
   setZoneHandler( ClientZoneIpcType::TradeReturnEventHandler, "TradeReturnEventHandler",
                   &GameConnection::eventHandlerReturn );
   setZoneHandler( ClientZoneIpcType::TradeReturnEventHandler2, "TradeReturnEventHandler2", &GameConnection::eventHandlerReturn );
-  setZoneHandler( ClientZoneIpcType::EventYieldHandler, "EventYieldHandler", &GameConnection::eventYieldHandler );
+  setZoneHandler( ClientZoneIpcType::EventYield2Handler, "EventYield2Handler", &GameConnection::eventYieldHandler );
   setZoneHandler( ClientZoneIpcType::EventYield16Handler, "EventYield16Handler", &GameConnection::eventYieldHandler );
 
   setZoneHandler( ClientZoneIpcType::ShopEventHandler, "ShopEventHandler",


### PR DESCRIPTION
This should fix the Duty Finder and update the opcodes for the newest client.

The opcode updates are courtesy of collett, Flavien Normand and Taezen.
I had assistance with CFCommenceHandler from Mordred and collett.