### PR TITLE
[3.0] Backport quests that don't require onBnpcKill or onEobjHit

### DIFF
--- a/src/scripts/quest/classquest/ARC/ClsArc004.cpp
+++ b/src/scripts/quest/classquest/ARC/ClsArc004.cpp
@@ -1,0 +1,477 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+#include "Manager/TerritoryMgr.h"
+
+// Quest Script: ClsArc004_00070
+// Quest Name: To Catch a Poacher
+// Quest ID: 65606
+// Start NPC: 1000200
+// End NPC: 1000200
+
+using namespace Sapphire;
+
+class ClsArc004 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // BitFlag8
+    // UI8AL
+
+    /// Countable Num: 1 Seq: 1 Event: 1 Listener: 1000590
+    /// Countable Num: 3 Seq: 2 Event: 1 Listener: 2000947
+    /// Countable Num: 1 Seq: 3 Event: 1 Listener: 2000948
+    /// Countable Num: 0 Seq: 4 Event: 1 Listener: 2000949
+    /// Countable Num: 1 Seq: 5 Event: 1 Listener: 2001105
+    /// Countable Num: 1 Seq: 255 Event: 1 Listener: 2000136
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      Seq1 = 1,
+      Seq2 = 2,
+      Seq3 = 3,
+      Seq4 = 4,
+      Seq5 = 5,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1000200;
+    static constexpr auto Actor1 = 1000590;
+    static constexpr auto Actor2 = 1000731;
+    static constexpr auto Actor3 = 1000732;
+    static constexpr auto Actor4 = 1000199;
+    static constexpr auto Actor5 = 1000204;
+    static constexpr auto Eobject0 = 2000947;
+    static constexpr auto Eobject1 = 2000948;
+    static constexpr auto Eobject2 = 2000949;
+    static constexpr auto Eobject3 = 2001105;
+    static constexpr auto Eobject4 = 2000136;
+    static constexpr auto EventActionGatherMiddle = 7;
+    static constexpr auto EventActionSearch = 1;
+    static constexpr auto EventActionWaiting = 10;
+    static constexpr auto LocPosActor5 = 3875531;
+    static constexpr auto Questbattle0 = 5;
+    static constexpr auto Seq0Actor0Lq = 90;
+    static constexpr auto Territorytype0 = 229;
+
+  public:
+    ClsArc004() : Sapphire::ScriptAPI::QuestScript( 65606 ){}; 
+    ~ClsArc004() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        if (!player.hasQuest(getId()))
+          Scene00000(quest, player);
+        else if (quest.getSeq() == SeqFinish)
+          Scene00021(quest, player);
+
+        break;
+      }
+      case Actor1:
+      {
+        if (quest.getSeq() == Seq1)
+          Scene00002(quest, player);
+        else if (quest.getSeq() == Seq5) //Master claims we can't talk with this NPC
+          Scene00018(quest, player);
+
+        break;
+      }
+      case Actor2:
+      {
+        if (quest.getSeq() == Seq5)
+          Scene00020(quest, player);
+        break;
+      }
+      case Actor3:
+      {
+        if (quest.getSeq() == Seq5)
+          Scene00019(quest, player);
+        break;
+      }
+      case Actor4:
+      {
+        break;
+      }
+      case Actor5:
+      {
+        break;
+      }
+      case Eobject0:
+      {
+        eventMgr().eventActionStart(player, getId(), 0x07,
+          [&](Entity::Player& player, uint32_t eventId, uint64_t additional)
+          {
+            Scene00003(quest, player);
+          },
+          nullptr, 0);
+        break;
+      }
+      case Eobject1:
+      {
+        eventMgr().eventActionStart(player, getId(), 0x07,
+          [&](Entity::Player& player, uint32_t eventId, uint64_t additional)
+          {
+            Scene00004(quest, player);
+          },
+          nullptr, 0);
+        break;
+      }
+      case Eobject2:
+      {
+        eventMgr().eventActionStart(player, getId(), 0x07,
+          [&](Entity::Player& player, uint32_t eventId, uint64_t additional)
+          {
+            Scene00005(quest, player);
+          },
+          nullptr, 0);
+        break;
+      }
+      case Eobject3:
+      {
+        eventMgr().eventActionStart(player, getId(), 0x0A,
+          [&](Entity::Player& player, uint32_t eventId, uint64_t additional)
+          {
+            Scene00013(quest, player);
+            player.sendEventNotice(getId(), 2, 2, 0, 0);
+          },
+          nullptr, 0);
+        break;
+      }
+      case Eobject4:
+      {
+        eventMgr().eventActionStart(player, getId(), 0x01,
+          [&](Entity::Player& player, uint32_t eventId, uint64_t additional)
+          {
+            Scene00015(quest, player);
+          },
+          nullptr, 0);
+        break;
+      }
+    }
+  }
+
+
+  private:
+
+
+    void checkQuestCompletion(World::Quest& quest, Entity::Player& player)
+    {
+      auto currentCC = quest.getUI8AL();
+
+      player.sendEventNotice(getId(), 1, 2, currentCC + 1, 3);
+
+      if (currentCC + 1 >= 3)
+      {
+        quest.setSeq(Seq3);
+        quest.setUI8AL(0);
+      }
+      else
+      {
+        quest.setUI8AL(currentCC + 1);
+      }
+    }
+
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &ClsArc004::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      Scene00001(quest, player);
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, SET_EOBJ_BASE | HIDE_HOTBAR | INVIS_EOBJ, bindSceneReturn( &ClsArc004::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setSeq(Seq1);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00002( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 2, SET_EOBJ_BASE | HIDE_HOTBAR | INVIS_EOBJ, bindSceneReturn( &ClsArc004::Scene00002Return ) );
+  }
+
+  void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    player.sendEventNotice(getId(), 0, 2, 0, 0);
+    quest.setSeq(Seq2);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00003( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 3, HIDE_HOTBAR, bindSceneReturn( &ClsArc004::Scene00003Return ) );
+  }
+
+  void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setBitFlag8(1, true);
+    checkQuestCompletion(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00004( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 4, HIDE_HOTBAR, bindSceneReturn( &ClsArc004::Scene00004Return ) );
+  }
+
+  void Scene00004Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setBitFlag8(2, true);
+    checkQuestCompletion(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00005( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 5, HIDE_HOTBAR, bindSceneReturn( &ClsArc004::Scene00005Return ) );
+  }
+
+  void Scene00005Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setBitFlag8(3, true);
+    checkQuestCompletion(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00006( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 6, HIDE_HOTBAR, bindSceneReturn( &ClsArc004::Scene00006Return ) );
+  }
+
+  void Scene00006Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00007( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 7, HIDE_HOTBAR, bindSceneReturn( &ClsArc004::Scene00007Return ) );
+  }
+
+  void Scene00007Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00008( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 8, HIDE_HOTBAR, bindSceneReturn( &ClsArc004::Scene00008Return ) );
+  }
+
+  void Scene00008Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00009( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 9, HIDE_HOTBAR, bindSceneReturn( &ClsArc004::Scene00009Return ) );
+  }
+
+  void Scene00009Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00010( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 10, HIDE_HOTBAR, bindSceneReturn( &ClsArc004::Scene00010Return ) );
+  }
+
+  void Scene00010Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00011( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 11, HIDE_HOTBAR, bindSceneReturn( &ClsArc004::Scene00011Return ) );
+  }
+
+  void Scene00011Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00012( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 12, HIDE_HOTBAR, bindSceneReturn( &ClsArc004::Scene00012Return ) );
+  }
+
+  void Scene00012Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00013( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 13, SET_EOBJ_BASE | HIDE_HOTBAR | INVIS_EOBJ, bindSceneReturn( &ClsArc004::Scene00013Return ) );
+  }
+
+  void Scene00013Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setSeq(Seq4);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00014( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 14, HIDE_HOTBAR, bindSceneReturn( &ClsArc004::Scene00014Return ) );
+  }
+
+  void Scene00014Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00015( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 15, HIDE_HOTBAR, bindSceneReturn( &ClsArc004::Scene00015Return ) );
+  }
+
+  void Scene00015Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    Scene00016(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00016( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 16, HIDE_HOTBAR, bindSceneReturn( &ClsArc004::Scene00016Return ) );
+  }
+
+  void Scene00016Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if (result.getResult(0) == 1) {
+      quest.setSeq(Seq5);
+      auto& pTeriMgr = Common::Service< Sapphire::World::Manager::TerritoryMgr >::ref();
+
+      eventMgr().eventFinish(player, result.eventId, 0);
+      pTeriMgr.createAndJoinQuestBattle(player, Questbattle0);
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00017( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 17, HIDE_HOTBAR, bindSceneReturn( &ClsArc004::Scene00017Return ) );
+  }
+
+  void Scene00017Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00018( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 18, HIDE_HOTBAR, bindSceneReturn( &ClsArc004::Scene00018Return ) );
+  }
+
+  void Scene00018Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    player.sendEventNotice(getId(), 4, 2, 0, 0);
+    quest.setSeq(SeqFinish);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00019( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 19, HIDE_HOTBAR, bindSceneReturn( &ClsArc004::Scene00019Return ) );
+  }
+
+  void Scene00019Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00020( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 20, HIDE_HOTBAR, bindSceneReturn( &ClsArc004::Scene00020Return ) );
+  }
+
+  void Scene00020Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00021( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 21, HIDE_HOTBAR, bindSceneReturn( &ClsArc004::Scene00021Return ) );
+  }
+
+  void Scene00021Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      if( player.giveQuestRewards( getId(), result.getResult(1)) )
+        player.finishQuest( getId() );
+    }
+
+  }
+
+};
+
+EXPOSE_SCRIPT( ClsArc004 );

--- a/src/scripts/quest/classquest/ARC/ClsArc005.cpp
+++ b/src/scripts/quest/classquest/ARC/ClsArc005.cpp
@@ -1,0 +1,280 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+#include "Manager/TerritoryMgr.h"
+
+// Quest Script: ClsArc005_00071
+// Quest Name: Homecoming
+// Quest ID: 65607
+// Start NPC: 1000200
+// End NPC: 1000200
+
+using namespace Sapphire;
+
+class ClsArc005 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // BitFlag8
+    // UI8AL
+
+    /// Countable Num: 1 Seq: 1 Event: 1 Listener: 1000204
+    /// Countable Num: 1 Seq: 2 Event: 1 Listener: 1000199
+    /// Countable Num: 1 Seq: 3 Event: 1 Listener: 2000951
+    /// Countable Num: 1 Seq: 4 Event: 1 Listener: 1000534
+    /// Countable Num: 1 Seq: 255 Event: 1 Listener: 2001840
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      Seq1 = 1,
+      Seq2 = 2,
+      Seq3 = 3,
+      Seq4 = 4,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1000200;
+    static constexpr auto Actor1 = 1000204;
+    static constexpr auto Actor2 = 1000199;
+    static constexpr auto Actor3 = 1000534;
+    static constexpr auto Actor4 = 1001284;
+    static constexpr auto Actor5 = 1003025;
+    static constexpr auto Actor6 = 1003026;
+    static constexpr auto Eobject0 = 2000951;
+    static constexpr auto Eobject1 = 2001840;
+    static constexpr auto EventActionSearch = 1;
+    static constexpr auto EventActionWaiting = 10;
+    static constexpr auto LocActor5Action1 = 834;
+    static constexpr auto LocPosActor5 = 3877820;
+    static constexpr auto LocPosPc = 3877813;
+    static constexpr auto Questbattle0 = 4;
+    static constexpr auto Territorytype0 = 230;
+
+  public:
+    ClsArc005() : Sapphire::ScriptAPI::QuestScript( 65607 ){}; 
+    ~ClsArc005() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        if (!player.hasQuest(getId()))
+          Scene00000(quest, player);
+        else if (quest.getSeq() == SeqFinish)
+          Scene00010(quest, player);
+
+        break;
+      }
+      case Actor1:
+      {
+        if (quest.getSeq() == Seq1)
+          Scene00002(quest, player);
+        break;
+      }
+      case Actor2:
+      {
+        if (quest.getSeq() == Seq2)
+          Scene00003(quest, player);
+        break;
+      }
+      case Actor3:
+      {
+        if (quest.getSeq() == Seq4)
+          Scene00006(quest, player);
+        break;
+      }
+      case Actor4:
+      {
+        break;
+      }
+      case Actor5:
+      {
+        break;
+      }
+      case Actor6:
+      {
+        break;
+      }
+      case Eobject0:
+      {
+        eventMgr().eventActionStart(player, getId(), 0x0A,
+          [&](Entity::Player& player, uint32_t eventId, uint64_t additional)
+          {
+            Scene00004(quest, player);
+            player.sendEventNotice(getId(), 2, 2, 0, 0);
+          },
+          nullptr, 0);
+        break;
+      }
+    }
+  }
+
+
+  private:
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &ClsArc005::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      Scene00001(quest, player);
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, HIDE_HOTBAR, bindSceneReturn( &ClsArc005::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setSeq(Seq1);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00002( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 2, HIDE_HOTBAR, bindSceneReturn( &ClsArc005::Scene00002Return ) );
+  }
+
+  void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    player.sendEventNotice(getId(), 0, 2, 0, 0);
+    quest.setSeq(Seq2);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00003( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 3, HIDE_HOTBAR, bindSceneReturn( &ClsArc005::Scene00003Return ) );
+  }
+
+  void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    player.sendEventNotice(getId(), 1, 2, 0, 0);
+    quest.setSeq(Seq3);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00004( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 4, HIDE_HOTBAR, bindSceneReturn( &ClsArc005::Scene00004Return ) );
+  }
+
+  void Scene00004Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    Scene00005(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00005( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 5, SET_EOBJ_BASE | HIDE_HOTBAR | INVIS_EOBJ, bindSceneReturn( &ClsArc005::Scene00005Return ) );
+  }
+
+  void Scene00005Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setSeq(Seq4);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00006( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 6, HIDE_HOTBAR, bindSceneReturn( &ClsArc005::Scene00006Return ) );
+  }
+
+  void Scene00006Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    Scene00007(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00007( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 7, HIDE_HOTBAR, bindSceneReturn( &ClsArc005::Scene00007Return ) );
+  }
+
+  void Scene00007Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if (result.getResult(0) == 1) {
+      quest.setSeq(SeqFinish);
+      auto& pTeriMgr = Common::Service< Sapphire::World::Manager::TerritoryMgr >::ref();
+
+      eventMgr().eventFinish(player, result.eventId, 0);
+      pTeriMgr.createAndJoinQuestBattle(player, Questbattle0);
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00008( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 8, HIDE_HOTBAR, bindSceneReturn( &ClsArc005::Scene00008Return ) );
+  }
+
+  void Scene00008Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00009( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 9, HIDE_HOTBAR, bindSceneReturn( &ClsArc005::Scene00009Return ) );
+  }
+
+  void Scene00009Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00010( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 10, HIDE_HOTBAR, bindSceneReturn( &ClsArc005::Scene00010Return ) );
+  }
+
+  void Scene00010Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      if( player.giveQuestRewards( getId(), result.getResult(1)) )
+        player.finishQuest( getId() );
+    }
+
+  }
+
+};
+
+EXPOSE_SCRIPT( ClsArc005 );

--- a/src/scripts/quest/classquest/ARC/ClsArc006.cpp
+++ b/src/scripts/quest/classquest/ARC/ClsArc006.cpp
@@ -1,0 +1,391 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+#include "Manager/TerritoryMgr.h"
+
+// Quest Script: ClsArc006_00076
+// Quest Name: The One that Got Away
+// Quest ID: 65612
+// Start NPC: 1000200
+// End NPC: 1000200
+
+using namespace Sapphire;
+
+class ClsArc006 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // BitFlag8
+    // UI8AL
+
+    /// Countable Num: 1 Seq: 1 Event: 1 Listener: 1000795
+    /// Countable Num: 1 Seq: 2 Event: 1 Listener: 1000796
+    /// Countable Num: 1 Seq: 255 Event: 1 Listener: 1000797
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      Seq1 = 1,
+      Seq2 = 2,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1000200;
+    static constexpr auto Actor1 = 1000795;
+    static constexpr auto Actor2 = 1000796;
+    static constexpr auto Actor3 = 1000797;
+    static constexpr auto Actor4 = 1000798;
+    static constexpr auto Actor5 = 1000799;
+    static constexpr auto Actor6 = 1000800;
+    static constexpr auto Actor7 = 1003066;
+    static constexpr auto Actor8 = 1003067;
+    static constexpr auto Actor9 = 1003068;
+    static constexpr auto Eobject0 = 2001841;
+    static constexpr auto Eobject1 = 2000709;
+    static constexpr auto EventAction = 27;
+    static constexpr auto EventActionSearch = 1;
+    static constexpr auto EventMotZephyr = 366;
+    static constexpr auto LocAction0 = 995;
+    static constexpr auto LocActor0 = 1000199;
+    static constexpr auto LocActor1 = 1000204;
+    static constexpr auto LocVfx = 241;
+    static constexpr auto LocWs = 113;
+    static constexpr auto Questbattle0 = 2;
+    static constexpr auto Questbattle1 = 3;
+    static constexpr auto Seq0Actor0Lq = 98;
+    static constexpr auto Territorytype0 = 231;
+    static constexpr auto Territorytype1 = 236;
+
+  public:
+    ClsArc006() : Sapphire::ScriptAPI::QuestScript( 65612 ){}; 
+    ~ClsArc006() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        if (!player.hasQuest(getId()))
+          Scene00000(quest, player);
+        else if (quest.getSeq() == SeqFinish)
+          Scene00013(quest, player);
+
+        break;
+      }
+      case Actor1:
+      {
+        if (quest.getSeq() == Seq1)
+          Scene00002(quest, player);
+
+        break;
+      }
+      case Actor2:
+      {
+        break;
+      }
+      case Actor3:
+      {
+        break;
+      }
+      case Actor4:
+      {
+        break;
+      }
+      case Actor5:
+      {
+        break;
+      }
+      case Actor6:
+      {
+        break;
+      }
+      case Actor7:
+      {
+        if (quest.getSeq() == SeqFinish)
+          Scene00014(quest, player);
+
+        break;
+      }
+      case Actor8:
+      {
+        if (quest.getSeq() == SeqFinish)
+          Scene00015(quest, player);
+
+        break;
+      }
+      case Actor9:
+      {
+        if (quest.getSeq() == SeqFinish)
+          Scene00016(quest, player);
+
+        break;
+      }
+      case Eobject1:
+      {
+        eventMgr().eventActionStart(player, getId(), 0x1B,
+          [&](Entity::Player& player, uint32_t eventId, uint64_t additional)
+          {
+            Scene00011(quest, player);
+          },
+          nullptr, 0);
+
+        break;
+      }
+    }
+  }
+
+
+  private:
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &ClsArc006::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      Scene00001(quest, player);
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, SET_EOBJ_BASE | HIDE_HOTBAR | INVIS_EOBJ, bindSceneReturn( &ClsArc006::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setSeq(Seq1);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00002( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 2, HIDE_HOTBAR, bindSceneReturn( &ClsArc006::Scene00002Return ) );
+  }
+
+  void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if (result.getResult(0) == 1) {
+      quest.setSeq(Seq2);
+      auto& pTeriMgr = Common::Service< Sapphire::World::Manager::TerritoryMgr >::ref();
+
+      eventMgr().eventFinish(player, result.eventId, 0);
+      pTeriMgr.createAndJoinQuestBattle(player, Questbattle0);
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00003( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 3, HIDE_HOTBAR, bindSceneReturn( &ClsArc006::Scene00003Return ) );
+  }
+
+  void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00004( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 4, HIDE_HOTBAR, bindSceneReturn( &ClsArc006::Scene00004Return ) );
+  }
+
+  void Scene00004Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00005( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 5, HIDE_HOTBAR, bindSceneReturn( &ClsArc006::Scene00005Return ) );
+  }
+
+  void Scene00005Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00006( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 6, HIDE_HOTBAR, bindSceneReturn( &ClsArc006::Scene00006Return ) );
+  }
+
+  void Scene00006Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00007( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 7, HIDE_HOTBAR, bindSceneReturn( &ClsArc006::Scene00007Return ) );
+  }
+
+  void Scene00007Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00008( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 8, HIDE_HOTBAR, bindSceneReturn( &ClsArc006::Scene00008Return ) );
+  }
+
+  void Scene00008Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00009( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 9, HIDE_HOTBAR, bindSceneReturn( &ClsArc006::Scene00009Return ) );
+  }
+
+  void Scene00009Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00010( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 10, HIDE_HOTBAR, bindSceneReturn( &ClsArc006::Scene00010Return ) );
+  }
+
+  void Scene00010Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00011( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 11, HIDE_HOTBAR, bindSceneReturn( &ClsArc006::Scene00011Return ) );
+  }
+
+  void Scene00011Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if (result.getResult(0) == 1) {
+      quest.setSeq(SeqFinish);
+      auto& pTeriMgr = Common::Service< Sapphire::World::Manager::TerritoryMgr >::ref();
+
+      eventMgr().eventFinish(player, result.eventId, 0);
+      pTeriMgr.createAndJoinQuestBattle(player, Questbattle1);
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00012( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 12, HIDE_HOTBAR, bindSceneReturn( &ClsArc006::Scene00012Return ) );
+  }
+
+  void Scene00012Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00013( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 13, SET_EOBJ_BASE | HIDE_HOTBAR | INVIS_EOBJ, bindSceneReturn( &ClsArc006::Scene00013Return ) );
+  }
+
+  void Scene00013Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      if( player.giveQuestRewards( getId(), result.getResult(1)) )
+        player.finishQuest( getId() );
+    }
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00014( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 14, HIDE_HOTBAR, bindSceneReturn( &ClsArc006::Scene00014Return ) );
+  }
+
+  void Scene00014Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00015( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 15, HIDE_HOTBAR, bindSceneReturn( &ClsArc006::Scene00015Return ) );
+  }
+
+  void Scene00015Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00016( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 16, HIDE_HOTBAR, bindSceneReturn( &ClsArc006::Scene00016Return ) );
+  }
+
+  void Scene00016Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+};
+
+EXPOSE_SCRIPT( ClsArc006 );

--- a/src/scripts/quest/subquest/gridania/SubFst001.cpp
+++ b/src/scripts/quest/subquest/gridania/SubFst001.cpp
@@ -1,0 +1,140 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubFst001_00024
+// Quest Name: Coarse Correspondence
+// Quest ID: 65560
+// Start NPC: 1000206
+// End NPC: 1000233
+
+using namespace Sapphire;
+
+class SubFst001 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // UI8AL
+    // UI8BH
+
+    /// Countable Num: 1 Seq: 255 Event: 1 Listener: 1000233
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1000206;
+    static constexpr auto Actor1 = 1000233;
+    static constexpr auto Item0 = 2000079;
+    static constexpr auto Seq0Actor0 = 0;
+    static constexpr auto Seq1Actor1 = 1;
+    static constexpr auto Seq1Actor1Npctradeno = 99;
+    static constexpr auto Seq1Actor1Npctradeok = 100;
+
+  public:
+    SubFst001() : Sapphire::ScriptAPI::QuestScript( 65560 ){}; 
+    ~SubFst001() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        if (!player.hasQuest(getId()))
+          Scene00000( quest, player );
+        else
+          Scene00001( quest, player );
+      }
+      case Actor1:
+      {
+        if (!player.hasQuest(getId()))
+          Scene00099( quest, player );
+        else
+          Scene00100( quest, player );
+      }
+    }
+  }
+
+
+  private:
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, NONE, bindSceneReturn( &SubFst001::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      quest.setUI8AL(1);
+      quest.setUI8BH( 1);
+      quest.setSeq(SeqFinish);
+    }
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, NONE, bindSceneReturn( &SubFst001::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00099( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 99, NONE, bindSceneReturn( &SubFst001::Scene00099Return ) );
+  }
+
+  void Scene00099Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00100( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 100, NONE, bindSceneReturn( &SubFst001::Scene00100Return ) );
+  }
+
+  void Scene00100Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      if( player.giveQuestRewards( getId(), 0 ) )
+        player.finishQuest( getId() );
+    }
+
+  }
+
+};
+
+EXPOSE_SCRIPT( SubFst001 );

--- a/src/scripts/quest/subquest/gridania/SubFst003.cpp
+++ b/src/scripts/quest/subquest/gridania/SubFst003.cpp
@@ -1,0 +1,135 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubFst003_00026
+// Quest Name: Once Bitten, Twice Shy
+// Quest ID: 65562
+// Start NPC: 1000297
+// End NPC: 1000315
+
+using namespace Sapphire;
+
+class SubFst003 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // UI8AL
+    // UI8BH
+
+    /// Countable Num: 1 Seq: 255 Event: 1 Listener: 1000315
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1000297;
+    static constexpr auto Actor1 = 1000315;
+    static constexpr auto Item0 = 2000028;
+    static constexpr auto Seq0Actor0 = 0;
+    static constexpr auto Seq1Actor1 = 1;
+    static constexpr auto Seq1Actor1Npctradeno = 99;
+    static constexpr auto Seq1Actor1Npctradeok = 100;
+
+  public:
+    SubFst003() : Sapphire::ScriptAPI::QuestScript( 65562 ){}; 
+    ~SubFst003() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        Scene00000(quest, player);
+        break;
+      }
+      case Actor1:
+      {
+        Scene00001(quest, player);
+        break;
+      }
+    }
+  }
+
+
+  private:
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &SubFst003::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      quest.setSeq(SeqFinish);
+      quest.setUI8BH(1);
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, HIDE_HOTBAR, bindSceneReturn( &SubFst003::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if (result.getResult(0) == 1)
+      Scene00100(quest, player);
+    else
+      Scene00099(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00099( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 99, HIDE_HOTBAR, bindSceneReturn( &SubFst003::Scene00099Return ) );
+  }
+
+  void Scene00099Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    eventMgr().playScene(player, getId(), 99, 0, 0);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00100( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 100, HIDE_HOTBAR, bindSceneReturn( &SubFst003::Scene00100Return ) );
+  }
+
+  void Scene00100Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      if (player.giveQuestRewards(getId(), 0))
+        quest.setUI8BH(0);
+        player.finishQuest( getId() );
+    }
+
+  }
+
+};
+
+EXPOSE_SCRIPT( SubFst003 );

--- a/src/scripts/quest/subquest/gridania/SubFst004.cpp
+++ b/src/scripts/quest/subquest/gridania/SubFst004.cpp
@@ -1,0 +1,156 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubFst004_00027
+// Quest Name: Preserving the Past
+// Quest ID: 65563
+// Start NPC: 1000194
+// End NPC: 1000789
+
+using namespace Sapphire;
+
+class SubFst004 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // UI8AL
+    // UI8BH
+
+    /// Countable Num: 1 Seq: 1 Event: 1 Listener: 1000686
+    /// Countable Num: 1 Seq: 255 Event: 1 Listener: 1000789
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      Seq1 = 1,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1000194;
+    static constexpr auto Actor1 = 1000686;
+    static constexpr auto Actor2 = 1000789;
+    static constexpr auto Item0 = 2000024;
+    static constexpr auto Seq0Actor0 = 0;
+    static constexpr auto Seq1Actor1 = 1;
+    static constexpr auto Seq2Actor2 = 2;
+    static constexpr auto Seq2Actor2Npctradeno = 99;
+    static constexpr auto Seq2Actor2Npctradeok = 100;
+
+  public:
+    SubFst004() : Sapphire::ScriptAPI::QuestScript( 65563 ){}; 
+    ~SubFst004() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        Scene00000(quest, player);
+        break;
+      }
+      case Actor1:
+      {
+        Scene00001(quest, player);
+        break;
+      }
+      case Actor2:
+      {
+        Scene00002(quest, player);
+        break;
+      }
+    }
+  }
+
+
+  private:
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &SubFst004::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      quest.setSeq(Seq1);
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, HIDE_HOTBAR, bindSceneReturn( &SubFst004::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    player.sendEventNotice(getId(), 0, 2, 21002, 0);
+    quest.setUI8BH(1);
+    quest.setSeq(SeqFinish);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00002( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 2, HIDE_HOTBAR, bindSceneReturn( &SubFst004::Scene00002Return ) );
+  }
+
+  void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if (result.getResult(0) == 1)
+      Scene00100(quest, player);
+    else
+      Scene00099(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00099( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 99, HIDE_HOTBAR, bindSceneReturn( &SubFst004::Scene00099Return ) );
+  }
+
+  void Scene00099Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    eventMgr().playScene(player, getId(), 99, 0, 0);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00100( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 100, HIDE_HOTBAR, bindSceneReturn( &SubFst004::Scene00100Return ) );
+  }
+
+  void Scene00100Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      if( player.giveQuestRewards( getId(), 0 ) )
+        player.finishQuest( getId() );
+    }
+
+  }
+
+};
+
+EXPOSE_SCRIPT( SubFst004 );

--- a/src/scripts/quest/subquest/gridania/SubFst008.cpp
+++ b/src/scripts/quest/subquest/gridania/SubFst008.cpp
@@ -1,0 +1,156 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubFst008_00032
+// Quest Name: A Hard Nut to Crack
+// Quest ID: 65568
+// Start NPC: 1000372
+// End NPC: 1000629
+
+using namespace Sapphire;
+
+class SubFst008 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // UI8AL
+    // UI8BH
+
+    /// Countable Num: 1 Seq: 1 Event: 1 Listener: 1000311
+    /// Countable Num: 1 Seq: 255 Event: 1 Listener: 1000629
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      Seq1 = 1,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1000372;
+    static constexpr auto Actor1 = 1000311;
+    static constexpr auto Actor2 = 1000629;
+    static constexpr auto Item0 = 2000029;
+    static constexpr auto Seq0Actor0 = 0;
+    static constexpr auto Seq1Actor1 = 1;
+    static constexpr auto Seq2Actor2 = 2;
+    static constexpr auto Seq2Actor2Npctradeno = 99;
+    static constexpr auto Seq2Actor2Npctradeok = 100;
+
+  public:
+    SubFst008() : Sapphire::ScriptAPI::QuestScript( 65568 ){}; 
+    ~SubFst008() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        Scene00000(quest, player);
+        break;
+      }
+      case Actor1:
+      {
+        Scene00001(quest, player);
+        break;
+      }
+      case Actor2:
+      {
+        Scene00002(quest, player);
+        break;
+      }
+    }
+  }
+
+
+  private:
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, NONE, bindSceneReturn( &SubFst008::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      quest.setSeq(Seq1);
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, NONE, bindSceneReturn( &SubFst008::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setUI8BH(1);
+    player.sendEventNotice(getId(), 0, 0, 0, 0);
+    quest.setSeq(SeqFinish);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00002( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 2, NONE, bindSceneReturn( &SubFst008::Scene00002Return ) );
+  }
+
+  void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if (result.getResult(0) == 1)
+      Scene00100(quest, player);
+    else
+      Scene00099(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00099( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 99, NONE, bindSceneReturn( &SubFst008::Scene00099Return ) );
+  }
+
+  void Scene00099Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    eventMgr().playScene(player, getId(), 99, 0, 0);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00100( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 100, NONE, bindSceneReturn( &SubFst008::Scene00100Return ) );
+  }
+
+  void Scene00100Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      if( player.giveQuestRewards( getId(), result.getResult(1)) )
+        player.finishQuest( getId() );
+    }
+
+  }
+
+};
+
+EXPOSE_SCRIPT( SubFst008 );

--- a/src/scripts/quest/subquest/gridania/SubFst009.cpp
+++ b/src/scripts/quest/subquest/gridania/SubFst009.cpp
@@ -1,0 +1,134 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubFst009_00034
+// Quest Name: Derision of Labor
+// Quest ID: 65570
+// Start NPC: 1000370
+// End NPC: 1000408
+
+using namespace Sapphire;
+
+class SubFst009 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // UI8AL
+    // UI8BH
+
+    /// Countable Num: 1 Seq: 255 Event: 1 Listener: 1000408
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1000370;
+    static constexpr auto Actor1 = 1000408;
+    static constexpr auto Item0 = 2000080;
+    static constexpr auto Seq0Actor0 = 0;
+    static constexpr auto Seq1Actor1 = 1;
+    static constexpr auto Seq1Actor1Npctradeno = 99;
+    static constexpr auto Seq1Actor1Npctradeok = 100;
+
+  public:
+    SubFst009() : Sapphire::ScriptAPI::QuestScript( 65570 ){}; 
+    ~SubFst009() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        Scene00000(quest, player);
+        break;
+      }
+      case Actor1:
+      {
+        Scene00001(quest, player);
+        break;
+      }
+    }
+  }
+
+
+  private:
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &SubFst009::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      quest.setSeq(SeqFinish);
+      quest.setUI8BH(1);
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, HIDE_HOTBAR, bindSceneReturn( &SubFst009::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if (result.getResult(0) == 1)
+      Scene00100(quest, player);
+    else
+      Scene00099(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00099( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 99, HIDE_HOTBAR, bindSceneReturn( &SubFst009::Scene00099Return ) );
+  }
+
+  void Scene00099Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    eventMgr().playScene( player, getId(), 99, 0 );
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00100( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 100, HIDE_HOTBAR, bindSceneReturn( &SubFst009::Scene00100Return ) );
+  }
+
+  void Scene00100Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      if( player.giveQuestRewards( getId(), 0 ) )
+        player.finishQuest( getId() );
+    }
+
+  }
+
+};
+
+EXPOSE_SCRIPT( SubFst009 );

--- a/src/scripts/quest/subquest/gridania/SubFst010.cpp
+++ b/src/scripts/quest/subquest/gridania/SubFst010.cpp
@@ -1,0 +1,97 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubFst010_00001
+// Quest Name: A Good Adventurer Is Hard to Find
+// Quest ID: 65537
+// Start NPC: 1000146
+// End NPC: 1000195
+
+using namespace Sapphire;
+
+class SubFst010 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // UI8AL
+
+    /// Countable Num: 1 Seq: 255 Event: 1 Listener: 1000195
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1000146;
+    static constexpr auto Actor1 = 1000195;
+    static constexpr auto Seq0Actor0 = 0;
+    static constexpr auto Seq1Actor1 = 1;
+
+  public:
+    SubFst010() : Sapphire::ScriptAPI::QuestScript( 65537 ){}; 
+    ~SubFst010() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    if (actorId == Actor0)
+    {
+      Scene00000(quest, player);
+    }
+    else if (actorId == Actor1)
+    {
+      Scene00001(quest, player);
+    }
+  }
+
+
+  private:
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, NONE, bindSceneReturn( &SubFst010::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      quest.setSeq( SeqFinish );
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, NONE, bindSceneReturn( &SubFst010::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      if( player.giveQuestRewards( getId(), 0 ) )
+        player.finishQuest( getId() );
+    }
+
+  }
+
+};
+
+EXPOSE_SCRIPT( SubFst010 );

--- a/src/scripts/quest/subquest/gridania/SubFst013.cpp
+++ b/src/scripts/quest/subquest/gridania/SubFst013.cpp
@@ -1,0 +1,276 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubFst013_00040
+// Quest Name: For Friendship
+// Quest ID: 65576
+// Start NPC: 1000162
+// End NPC: 1000162
+
+using namespace Sapphire;
+
+class SubFst013 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // UI8AL
+
+    /// Countable Num: 1 Seq: 1 Event: 1 Listener: 1000161
+    /// Countable Num: 1 Seq: 2 Event: 2 Listener: 1000161
+    /// Countable Num: 1 Seq: 3 Event: 1 Listener: 1000162
+    /// Countable Num: 1 Seq: 4 Event: 1 Listener: 1000161
+    /// Countable Num: 1 Seq: 5 Event: 2 Listener: 1000161
+    /// Countable Num: 1 Seq: 255 Event: 1 Listener: 1000162
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      Seq1 = 1,
+      Seq2 = 2,
+      Seq3 = 3,
+      Seq4 = 4,
+      Seq5 = 5,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1000162;
+    static constexpr auto Actor1 = 1000161;
+    static constexpr auto FirstQuest = 65575;
+    static constexpr auto Seq0Actor0 = 0;
+    static constexpr auto Seq1Actor1 = 1;
+    static constexpr auto Seq1Actor1Emoteno = 99;
+    static constexpr auto Seq1Actor1Emoteok = 100;
+    static constexpr auto Seq2Actor0 = 2;
+    static constexpr auto Seq3Actor1 = 3;
+    static constexpr auto Seq3Actor1Emoteno = 97;
+    static constexpr auto Seq3Actor1Emoteok = 98;
+    static constexpr auto Seq4Actor0 = 4;
+    static constexpr auto Seq5Actor1 = 5;
+    static constexpr auto Seq5Actor1Emoteno = 95;
+    static constexpr auto Seq5Actor1Emoteok = 96;
+    static constexpr auto Seq6Actor0 = 6;
+
+  public:
+    SubFst013() : Sapphire::ScriptAPI::QuestScript( 65576 ){}; 
+    ~SubFst013() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        if (quest.getSeq() == Seq2)
+          Scene00002(quest, player);
+        else if (quest.getSeq() == Seq4)
+          Scene00004(quest, player);
+        else if (quest.getSeq() == SeqFinish)
+          Scene00006(quest, player);
+        break;
+      }
+      case Actor1: // talking to Aunillie while on quest
+      {
+        Scene00003(quest, player);
+        break;
+      }
+    }
+  }
+
+  void onEmote(World::Quest& quest, uint64_t actorId, uint32_t emoteId, Sapphire::Entity::Player& player) override
+  {
+    if (actorId != Actor1)
+      return;
+
+    if (emoteId == 5 && quest.getSeq() == Seq1)
+      Scene00100(quest, player);
+    else if (emoteId == 18 && quest.getSeq() == Seq3)
+      Scene00098(quest, player);
+    else if (emoteId == 11 && quest.getSeq() == Seq5)
+      Scene00096(quest, player);
+  }
+
+
+  private:
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, NONE, bindSceneReturn( &SubFst013::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      quest.setSeq(Seq1);
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, NONE, bindSceneReturn( &SubFst013::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty??
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00002( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 2, NONE, bindSceneReturn( &SubFst013::Scene00002Return ) );
+  }
+
+  void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setSeq(Seq3);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00003( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 3, NONE, bindSceneReturn( &SubFst013::Scene00003Return ) );
+  }
+
+  void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty??
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00004( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 4, NONE, bindSceneReturn( &SubFst013::Scene00004Return ) );
+  }
+
+  void Scene00004Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setSeq(Seq5);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00005( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 5, NONE, bindSceneReturn( &SubFst013::Scene00005Return ) );
+  }
+
+  void Scene00005Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty??
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00006( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 6, NONE, bindSceneReturn( &SubFst013::Scene00006Return ) );
+  }
+
+  void Scene00006Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      if( player.giveQuestRewards( getId(), 0 ) )
+        player.finishQuest( getId() );
+    }
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00095( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 95, NONE, bindSceneReturn( &SubFst013::Scene00095Return ) );
+  }
+
+  void Scene00095Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty??
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00096( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 96, NONE, bindSceneReturn( &SubFst013::Scene00096Return ) );
+  }
+
+  void Scene00096Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setSeq(SeqFinish);
+    player.sendEventNotice(getId(), 4, 2, 0, 0);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00097( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 97, NONE, bindSceneReturn( &SubFst013::Scene00097Return ) );
+  }
+
+  void Scene00097Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty??
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00098( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 98, NONE, bindSceneReturn( &SubFst013::Scene00098Return ) );
+  }
+
+  void Scene00098Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setSeq(Seq4);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00099( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 99, NONE, bindSceneReturn( &SubFst013::Scene00099Return ) );
+  }
+
+  void Scene00099Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty??
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00100( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 100, NONE, bindSceneReturn( &SubFst013::Scene00100Return ) );
+  }
+
+  void Scene00100Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setSeq(Seq2);
+    player.sendEventNotice(getId(), 0, 2, 0, 0);
+  }
+
+};
+
+EXPOSE_SCRIPT( SubFst013 );

--- a/src/scripts/quest/subquest/gridania/SubFst014.cpp
+++ b/src/scripts/quest/subquest/gridania/SubFst014.cpp
@@ -1,0 +1,432 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubFst014_00041
+// Quest Name: Covered in Roses
+// Quest ID: 65577
+// Start NPC: 1000300
+// End NPC: 1000300
+
+using namespace Sapphire;
+
+class SubFst014 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // BitFlag8
+    // UI8AL
+    // UI8BH
+
+    /// Countable Num: 6 Seq: 1 Event: 1 Listener: 2000026
+    /// Countable Num: 1 Seq: 255 Event: 1 Listener: 2000027
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      Seq1 = 1,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1000300;
+    static constexpr auto Eobject0 = 2000026;
+    static constexpr auto Eobject1 = 2000027;
+    static constexpr auto Eobject2 = 2000028;
+    static constexpr auto Eobject3 = 2000029;
+    static constexpr auto Eobject4 = 2000030;
+    static constexpr auto Eobject5 = 2000031;
+    static constexpr auto EventActionSearch = 1;
+    static constexpr auto Item0 = 2000084;
+
+  public:
+    SubFst014() : Sapphire::ScriptAPI::QuestScript( 65577 ){}; 
+    ~SubFst014() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        if (!player.hasQuest(getId()))
+          Scene00000(quest, player);
+        else if (quest.getSeq() == SeqFinish)
+          Scene00007(quest, player);
+        break;
+      }
+
+      case Eobject0:
+      {
+        eventMgr().eventActionStart(player, getId(), 0x01,
+          [&](Entity::Player& player, uint32_t eventId, uint64_t additional)
+          {
+            Scene00001(quest, player);
+          },
+          nullptr, 0);
+        break;
+      }
+      case Eobject1:
+      {
+        eventMgr().eventActionStart(player, getId(), 0x01,
+          [&](Entity::Player& player, uint32_t eventId, uint64_t additional)
+          {
+            Scene00002(quest, player);
+          },
+          nullptr, 0);
+        break;
+      }
+      case Eobject2:
+      {
+        eventMgr().eventActionStart(player, getId(), 0x01,
+          [&](Entity::Player& player, uint32_t eventId, uint64_t additional)
+          {
+            Scene00003(quest, player);
+          },
+          nullptr, 0);
+        break;
+      }
+      case Eobject3:
+      {
+        eventMgr().eventActionStart(player, getId(), 0x01,
+          [&](Entity::Player& player, uint32_t eventId, uint64_t additional)
+          {
+            Scene00004(quest, player);
+          },
+          nullptr, 0);
+        break;
+      }
+      case Eobject4:
+      {
+        eventMgr().eventActionStart(player, getId(), 0x01,
+          [&](Entity::Player& player, uint32_t eventId, uint64_t additional)
+          {
+            Scene00005(quest, player);
+          },
+          nullptr, 0);
+        break;
+      }
+      case Eobject5:
+      {
+        eventMgr().eventActionStart(player, getId(), 0x01,
+          [&](Entity::Player& player, uint32_t eventId, uint64_t additional)
+          {
+            Scene00006(quest, player);
+          },
+          nullptr, 0);
+        break;
+      }
+    }
+  }
+
+
+  private:
+
+    void checkQuestCompletion(World::Quest& quest, Entity::Player& player)
+    {
+      auto currentCC = quest.getUI8AL();
+
+      player.sendEventNotice(getId(), 0, 2, currentCC + 1, 6);
+      quest.setUI8AL(currentCC + 1);
+      quest.setUI8BH(currentCC + 1);
+
+      if (currentCC + 1 >= 6)
+      {
+        quest.setSeq(SeqFinish);
+      }
+    }
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &SubFst014::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      quest.setSeq(Seq1);
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, HIDE_HOTBAR, bindSceneReturn( &SubFst014::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    Scene00100(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00002( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 2, HIDE_HOTBAR, bindSceneReturn( &SubFst014::Scene00002Return ) );
+  }
+
+  void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    Scene00098(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00003( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 3, HIDE_HOTBAR, bindSceneReturn( &SubFst014::Scene00003Return ) );
+  }
+
+  void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    Scene00096(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00004( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 4, HIDE_HOTBAR, bindSceneReturn( &SubFst014::Scene00004Return ) );
+  }
+
+  void Scene00004Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    Scene00094(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00005( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 5, HIDE_HOTBAR, bindSceneReturn( &SubFst014::Scene00005Return ) );
+  }
+
+  void Scene00005Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    Scene00092(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00006( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 6, HIDE_HOTBAR, bindSceneReturn( &SubFst014::Scene00006Return ) );
+  }
+
+  void Scene00006Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    Scene00090(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00007( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 7, HIDE_HOTBAR, bindSceneReturn( &SubFst014::Scene00007Return ) );
+  }
+
+  void Scene00007Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if (result.getResult(0) == 1)
+      Scene00088(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00087( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 87, HIDE_HOTBAR, bindSceneReturn( &SubFst014::Scene00087Return ) );
+  }
+
+  void Scene00087Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00088( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 88, HIDE_HOTBAR, bindSceneReturn( &SubFst014::Scene00088Return ) );
+  }
+
+  void Scene00088Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      if( player.giveQuestRewards( getId(), 0 ) )
+        player.finishQuest( getId() );
+    }
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00089( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 89, HIDE_HOTBAR, bindSceneReturn( &SubFst014::Scene00089Return ) );
+  }
+
+  void Scene00089Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00090( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 90, HIDE_HOTBAR, bindSceneReturn( &SubFst014::Scene00090Return ) );
+  }
+
+  void Scene00090Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    checkQuestCompletion(quest, player);
+    quest.setBitFlag8(6, true);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00091( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 91, HIDE_HOTBAR, bindSceneReturn( &SubFst014::Scene00091Return ) );
+  }
+
+  void Scene00091Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00092( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 92, HIDE_HOTBAR, bindSceneReturn( &SubFst014::Scene00092Return ) );
+  }
+
+  void Scene00092Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    checkQuestCompletion(quest, player);
+    quest.setBitFlag8(5, true);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00093( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 93, HIDE_HOTBAR, bindSceneReturn( &SubFst014::Scene00093Return ) );
+  }
+
+  void Scene00093Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00094( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 94, HIDE_HOTBAR, bindSceneReturn( &SubFst014::Scene00094Return ) );
+  }
+
+  void Scene00094Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    checkQuestCompletion(quest, player);
+    quest.setBitFlag8(4, true);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00095( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 95, HIDE_HOTBAR, bindSceneReturn( &SubFst014::Scene00095Return ) );
+  }
+
+  void Scene00095Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00096( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 96, HIDE_HOTBAR, bindSceneReturn( &SubFst014::Scene00096Return ) );
+  }
+
+  void Scene00096Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    checkQuestCompletion(quest, player);
+    quest.setBitFlag8(3, true);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00097( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 97, HIDE_HOTBAR, bindSceneReturn( &SubFst014::Scene00097Return ) );
+  }
+
+  void Scene00097Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00098( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 98, HIDE_HOTBAR, bindSceneReturn( &SubFst014::Scene00098Return ) );
+  }
+
+  void Scene00098Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    checkQuestCompletion(quest, player);
+    quest.setBitFlag8(2, true);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00099( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 99, HIDE_HOTBAR, bindSceneReturn( &SubFst014::Scene00099Return ) );
+  }
+
+  void Scene00099Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00100( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 100, HIDE_HOTBAR, bindSceneReturn( &SubFst014::Scene00100Return ) );
+  }
+
+  void Scene00100Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    checkQuestCompletion(quest, player);
+    quest.setBitFlag8(1, true);
+  }
+
+};
+
+EXPOSE_SCRIPT( SubFst014 );

--- a/src/scripts/quest/subquest/gridania/SubFst015.cpp
+++ b/src/scripts/quest/subquest/gridania/SubFst015.cpp
@@ -1,0 +1,407 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubFst015_00042
+// Quest Name: Sylphic Gratitude
+// Quest ID: 65578
+// Start NPC: 1000286
+// End NPC: 1000286
+
+using namespace Sapphire;
+
+class SubFst015 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // BitFlag8
+    // UI8AL
+
+    /// Countable Num: 6 Seq: 1 Event: 1 Listener: 2000020
+    /// Countable Num: 1 Seq: 255 Event: 1 Listener: 2000021
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      Seq1 = 1,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1000286;
+    static constexpr auto Eobject0 = 2000020;
+    static constexpr auto Eobject1 = 2000021;
+    static constexpr auto Eobject2 = 2000022;
+    static constexpr auto Eobject3 = 2000023;
+    static constexpr auto Eobject4 = 2000024;
+    static constexpr auto Eobject5 = 2000025;
+    static constexpr auto EventActionSearch = 1;
+
+  public:
+    SubFst015() : Sapphire::ScriptAPI::QuestScript( 65578 ){}; 
+    ~SubFst015() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        if (!player.hasQuest(getId()))
+          Scene00000(quest, player);
+        else
+          Scene00007(quest, player);
+        break;
+      }
+
+      case Eobject0:
+      {
+        eventMgr().eventActionStart(player, getId(), 0x01,
+          [&](Entity::Player& player, uint32_t eventId, uint64_t additional)
+          {
+            Scene00001(quest, player);
+          },
+          nullptr, 0);
+        break;
+      }
+      case Eobject1:
+      {
+        eventMgr().eventActionStart(player, getId(), 0x01,
+          [&](Entity::Player& player, uint32_t eventId, uint64_t additional)
+          {
+            Scene00002(quest, player);
+          },
+          nullptr, 0);
+        break;
+      }
+      case Eobject2:
+      {
+        eventMgr().eventActionStart(player, getId(), 0x01,
+          [&](Entity::Player& player, uint32_t eventId, uint64_t additional)
+          {
+            Scene00003(quest, player);
+          },
+          nullptr, 0);
+        break;
+      }
+      case Eobject3:
+      {
+        eventMgr().eventActionStart(player, getId(), 0x01,
+          [&](Entity::Player& player, uint32_t eventId, uint64_t additional)
+          {
+            Scene00004(quest, player);
+          },
+          nullptr, 0);
+        break;
+      }
+      case Eobject4:
+      {
+        eventMgr().eventActionStart(player, getId(), 0x01,
+          [&](Entity::Player& player, uint32_t eventId, uint64_t additional)
+          {
+            Scene00005(quest, player);
+          },
+          nullptr, 0);
+        break;
+      }
+      case Eobject5:
+      {
+        eventMgr().eventActionStart(player, getId(), 0x01,
+          [&](Entity::Player& player, uint32_t eventId, uint64_t additional)
+          {
+            Scene00006(quest, player);
+          },
+          nullptr, 0);
+        break;
+      }
+    }
+  }
+
+
+  private:
+
+    void checkQuestCompletion(World::Quest& quest, Entity::Player& player)
+    {
+      auto currentCC = quest.getUI8AL();
+
+      player.sendEventNotice(getId(), 0, 2, currentCC + 1, 6);
+
+      if (currentCC + 1 >= 6)
+      {
+        quest.setSeq(SeqFinish);
+      }
+      else
+      {
+        quest.setUI8AL(currentCC + 1);
+      }
+    }
+
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &SubFst015::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      quest.setSeq(Seq1);
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, HIDE_HOTBAR, bindSceneReturn( &SubFst015::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    Scene00100(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00002( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 2, HIDE_HOTBAR, bindSceneReturn( &SubFst015::Scene00002Return ) );
+  }
+
+  void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    Scene00098(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00003( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 3, HIDE_HOTBAR, bindSceneReturn( &SubFst015::Scene00003Return ) );
+  }
+
+  void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    Scene00096(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00004( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 4, HIDE_HOTBAR, bindSceneReturn( &SubFst015::Scene00004Return ) );
+  }
+
+  void Scene00004Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    Scene00094(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00005( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 5, HIDE_HOTBAR, bindSceneReturn( &SubFst015::Scene00005Return ) );
+  }
+
+  void Scene00005Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    Scene00092(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00006( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 6, HIDE_HOTBAR, bindSceneReturn( &SubFst015::Scene00006Return ) );
+  }
+
+  void Scene00006Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    Scene00090(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00007( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 7, HIDE_HOTBAR, bindSceneReturn( &SubFst015::Scene00007Return ) );
+  }
+
+  void Scene00007Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      if( player.giveQuestRewards( getId(), 0 ) )
+        player.finishQuest( getId() );
+    }
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00089( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 89, HIDE_HOTBAR, bindSceneReturn( &SubFst015::Scene00089Return ) );
+  }
+
+  void Scene00089Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00090( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 90, HIDE_HOTBAR, bindSceneReturn( &SubFst015::Scene00090Return ) );
+  }
+
+  void Scene00090Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    checkQuestCompletion(quest, player);
+    quest.setBitFlag8(6, true);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00091( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 91, HIDE_HOTBAR, bindSceneReturn( &SubFst015::Scene00091Return ) );
+  }
+
+  void Scene00091Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00092( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 92, HIDE_HOTBAR, bindSceneReturn( &SubFst015::Scene00092Return ) );
+  }
+
+  void Scene00092Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    checkQuestCompletion(quest, player);
+    quest.setBitFlag8(5, true);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00093( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 93, HIDE_HOTBAR, bindSceneReturn( &SubFst015::Scene00093Return ) );
+  }
+
+  void Scene00093Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00094( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 94, HIDE_HOTBAR, bindSceneReturn( &SubFst015::Scene00094Return ) );
+  }
+
+  void Scene00094Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    checkQuestCompletion(quest, player);
+    quest.setBitFlag8(4, true);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00095( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 95, HIDE_HOTBAR, bindSceneReturn( &SubFst015::Scene00095Return ) );
+  }
+
+  void Scene00095Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00096( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 96, HIDE_HOTBAR, bindSceneReturn( &SubFst015::Scene00096Return ) );
+  }
+
+  void Scene00096Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    checkQuestCompletion(quest, player);
+    quest.setBitFlag8(3, true);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00097( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 97, HIDE_HOTBAR, bindSceneReturn( &SubFst015::Scene00097Return ) );
+  }
+
+  void Scene00097Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00098( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 98, HIDE_HOTBAR, bindSceneReturn( &SubFst015::Scene00098Return ) );
+  }
+
+  void Scene00098Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    checkQuestCompletion(quest, player);
+    quest.setBitFlag8(2, true);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00099( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 99, HIDE_HOTBAR, bindSceneReturn( &SubFst015::Scene00099Return ) );
+  }
+
+  void Scene00099Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00100( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 100, HIDE_HOTBAR, bindSceneReturn( &SubFst015::Scene00100Return ) );
+  }
+
+  void Scene00100Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    checkQuestCompletion(quest, player);
+    quest.setBitFlag8(1, true);
+  }
+
+};
+
+EXPOSE_SCRIPT( SubFst015 );

--- a/src/scripts/quest/subquest/gridania/SubFst019.cpp
+++ b/src/scripts/quest/subquest/gridania/SubFst019.cpp
@@ -1,0 +1,102 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubFst019_00049
+// Quest Name: I Am Millicent, Hear Me Roar
+// Quest ID: 65585
+// Start NPC: 1000788
+// End NPC: 1000429
+
+using namespace Sapphire;
+
+class SubFst019 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // UI8AL
+
+    /// Countable Num: 1 Seq: 255 Event: 1 Listener: 1000429
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1000788;
+    static constexpr auto Actor1 = 1000429;
+    static constexpr auto Seq0Actor0 = 0;
+    static constexpr auto Seq1Actor1 = 1;
+
+  public:
+    SubFst019() : Sapphire::ScriptAPI::QuestScript( 65585 ){}; 
+    ~SubFst019() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        Scene00000(quest, player);
+        break;
+      }
+      case Actor1:
+      {
+        Scene00001(quest, player);
+        break;
+      }
+    }
+  }
+
+
+  private:
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &SubFst019::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      quest.setSeq(SeqFinish);
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, HIDE_HOTBAR, bindSceneReturn( &SubFst019::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      if( player.giveQuestRewards( getId(), 0 ) )
+        player.finishQuest( getId() );
+    }
+
+  }
+
+};
+
+EXPOSE_SCRIPT( SubFst019 );

--- a/src/scripts/quest/subquest/gridania/SubFst029.cpp
+++ b/src/scripts/quest/subquest/gridania/SubFst029.cpp
@@ -1,0 +1,130 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubFst029_00172
+// Quest Name: More than a Flesh Wound
+// Quest ID: 65708
+// Start NPC: 1000430
+// End NPC: 1000430
+
+using namespace Sapphire;
+
+class SubFst029 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // UI8AH
+
+    /// Countable Num: 1 Seq: 255 Event: 1 Listener: 1000430
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1000430;
+    static constexpr auto Ritem0 = 4552;
+    static constexpr auto Seq0Actor0 = 0;
+    static constexpr auto Seq1Actor0 = 1;
+    static constexpr auto Seq1Actor0Npctradeno = 99;
+    static constexpr auto Seq1Actor0Npctradeok = 100;
+
+  public:
+    SubFst029() : Sapphire::ScriptAPI::QuestScript( 65708 ){}; 
+    ~SubFst029() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        if (!player.hasQuest(getId()))
+          Scene00000(quest, player);
+        else if (quest.getSeq() == SeqFinish)
+          Scene00001(quest, player);
+        break;
+      }
+    }
+  }
+
+
+  private:
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &SubFst029::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      quest.setSeq(SeqFinish);
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, HIDE_HOTBAR, bindSceneReturn( &SubFst029::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if (result.getResult(0) == 1 && player.collectHandInItems({ Ritem0 }))
+      Scene00100(quest, player);
+    else
+      Scene00099(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00099( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 99, HIDE_HOTBAR, bindSceneReturn( &SubFst029::Scene00099Return ) );
+  }
+
+  void Scene00099Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Needs a replacement
+    //player.playScene( getId(), 99, 0, 0, 0 );
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00100( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 100, HIDE_HOTBAR, bindSceneReturn( &SubFst029::Scene00100Return ) );
+  }
+
+  void Scene00100Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      if( player.giveQuestRewards( getId(), 0 ) )
+        player.finishQuest( getId() );
+    }
+
+  }
+
+};
+
+EXPOSE_SCRIPT( SubFst029 );

--- a/src/scripts/quest/subquest/gridania/SubFst030.cpp
+++ b/src/scripts/quest/subquest/gridania/SubFst030.cpp
@@ -1,0 +1,232 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubFst030_00173
+// Quest Name: The Nose Knows
+// Quest ID: 65709
+// Start NPC: 1000632
+// End NPC: 1000632
+
+using namespace Sapphire;
+
+class SubFst030 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // UI8AL
+    // UI8BH
+
+    /// Countable Num: 1 Seq: 1 Event: 1 Listener: 1000784
+    /// Countable Num: 1 Seq: 2 Event: 1 Listener: 2000146
+    /// Countable Num: 1 Seq: 3 Event: 1 Listener: 1000764
+    /// Countable Num: 1 Seq: 255 Event: 1 Listener: 1000632
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      Seq1 = 1,
+      Seq2 = 2,
+      Seq3 = 3,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1000632;
+    static constexpr auto Actor1 = 1000784;
+    static constexpr auto Actor2 = 1000764;
+    static constexpr auto Eobject0 = 2000146;
+    static constexpr auto EventActionGatherShort = 6;
+    static constexpr auto Item0 = 2000140;
+    static constexpr auto Seq0Actor0 = 0;
+    static constexpr auto Seq1Actor1 = 1;
+    static constexpr auto Seq2Eobject0 = 2;
+    static constexpr auto Seq2Eobject0Eventactionno = 99;
+    static constexpr auto Seq2Eobject0Eventactionok = 100;
+    static constexpr auto Seq3Actor2 = 3;
+    static constexpr auto Seq3Actor2Npctradeno = 97;
+    static constexpr auto Seq3Actor2Npctradeok = 98;
+    static constexpr auto Seq4Actor0 = 4;
+
+  public:
+    SubFst030() : Sapphire::ScriptAPI::QuestScript( 65709 ){}; 
+    ~SubFst030() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        if (!player.hasQuest(getId()))
+          Scene00000(quest, player);
+        else
+          Scene00004(quest, player);
+        break;
+      }
+      case Actor1:
+      {
+        Scene00001(quest, player);
+        break;
+      }
+      case Actor2:
+      {
+        Scene00003(quest, player);
+        break;
+      }
+      case Eobject0:
+      {
+        eventMgr().eventActionStart(player, getId(), 0x06,
+          [&](Entity::Player& player, uint32_t eventId, uint64_t additional)
+          {
+            Scene00002(quest, player);
+          },
+          nullptr, 0);
+        break;
+      }
+    }
+  }
+
+
+  private:
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &SubFst030::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      quest.setSeq(Seq1);
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, HIDE_HOTBAR, bindSceneReturn( &SubFst030::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setSeq(Seq2);
+    player.sendEventNotice(getId(), 0, 2, 0, 0);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00002( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 2, HIDE_HOTBAR, bindSceneReturn( &SubFst030::Scene00002Return ) );
+  }
+
+  void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    Scene00100(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00003( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 3, HIDE_HOTBAR, bindSceneReturn( &SubFst030::Scene00003Return ) );
+  }
+
+  void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if (result.getResult(0) == 1)
+      Scene00098(quest, player);
+    else
+      Scene00097(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00004( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 4, HIDE_HOTBAR, bindSceneReturn( &SubFst030::Scene00004Return ) );
+  }
+
+  void Scene00004Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      if( player.giveQuestRewards( getId(), 0 ) )
+        player.finishQuest( getId() );
+    }
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00097( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 97, HIDE_HOTBAR, bindSceneReturn( &SubFst030::Scene00097Return ) );
+  }
+
+  void Scene00097Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Needs replacement
+    //eventMgr().playScene(player, getId(), 97, 0, 0, 0);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00098( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 98, HIDE_HOTBAR, bindSceneReturn( &SubFst030::Scene00098Return ) );
+  }
+
+  void Scene00098Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setSeq(SeqFinish);
+    player.sendEventNotice(getId(), 2, 2, 0, 0);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00099( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 99, HIDE_HOTBAR, bindSceneReturn( &SubFst030::Scene00099Return ) );
+  }
+
+  void Scene00099Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Needs replacement
+    //eventMgr().playScene(player, getId(), 99, 0, 0, 0);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00100( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 100, HIDE_HOTBAR, bindSceneReturn( &SubFst030::Scene00100Return ) );
+  }
+
+  void Scene00100Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setSeq(Seq3);
+    player.sendEventNotice(getId(), 1, 2, 0, 0);
+    quest.setUI8FL(1);
+    quest.setUI8BH(1);
+  }
+
+};
+
+EXPOSE_SCRIPT( SubFst030 );

--- a/src/scripts/quest/subquest/gridania/SubFst043.cpp
+++ b/src/scripts/quest/subquest/gridania/SubFst043.cpp
@@ -1,0 +1,229 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubFst043_00199
+// Quest Name: A Clear Sign
+// Quest ID: 65735
+// Start NPC: 1000172
+// End NPC: 1000627
+
+using namespace Sapphire;
+
+class SubFst043 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // BitFlag8
+    // UI8AL
+
+    /// Countable Num: 2 Seq: 1 Event: 1 Listener: 2000143
+    /// Countable Num: 1 Seq: 255 Event: 1 Listener: 2000144
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      Seq1 = 1,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1000172;
+    static constexpr auto Actor1 = 1000627;
+    static constexpr auto Eobject0 = 2000143;
+    static constexpr auto Eobject1 = 2000144;
+    static constexpr auto EventActionProcessMiddle = 16;
+    static constexpr auto Seq0Actor0 = 0;
+    static constexpr auto Seq1Eobject0 = 1;
+    static constexpr auto Seq1Eobject0Eventactionno = 99;
+    static constexpr auto Seq1Eobject0Eventactionok = 100;
+    static constexpr auto Seq1Eobject1 = 2;
+    static constexpr auto Seq1Eobject1Eventactionno = 97;
+    static constexpr auto Seq1Eobject1Eventactionok = 98;
+    static constexpr auto Seq2Actor1 = 3;
+
+  public:
+    SubFst043() : Sapphire::ScriptAPI::QuestScript( 65735 ){}; 
+    ~SubFst043() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        Scene00000(quest, player);
+        break;
+      }
+      case Actor1:
+      {
+        if (quest.getSeq() == SeqFinish)
+          Scene00003(quest, player);
+        break;
+      }
+      case Eobject0:
+      {
+        eventMgr().eventActionStart(player, getId(), EventActionProcessMiddle,
+          [&](Entity::Player& player, uint32_t eventId, uint64_t additional)
+          {
+            Scene00001(quest, player);
+          },
+          nullptr, 0);
+        break;
+      }
+      case Eobject1:
+      {
+        eventMgr().eventActionStart(player, getId(), EventActionProcessMiddle,
+          [&](Entity::Player& player, uint32_t eventId, uint64_t additional)
+          {
+            Scene00002(quest, player);
+          },
+          nullptr, 0);
+        break;
+      }
+    }
+  }
+
+
+  private:
+    void checkQuestCompletion(World::Quest& quest, Entity::Player& player)
+    {
+      auto credit = quest.getUI8AL();
+
+      if (credit + 1 >= 2)
+      {
+        quest.setUI8AL(credit + 1);
+        player.sendEventNotice(getId(), 0, 2, credit + 1, 2);
+        quest.setSeq(SeqFinish);
+      }
+      else
+      {
+        quest.setUI8AL( credit + 1);
+        player.sendEventNotice(getId(), 0, 2, credit + 1, 2);
+      }
+    }
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &SubFst043::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      quest.setSeq(Seq1);
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, HIDE_HOTBAR, bindSceneReturn( &SubFst043::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    Scene00100(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00002( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 2, HIDE_HOTBAR, bindSceneReturn( &SubFst043::Scene00002Return ) );
+  }
+
+  void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    Scene00098(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00003( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 3, HIDE_HOTBAR, bindSceneReturn( &SubFst043::Scene00003Return ) );
+  }
+
+  void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      if( player.giveQuestRewards( getId(), 0 ) )
+      {
+        quest.setUI8BH(0);
+        player.finishQuest(getId());
+      }
+        
+    }
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00097( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 97, HIDE_HOTBAR, bindSceneReturn( &SubFst043::Scene00097Return ) );
+  }
+
+  void Scene00097Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00098( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 98, HIDE_HOTBAR, bindSceneReturn( &SubFst043::Scene00098Return ) );
+  }
+
+  void Scene00098Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    checkQuestCompletion(quest, player);
+    quest.setBitFlag8(2, true);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00099( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 99, HIDE_HOTBAR, bindSceneReturn( &SubFst043::Scene00099Return ) );
+  }
+
+  void Scene00099Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00100( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 100, HIDE_HOTBAR, bindSceneReturn( &SubFst043::Scene00100Return ) );
+  }
+
+  void Scene00100Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    checkQuestCompletion(quest, player);
+    quest.setBitFlag8(1, true);
+  }
+
+};
+
+EXPOSE_SCRIPT( SubFst043 );

--- a/src/scripts/quest/subquest/gridania/SubFst046.cpp
+++ b/src/scripts/quest/subquest/gridania/SubFst046.cpp
@@ -1,0 +1,180 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubFst046_00210
+// Quest Name: Idle Initiatives
+// Quest ID: 65746
+// Start NPC: 1000408
+// End NPC: 1000408
+
+using namespace Sapphire;
+
+class SubFst046 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // BitFlag8
+    // UI8AL
+
+    /// Countable Num: 3 Seq: 1 Event: 1 Listener: 1000792
+    /// Countable Num: 1 Seq: 255 Event: 1 Listener: 1000793
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      Seq1 = 1,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto ActionTimelineEventBaseIdle = 783;
+    static constexpr auto Actor0 = 1000408;
+    static constexpr auto Actor1 = 1000792;
+    static constexpr auto Actor2 = 1000793;
+    static constexpr auto Actor3 = 1000794;
+    static constexpr auto Seq0Actor0 = 0;
+    static constexpr auto Seq1Actor1 = 1;
+    static constexpr auto Seq1Actor2 = 2;
+    static constexpr auto Seq1Actor3 = 3;
+    static constexpr auto Seq2Actor0 = 4;
+
+  public:
+    SubFst046() : Sapphire::ScriptAPI::QuestScript( 65746 ){}; 
+    ~SubFst046() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        if (!player.hasQuest(getId()))
+          Scene00000(quest, player);
+        else if (quest.getSeq() == SeqFinish)
+          Scene00004(quest, player);
+        break;
+      }
+      case Actor1:
+      {
+        Scene00001(quest, player);
+        break;
+      }
+      case Actor2:
+      {
+        Scene00002(quest, player);
+        break;
+      }
+      case Actor3:
+      {
+        Scene00003(quest, player);
+        break;
+      }
+    }
+  }
+
+
+  private:
+
+    void checkQuestCompletion(World::Quest& quest, Entity::Player& player)
+    {
+      auto credit = quest.getUI8AL();
+
+      if (credit + 1 >= 3)
+      {
+        quest.setUI8AL(credit + 1);
+        player.sendEventNotice(getId(), 0, 0, credit + 1, 3);
+        quest.setSeq(SeqFinish);
+      }
+      else
+      {
+        quest.setUI8AL(credit + 1);
+        player.sendEventNotice(getId(), 0, 0, credit + 1, 3);
+      }
+    }
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &SubFst046::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      quest.setSeq(Seq1);
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, HIDE_HOTBAR, bindSceneReturn( &SubFst046::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    checkQuestCompletion(quest, player);
+    quest.setBitFlag8(1, true);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00002( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 2, HIDE_HOTBAR, bindSceneReturn( &SubFst046::Scene00002Return ) );
+  }
+
+  void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    checkQuestCompletion(quest, player);
+    quest.setBitFlag8(2, true);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00003( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 3, HIDE_HOTBAR, bindSceneReturn( &SubFst046::Scene00003Return ) );
+  }
+
+  void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    checkQuestCompletion(quest, player);
+    quest.setBitFlag8(3, true);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00004( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 4, HIDE_HOTBAR, bindSceneReturn( &SubFst046::Scene00004Return ) );
+  }
+
+  void Scene00004Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      if( player.giveQuestRewards( getId(), 0 ) )
+        player.finishQuest( getId() );
+    }
+
+  }
+
+};
+
+EXPOSE_SCRIPT( SubFst046 );

--- a/src/scripts/quest/subquest/gridania/SubFst048.cpp
+++ b/src/scripts/quest/subquest/gridania/SubFst048.cpp
@@ -1,0 +1,178 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubFst048_00375
+// Quest Name: Not a Material Girl
+// Quest ID: 65911
+// Start NPC: 1000742
+// End NPC: 1000742
+
+using namespace Sapphire;
+
+class SubFst048 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // BitFlag8
+    // UI8AL
+
+    /// Countable Num: 3 Seq: 1 Event: 1 Listener: 1000474
+    /// Countable Num: 1 Seq: 255 Event: 1 Listener: 1000476
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      Seq1 = 1,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1000742;
+    static constexpr auto Actor1 = 1000474;
+    static constexpr auto Actor2 = 1000476;
+    static constexpr auto Actor3 = 1000483;
+    static constexpr auto Seq0Actor0 = 0;
+    static constexpr auto Seq1Actor1 = 1;
+    static constexpr auto Seq1Actor2 = 2;
+    static constexpr auto Seq1Actor3 = 3;
+    static constexpr auto Seq2Actor0 = 4;
+
+  public:
+    SubFst048() : Sapphire::ScriptAPI::QuestScript( 65911 ){}; 
+    ~SubFst048() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        if (!player.hasQuest(getId()))
+          Scene00000(quest, player);
+        else if (quest.getSeq() == SeqFinish)
+          Scene00004(quest, player);
+        break;
+      }
+      case Actor1:
+      {
+        Scene00001(quest, player);
+        break;
+      }
+      case Actor2:
+      {
+        Scene00002(quest, player);
+        break;
+      }
+      case Actor3:
+      {
+        Scene00003(quest, player);
+        break;
+      }
+    }
+  }
+
+
+  private:
+    void checkQuestCompletion(World::Quest& quest, Entity::Player& player)
+    {
+      auto credit = quest.getUI8AL();
+
+      if (credit + 1 >= 3)
+      {
+        quest.setUI8AL(credit + 1);
+        player.sendEventNotice(getId(), 0, 2, credit + 1, 3);
+        quest.setSeq(SeqFinish);
+      }
+      else
+      {
+        quest.setUI8AL(credit + 1);
+        player.sendEventNotice(getId(), 0, 2, credit + 1, 3);
+      }
+    }
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &SubFst048::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      quest.setSeq(Seq1);
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, HIDE_HOTBAR, bindSceneReturn( &SubFst048::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    checkQuestCompletion(quest, player);
+    quest.setBitFlag8(1, true);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00002( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 2, HIDE_HOTBAR, bindSceneReturn( &SubFst048::Scene00002Return ) );
+  }
+
+  void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    checkQuestCompletion(quest, player);
+    quest.setBitFlag8(2, true);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00003( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 3, HIDE_HOTBAR, bindSceneReturn( &SubFst048::Scene00003Return ) );
+  }
+
+  void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    checkQuestCompletion(quest, player);
+    quest.setBitFlag8(3, true);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00004( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 4, HIDE_HOTBAR, bindSceneReturn( &SubFst048::Scene00004Return ) );
+  }
+
+  void Scene00004Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      if( player.giveQuestRewards( getId(), result.getResult(1)) )
+        player.finishQuest( getId() );
+    }
+
+  }
+
+};
+
+EXPOSE_SCRIPT( SubFst048 );

--- a/src/scripts/quest/subquest/limsa/SubSea001.cpp
+++ b/src/scripts/quest/subquest/limsa/SubSea001.cpp
@@ -1,0 +1,422 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubSea001_00111
+// Quest Name: Making a Name
+// Quest ID: 65647
+// Start NPC: 1002698
+// End NPC: 1003604
+
+using namespace Sapphire;
+
+class SubSea001 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // BitFlag8
+    // UI8AL
+    // UI8BH
+
+    /// Countable Num: 1 Seq: 1 Event: 1 Listener: 1000969
+    /// Countable Num: 0 Seq: 2 Event: 1 Listener: 2001563
+    /// Countable Num: 0 Seq: 255 Event: 1 Listener: 2001564
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      Seq1 = 1,
+      Seq2 = 2,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1002698;
+    static constexpr auto Actor1 = 1000969;
+    static constexpr auto Actor2 = 1003604;
+    static constexpr auto Eobject0 = 2001563;
+    static constexpr auto Eobject1 = 2001564;
+    static constexpr auto Eobject2 = 2001565;
+    static constexpr auto Eobject3 = 2001566;
+    static constexpr auto Eobject4 = 2001567;
+    static constexpr auto Eobject5 = 2001568;
+    static constexpr auto EventActionProcess = 14;
+    static constexpr auto Item0 = 2000447;
+    static constexpr auto Poprange0 = 4161445;
+    static constexpr auto Quest0 = 65644;
+    static constexpr auto Quest1 = 65645;
+    static constexpr auto Territorytype0 = 129;
+
+  public:
+    SubSea001() : Sapphire::ScriptAPI::QuestScript( 65647 ){}; 
+    ~SubSea001() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        Scene00000(quest, player);
+        break;
+      }
+      case Actor1:
+      {
+        Scene00002(quest, player);
+        break;
+      }
+      case Actor2:
+      {
+        Scene00016(quest, player);
+        break;
+      }
+      case Eobject0:
+      {
+        eventMgr().eventActionStart(player, getId(), 0x0E,
+          [&](Entity::Player& player, uint32_t eventId, uint64_t additional)
+          {
+            Scene00003(quest, player);
+          },
+          nullptr, 0);
+
+        break;
+      }
+      case Eobject1:
+      {
+        eventMgr().eventActionStart(player, getId(), 0x0E,
+          [&](Entity::Player& player, uint32_t eventId, uint64_t additional)
+          {
+            Scene00005(quest, player);
+          },
+          nullptr, 0);
+
+        break;
+      }
+      case Eobject2:
+      {
+        eventMgr().eventActionStart(player, getId(), 0x0E,
+          [&](Entity::Player& player, uint32_t eventId, uint64_t additional)
+          {
+            Scene00007(quest, player);
+          },
+          nullptr, 0);
+
+        break;
+      }
+      case Eobject3:
+      {
+        eventMgr().eventActionStart(player, getId(), 0x0E,
+          [&](Entity::Player& player, uint32_t eventId, uint64_t additional)
+          {
+            Scene00009(quest, player);
+          },
+          nullptr, 0);
+
+        break;
+      }
+      case Eobject4:
+      {
+        eventMgr().eventActionStart(player, getId(), 0x0E,
+          [&](Entity::Player& player, uint32_t eventId, uint64_t additional)
+          {
+            Scene00011(quest, player);
+          },
+          nullptr, 0);
+
+        break;
+      }
+      case Eobject5:
+      {
+        eventMgr().eventActionStart(player, getId(), 0x0E,
+          [&](Entity::Player& player, uint32_t eventId, uint64_t additional)
+          {
+            Scene00013(quest, player);
+          },
+          nullptr, 0);
+
+        break;
+      }
+    }
+  }
+
+
+  private:
+
+
+    void checkQuestCompletion(World::Quest& quest, Entity::Player& player)
+    {
+      auto currentCC = quest.getUI8BH();
+
+      player.sendEventNotice(getId(), 1, 3, currentCC + 1, 6);
+
+      if (currentCC + 1 >= 6)
+      {
+        quest.setSeq(SeqFinish);
+        quest.setUI8BH(currentCC + 1);
+        quest.setUI8AL(currentCC + 1);
+      }
+      else
+      {
+        quest.setUI8BH(currentCC + 1);
+        quest.setUI8AL(currentCC + 1);
+      }
+    }
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &SubSea001::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      quest.setSeq(Seq1);
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, HIDE_HOTBAR, bindSceneReturn( &SubSea001::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00002( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 2, HIDE_HOTBAR, bindSceneReturn( &SubSea001::Scene00002Return ) );
+  }
+
+  void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if (player.hasQuest(Quest0) || player.hasQuest(Quest1))
+    {
+      if (result.getResult(0) == 1)
+      {
+        quest.setSeq(Seq2);
+        player.changePosition(10, 21, 13, -2);
+        player.forceZoneing(Territorytype0); //Teleport to real Limsa
+      }
+    }
+    else
+    {
+      return;
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00003( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 3, HIDE_HOTBAR, bindSceneReturn( &SubSea001::Scene00003Return ) );
+  }
+
+  void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    Scene00004(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00004( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 4, HIDE_HOTBAR, bindSceneReturn( &SubSea001::Scene00004Return ) );
+  }
+
+  void Scene00004Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    checkQuestCompletion(quest, player);
+    quest.setBitFlag8(1, true);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00005( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 5, HIDE_HOTBAR, bindSceneReturn( &SubSea001::Scene00005Return ) );
+  }
+
+  void Scene00005Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    Scene00006(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00006( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 6, HIDE_HOTBAR, bindSceneReturn( &SubSea001::Scene00006Return ) );
+  }
+
+  void Scene00006Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    checkQuestCompletion(quest, player);
+    quest.setBitFlag8(2, true);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00007( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 7, HIDE_HOTBAR, bindSceneReturn( &SubSea001::Scene00007Return ) );
+  }
+
+  void Scene00007Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    Scene00008(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00008( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 8, HIDE_HOTBAR, bindSceneReturn( &SubSea001::Scene00008Return ) );
+  }
+
+  void Scene00008Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    checkQuestCompletion(quest, player);
+    quest.setBitFlag8(3, true);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00009( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 9, HIDE_HOTBAR, bindSceneReturn( &SubSea001::Scene00009Return ) );
+  }
+
+  void Scene00009Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    Scene00010(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00010( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 10, HIDE_HOTBAR, bindSceneReturn( &SubSea001::Scene00010Return ) );
+  }
+
+  void Scene00010Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    checkQuestCompletion(quest, player);
+    quest.setBitFlag8(4, true);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00011( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 11, HIDE_HOTBAR, bindSceneReturn( &SubSea001::Scene00011Return ) );
+  }
+
+  void Scene00011Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    Scene00012(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00012( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 12, HIDE_HOTBAR, bindSceneReturn( &SubSea001::Scene00012Return ) );
+  }
+
+  void Scene00012Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    checkQuestCompletion(quest, player);
+    quest.setBitFlag8(5, true);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00013( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 13, HIDE_HOTBAR, bindSceneReturn( &SubSea001::Scene00013Return ) );
+  }
+
+  void Scene00013Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    Scene00014(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00014( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 14, HIDE_HOTBAR, bindSceneReturn( &SubSea001::Scene00014Return ) );
+  }
+
+  void Scene00014Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    checkQuestCompletion(quest, player);
+    quest.setBitFlag8(6, true);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00015( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 15, HIDE_HOTBAR, bindSceneReturn( &SubSea001::Scene00015Return ) );
+  }
+
+  void Scene00015Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //What do I replace this with?
+    //player.playScene(player, getId(), 15, 0, 0, 0);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00016( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 16, HIDE_HOTBAR, bindSceneReturn( &SubSea001::Scene00016Return ) );
+  }
+
+  void Scene00016Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    Scene00017(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00017( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 17, HIDE_HOTBAR, bindSceneReturn( &SubSea001::Scene00017Return ) );
+  }
+
+  void Scene00017Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      if( player.giveQuestRewards( getId(), 0 ) )
+        player.finishQuest( getId() );
+    }
+
+  }
+
+};
+
+EXPOSE_SCRIPT( SubSea001 );

--- a/src/scripts/quest/subquest/uldah/SubWil000.cpp
+++ b/src/scripts/quest/subquest/uldah/SubWil000.cpp
@@ -1,0 +1,134 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubWil000_00149
+// Quest Name: Due Diligence
+// Quest ID: 65685
+// Start NPC: 1001285
+// End NPC: 1002278
+
+using namespace Sapphire;
+
+class SubWil000 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // UI8AL
+    // UI8BH
+
+    /// Countable Num: 1 Seq: 255 Event: 1 Listener: 1002278
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1001285;
+    static constexpr auto Actor1 = 1002278;
+    static constexpr auto Item0 = 2000136;
+
+  public:
+    SubWil000() : Sapphire::ScriptAPI::QuestScript( 65685 ){}; 
+    ~SubWil000() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        Scene00000(quest, player);
+        break;
+      }
+      case Actor1:
+      {
+        Scene00001(quest, player);
+        break;
+      }
+    }
+  }
+
+
+  private:
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &SubWil000::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      quest.setSeq(SeqFinish);
+      quest.setUI8BH(1);
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, HIDE_HOTBAR, bindSceneReturn( &SubWil000::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if (result.getResult(0) == 1)
+    {
+      Scene00100(quest, player);
+    }
+    else
+    {
+      Scene00099(quest, player);
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00099( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 99, HIDE_HOTBAR, bindSceneReturn( &SubWil000::Scene00099Return ) );
+  }
+
+  void Scene00099Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Emoty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00100( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 100, HIDE_HOTBAR, bindSceneReturn( &SubWil000::Scene00100Return ) );
+  }
+
+  void Scene00100Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      if( player.giveQuestRewards( getId(), 0 ) )
+        player.finishQuest( getId() );
+    }
+
+  }
+
+};
+
+EXPOSE_SCRIPT( SubWil000 );

--- a/src/scripts/quest/subquest/uldah/SubWil001.cpp
+++ b/src/scripts/quest/subquest/uldah/SubWil001.cpp
@@ -1,0 +1,104 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubWil001_00150
+// Quest Name: Motivational Speaking
+// Quest ID: 65686
+// Start NPC: 1001287
+// End NPC: 1001288
+
+using namespace Sapphire;
+
+class SubWil001 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // UI8AL
+
+    /// Countable Num: 1 Seq: 255 Event: 1 Listener: 1001288
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1001287;
+    static constexpr auto Actor1 = 1001288;
+    static constexpr auto Seq0Actor0 = 0;
+    static constexpr auto Seq1Actor1 = 1;
+
+  public:
+    SubWil001() : Sapphire::ScriptAPI::QuestScript( 65686 ){}; 
+    ~SubWil001() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        Scene00000(quest, player);
+        break;
+      }
+      case Actor1:
+      {
+        Scene00001(quest, player);
+        break;
+      }
+    }
+  }
+
+
+  private:
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &SubWil001::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      quest.setSeq(SeqFinish);
+    }
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, HIDE_HOTBAR, bindSceneReturn( &SubWil001::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      if( player.giveQuestRewards( getId(), 0 ) )
+        player.finishQuest( getId() );
+    }
+
+  }
+
+};
+
+EXPOSE_SCRIPT( SubWil001 );

--- a/src/scripts/quest/subquest/uldah/SubWil002.cpp
+++ b/src/scripts/quest/subquest/uldah/SubWil002.cpp
@@ -1,0 +1,138 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubWil002_00151
+// Quest Name: Gil for Gold
+// Quest ID: 65687
+// Start NPC: 1001288
+// End NPC: 1001289
+
+using namespace Sapphire;
+
+class SubWil002 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // UI8AL
+    // UI8BH
+
+    /// Countable Num: 1 Seq: 255 Event: 1 Listener: 1001289
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1001288;
+    static constexpr auto Actor1 = 1001289;
+    static constexpr auto Item0 = 2000245;
+    static constexpr auto Seq0Actor0 = 0;
+    static constexpr auto Seq1Actor1 = 1;
+    static constexpr auto Seq1Actor1Npctradeno = 99;
+    static constexpr auto Seq1Actor1Npctradeok = 100;
+
+  public:
+    SubWil002() : Sapphire::ScriptAPI::QuestScript( 65687 ){}; 
+    ~SubWil002() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        Scene00000(quest, player);
+        break;
+      }
+      case Actor1:
+      {
+        Scene00001(quest, player);
+        break;
+      }
+    }
+  }
+
+
+  private:
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &SubWil002::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      quest.setSeq(SeqFinish);
+      quest.setUI8BH(1);
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, HIDE_HOTBAR, bindSceneReturn( &SubWil002::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if (result.getResult(0) == 1)
+    {
+      Scene00100(quest, player);
+    }
+    else
+    {
+      Scene00099(quest, player);
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00099( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 99, HIDE_HOTBAR, bindSceneReturn( &SubWil002::Scene00099Return ) );
+  }
+
+  void Scene00099Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00100( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 100, HIDE_HOTBAR, bindSceneReturn( &SubWil002::Scene00100Return ) );
+  }
+
+  void Scene00100Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      if( player.giveQuestRewards( getId(), 0 ) )
+        player.finishQuest( getId() );
+    }
+
+  }
+
+};
+
+EXPOSE_SCRIPT( SubWil002 );

--- a/src/scripts/quest/subquest/uldah/SubWil004.cpp
+++ b/src/scripts/quest/subquest/uldah/SubWil004.cpp
@@ -1,0 +1,333 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubWil004_00153
+// Quest Name: Unholy Matrimony
+// Quest ID: 65689
+// Start NPC: 1001291
+// End NPC: 1003896
+
+using namespace Sapphire;
+
+class SubWil004 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // BitFlag8
+    // UI8AH
+    // UI8AL
+    // UI8BH
+
+    /// Countable Num: 1 Seq: 1 Event: 1 Listener: 1001292
+    /// Countable Num: 2 Seq: 2 Event: 1 Listener: 2000691
+    /// Countable Num: 1 Seq: 255 Event: 8 Listener: 2000691
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      Seq1 = 1,
+      Seq2 = 2,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1001291;
+    static constexpr auto Actor1 = 1001292;
+    static constexpr auto Actor2 = 1003896;
+    static constexpr auto Eobject0 = 2000691;
+    static constexpr auto Eobject1 = 2000692;
+    static constexpr auto Eobject2 = 2000693;
+    static constexpr auto EventActionSearch = 1;
+    static constexpr auto Item0 = 2000137;
+
+  public:
+    SubWil004() : Sapphire::ScriptAPI::QuestScript( 65689 ){}; 
+    ~SubWil004() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        Scene00000(quest, player);
+        break;
+      }
+      case Actor1:
+      {
+        Scene00001(quest, player);
+        break;
+      }
+      case Actor2:
+      {
+        Scene00008(quest, player);
+        break;
+      }
+      case Eobject0:
+      {
+        eventMgr().eventActionStart(player, getId(), 0x01,
+          [&](Entity::Player& player, uint32_t eventId, uint64_t additional)
+          {
+            Scene00003(quest, player);
+          },
+          nullptr, 0);
+        break;
+      }
+      case Eobject1:
+      {
+        eventMgr().eventActionStart(player, getId(), 0x01,
+          [&](Entity::Player& player, uint32_t eventId, uint64_t additional)
+          {
+            Scene00005(quest, player);
+          },
+          nullptr, 0);
+        break;
+      }
+      case Eobject2:
+      {
+        eventMgr().eventActionStart(player, getId(), 0x01,
+          [&](Entity::Player& player, uint32_t eventId, uint64_t additional)
+          {
+            Scene00007(quest, player);
+          },
+          nullptr, 0);
+        break;
+      }
+    }
+  }
+
+
+  private:
+
+
+    void checkQuestCompletion(World::Quest& quest, Entity::Player& player)
+    {
+      auto currentCC = quest.getUI8AL();
+      auto currentQC = quest.getUI8BH();
+
+      player.sendEventNotice(getId(), 1, 3, currentCC + 1, 3);
+
+      if (currentCC + 1 >= 3)
+      {
+        quest.setSeq(SeqFinish);
+        quest.setUI8AH(currentCC + 1);
+        quest.setUI8AL(currentCC + 1);
+        quest.setUI8BH(0);
+      }
+      else
+      {
+        quest.setUI8AH(currentCC + 1);
+        quest.setUI8AL(currentCC + 1);
+        quest.setUI8BH(currentQC - 1);
+      }
+    }
+
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &SubWil004::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      quest.setSeq(Seq1);
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, HIDE_HOTBAR, bindSceneReturn( &SubWil004::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setSeq(Seq2);
+    player.sendEventNotice(getId(), 0, 2, 0, 0);
+    quest.setUI8BH(3);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00002( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 2, HIDE_HOTBAR, bindSceneReturn( &SubWil004::Scene00002Return ) );
+  }
+
+  void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    Scene00003(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00003( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 3, HIDE_HOTBAR, bindSceneReturn( &SubWil004::Scene00003Return ) );
+  }
+
+  void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    checkQuestCompletion(quest, player);
+    quest.setBitFlag8(1, true);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00004( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 4, HIDE_HOTBAR, bindSceneReturn( &SubWil004::Scene00004Return ) );
+  }
+
+  void Scene00004Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    Scene00005(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00005( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 5, HIDE_HOTBAR, bindSceneReturn( &SubWil004::Scene00005Return ) );
+  }
+
+  void Scene00005Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    checkQuestCompletion(quest, player);
+    quest.setBitFlag8(2, true);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00006( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 6, HIDE_HOTBAR, bindSceneReturn( &SubWil004::Scene00006Return ) );
+  }
+
+  void Scene00006Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    Scene00007(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00007( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 7, HIDE_HOTBAR, bindSceneReturn( &SubWil004::Scene00007Return ) );
+  }
+
+  void Scene00007Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    checkQuestCompletion(quest, player);
+    quest.setBitFlag8(3, true);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00008( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 8, HIDE_HOTBAR, bindSceneReturn( &SubWil004::Scene00008Return ) );
+  }
+
+  void Scene00008Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      if( player.giveQuestRewards( getId(), 0 ) )
+        player.finishQuest( getId() );
+    }
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00009( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 9, HIDE_HOTBAR, bindSceneReturn( &SubWil004::Scene00009Return ) );
+  }
+
+  void Scene00009Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00010( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 10, HIDE_HOTBAR, bindSceneReturn( &SubWil004::Scene00010Return ) );
+  }
+
+  void Scene00010Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00011( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 11, HIDE_HOTBAR, bindSceneReturn( &SubWil004::Scene00011Return ) );
+  }
+
+  void Scene00011Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00012( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 12, HIDE_HOTBAR, bindSceneReturn( &SubWil004::Scene00012Return ) );
+  }
+
+  void Scene00012Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00013( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 13, HIDE_HOTBAR, bindSceneReturn( &SubWil004::Scene00013Return ) );
+  }
+
+  void Scene00013Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00014( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 14, HIDE_HOTBAR, bindSceneReturn( &SubWil004::Scene00014Return ) );
+  }
+
+  void Scene00014Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+};
+
+EXPOSE_SCRIPT( SubWil004 );

--- a/src/scripts/quest/subquest/uldah/SubWil006.cpp
+++ b/src/scripts/quest/subquest/uldah/SubWil006.cpp
@@ -1,0 +1,151 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubWil006_00165
+// Quest Name: The Great Gladiator
+// Quest ID: 65701
+// Start NPC: 1001295
+// End NPC: 1001299
+
+using namespace Sapphire;
+
+class SubWil006 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // UI8AL
+    // UI8BH
+
+    /// Countable Num: 1 Seq: 1 Event: 1 Listener: 1002280
+    /// Countable Num: 1 Seq: 255 Event: 1 Listener: 1001299
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      Seq1 = 1,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1001295;
+    static constexpr auto Actor1 = 1002280;
+    static constexpr auto Actor2 = 1001299;
+    static constexpr auto Item0 = 2000201;
+
+  public:
+    SubWil006() : Sapphire::ScriptAPI::QuestScript( 65701 ){}; 
+    ~SubWil006() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        Scene00000(quest, player);
+        break;
+      }
+      case Actor1:
+      {
+        Scene00001(quest, player);
+        break;
+      }
+      case Actor2:
+      {
+        Scene00004(quest, player);
+        break;
+      }
+    }
+  }
+
+
+  private:
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &SubWil006::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      quest.setSeq(Seq1);
+      quest.setUI8BH(1);
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, HIDE_HOTBAR, bindSceneReturn( &SubWil006::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if (result.getResult(0) == 1)
+      Scene00002(quest, player);
+    else
+      Scene00003(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00002( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 2, HIDE_HOTBAR, bindSceneReturn( &SubWil006::Scene00002Return ) );
+  }
+
+  void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setSeq(SeqFinish);
+    player.sendEventNotice(getId(), 0, 2, 0, 0);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00003( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 3, HIDE_HOTBAR, bindSceneReturn( &SubWil006::Scene00003Return ) );
+  }
+
+  void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00004( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 4, HIDE_HOTBAR, bindSceneReturn( &SubWil006::Scene00004Return ) );
+  }
+
+  void Scene00004Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      if( player.giveQuestRewards( getId(), 0 ) )
+        player.finishQuest( getId() );
+    }
+
+  }
+
+};
+
+EXPOSE_SCRIPT( SubWil006 );

--- a/src/scripts/quest/subquest/uldah/SubWil007.cpp
+++ b/src/scripts/quest/subquest/uldah/SubWil007.cpp
@@ -1,0 +1,415 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubWil007_00167
+// Quest Name: With Open Arms
+// Quest ID: 65703
+// Start NPC: 1007621
+// End NPC: 1007621
+
+using namespace Sapphire;
+
+class SubWil007 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // BitFlag8
+    // UI8AL
+
+    /// Countable Num: 1 Seq: 1 Event: 1 Listener: 1007621
+    /// Countable Num: 5 Seq: 2 Event: 2 Listener: 1007621
+    /// Countable Num: 1 Seq: 255 Event: 1 Listener: 1001297
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      Seq1 = 1,
+      Seq2 = 2,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1007621;
+    static constexpr auto Actor1 = 1001297;
+    static constexpr auto Actor2 = 1001692;
+    static constexpr auto Actor3 = 1001693;
+    static constexpr auto Actor4 = 1001697;
+    static constexpr auto Actor5 = 1001698;
+    static constexpr auto FirstQuest = 66130;
+
+  public:
+    SubWil007() : Sapphire::ScriptAPI::QuestScript( 65703 ){}; 
+    ~SubWil007() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        if (!player.hasQuest(getId()))
+          Scene00000(quest, player);
+        else if (quest.getSeq() == SeqFinish)
+          Scene00020(quest, player);
+        break;
+      }
+      case Actor1:
+      {
+        Scene00005(quest, player);
+        break;
+      }
+      case Actor2:
+      {
+        Scene00008(quest, player);
+        break;
+      }
+      case Actor3:
+      {
+        Scene00011(quest, player);
+        break;
+      }
+      case Actor4:
+      {
+        Scene00014(quest, player);
+        break;
+      }
+      case Actor5:
+      {
+        Scene00017(quest, player);
+        break;
+      }
+    }
+  }
+
+  void onEmote(World::Quest& quest, uint64_t actorId, uint32_t emoteId, Entity::Player& player) override
+  {
+    if (emoteId != 41)
+      return;
+
+    if (actorId == Actor0 && quest.getSeq() == Seq1)
+    {
+      Scene00003(quest, player);
+    }
+    else if (actorId == Actor1 && quest.getSeq() == Seq2)
+    {
+      Scene00006(quest, player);
+    }
+    else if (actorId == Actor2 && quest.getSeq() == Seq2)
+    {
+      Scene00009(quest, player);
+    }
+    else if (actorId == Actor3 && quest.getSeq() == Seq2)
+    {
+      Scene00012(quest, player);
+    }
+    else if (actorId == Actor4 && quest.getSeq() == Seq2)
+    {
+      Scene00015(quest, player);
+    }
+    else if (actorId == Actor5 && quest.getSeq() == Seq2)
+    {
+      Scene00018(quest, player);
+    }
+  }
+
+
+  private:
+
+
+    void checkQuestCompletion(World::Quest& quest, Entity::Player& player)
+    {
+      auto currentQC = quest.getUI8AL() + 1;
+
+      if (currentQC >= 5)
+      {
+        quest.setSeq(SeqFinish);
+        player.sendEventNotice(getId(), 1, 2, currentQC, 5);
+      }
+      else
+      {
+        quest.setUI8AL(currentQC);
+        player.sendEventNotice(getId(), 1, 2, currentQC, 5);
+      }
+    }
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &SubWil007::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      Scene00001(quest, player);
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, HIDE_HOTBAR, bindSceneReturn( &SubWil007::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setSeq(Seq1);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00002( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 2, HIDE_HOTBAR, bindSceneReturn( &SubWil007::Scene00002Return ) );
+  }
+
+  void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00003( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 3, HIDE_HOTBAR, bindSceneReturn( &SubWil007::Scene00003Return ) );
+  }
+
+  void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setSeq(Seq2);
+    player.sendEventNotice(getId(), 0, 1, 0, 0);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00004( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 4, HIDE_HOTBAR, bindSceneReturn( &SubWil007::Scene00004Return ) );
+  }
+
+  void Scene00004Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00005( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 5, HIDE_HOTBAR, bindSceneReturn( &SubWil007::Scene00005Return ) );
+  }
+
+  void Scene00005Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00006( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 6, HIDE_HOTBAR, bindSceneReturn( &SubWil007::Scene00006Return ) );
+  }
+
+  void Scene00006Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    checkQuestCompletion(quest, player);
+    quest.setBitFlag8(1, true);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00007( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 7, HIDE_HOTBAR, bindSceneReturn( &SubWil007::Scene00007Return ) );
+  }
+
+  void Scene00007Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00008( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 8, HIDE_HOTBAR, bindSceneReturn( &SubWil007::Scene00008Return ) );
+  }
+
+  void Scene00008Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00009( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 9, HIDE_HOTBAR, bindSceneReturn( &SubWil007::Scene00009Return ) );
+  }
+
+  void Scene00009Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    checkQuestCompletion(quest, player);
+    quest.setBitFlag8(2, true);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00010( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 10, HIDE_HOTBAR, bindSceneReturn( &SubWil007::Scene00010Return ) );
+  }
+
+  void Scene00010Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00011( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 11, HIDE_HOTBAR, bindSceneReturn( &SubWil007::Scene00011Return ) );
+  }
+
+  void Scene00011Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00012( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 12, HIDE_HOTBAR, bindSceneReturn( &SubWil007::Scene00012Return ) );
+  }
+
+  void Scene00012Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    checkQuestCompletion(quest, player);
+    quest.setBitFlag8(3, true);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00013( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 13, HIDE_HOTBAR, bindSceneReturn( &SubWil007::Scene00013Return ) );
+  }
+
+  void Scene00013Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00014( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 14, HIDE_HOTBAR, bindSceneReturn( &SubWil007::Scene00014Return ) );
+  }
+
+  void Scene00014Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00015( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 15, HIDE_HOTBAR, bindSceneReturn( &SubWil007::Scene00015Return ) );
+  }
+
+  void Scene00015Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    checkQuestCompletion(quest, player);
+    quest.setBitFlag8(4, true);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00016( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 16, HIDE_HOTBAR, bindSceneReturn( &SubWil007::Scene00016Return ) );
+  }
+
+  void Scene00016Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00017( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 17, HIDE_HOTBAR, bindSceneReturn( &SubWil007::Scene00017Return ) );
+  }
+
+  void Scene00017Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00018( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 18, HIDE_HOTBAR, bindSceneReturn( &SubWil007::Scene00018Return ) );
+  }
+
+  void Scene00018Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    checkQuestCompletion(quest, player);
+    quest.setBitFlag8(5, true);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00019( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 19, HIDE_HOTBAR, bindSceneReturn( &SubWil007::Scene00019Return ) );
+  }
+
+  void Scene00019Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00020( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 20, HIDE_HOTBAR, bindSceneReturn( &SubWil007::Scene00020Return ) );
+  }
+
+  void Scene00020Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      if( player.giveQuestRewards( getId(), 0 ) )
+        player.finishQuest( getId() );
+    }
+
+  }
+
+};
+
+EXPOSE_SCRIPT( SubWil007 );

--- a/src/scripts/quest/subquest/uldah/SubWil018.cpp
+++ b/src/scripts/quest/subquest/uldah/SubWil018.cpp
@@ -1,0 +1,364 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubWil018_00396
+// Quest Name: No Lady Is an Island
+// Quest ID: 65932
+// Start NPC: 1001675
+// End NPC: 1001675
+
+using namespace Sapphire;
+
+class SubWil018 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // BitFlag8
+    // UI8AL
+    // UI8BH
+
+    /// Countable Num: 5 Seq: 1 Event: 1 Listener: 2000695
+    /// Countable Num: 1 Seq: 255 Event: 1 Listener: 2000696
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      Seq1 = 1,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1001675;
+    static constexpr auto Eobject0 = 2000695;
+    static constexpr auto Eobject1 = 2000696;
+    static constexpr auto Eobject2 = 2000697;
+    static constexpr auto Eobject3 = 2001089;
+    static constexpr auto Eobject4 = 2001090;
+    static constexpr auto EventActionSearch = 1;
+    static constexpr auto Item0 = 2000198;
+
+  public:
+    SubWil018() : Sapphire::ScriptAPI::QuestScript( 65932 ){}; 
+    ~SubWil018() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        if (!player.hasQuest(getId()))
+          Scene00000(quest, player);
+        else
+          Scene00016(quest, player);
+        break;
+      }
+      case Eobject0:
+      {
+        Scene00001(quest, player);
+        break;
+      }
+      case Eobject1:
+      {
+        Scene00004(quest, player);
+        break;
+      }
+      case Eobject2:
+      {
+        Scene00007(quest, player);
+        break;
+      }
+      case Eobject3:
+      {
+        Scene00010(quest, player);
+        break;
+      }
+      case Eobject4:
+      {
+        Scene00013(quest, player);
+        break;
+      }
+    }
+  }
+
+
+  private:
+
+    void checkQuestCompletion(World::Quest& quest, Entity::Player& player)
+    {
+      auto currentCC = quest.getUI8AL();
+
+      player.sendEventNotice(getId(), 0, 3, currentCC + 1, 5);
+
+      if (currentCC + 1 >= 5)
+      {
+        quest.setSeq(SeqFinish);
+        quest.setUI8BH(currentCC + 1);
+        quest.setUI8AL(currentCC + 1);
+      }
+      else
+      {
+        quest.setUI8BH(currentCC + 1);
+        quest.setUI8AL(currentCC + 1);
+      }
+    }
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, NONE, bindSceneReturn( &SubWil018::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      quest.setSeq(Seq1);
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, HIDE_HOTBAR, bindSceneReturn( &SubWil018::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    Scene00002(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00002( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 2, HIDE_HOTBAR, bindSceneReturn( &SubWil018::Scene00002Return ) );
+  }
+
+  void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    checkQuestCompletion(quest, player);
+    quest.setBitFlag8(1, true);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00003( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 3, HIDE_HOTBAR, bindSceneReturn( &SubWil018::Scene00003Return ) );
+  }
+
+  void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00004( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 4, HIDE_HOTBAR, bindSceneReturn( &SubWil018::Scene00004Return ) );
+  }
+
+  void Scene00004Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    Scene00005(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00005( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 5, HIDE_HOTBAR, bindSceneReturn( &SubWil018::Scene00005Return ) );
+  }
+
+  void Scene00005Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    checkQuestCompletion(quest, player);
+    quest.setBitFlag8(2, true);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00006( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 6, HIDE_HOTBAR, bindSceneReturn( &SubWil018::Scene00006Return ) );
+  }
+
+  void Scene00006Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00007( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 7, HIDE_HOTBAR, bindSceneReturn( &SubWil018::Scene00007Return ) );
+  }
+
+  void Scene00007Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    Scene00008(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00008( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 8, HIDE_HOTBAR, bindSceneReturn( &SubWil018::Scene00008Return ) );
+  }
+
+  void Scene00008Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    checkQuestCompletion(quest, player);
+    quest.setBitFlag8(3, true);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00009( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 9, HIDE_HOTBAR, bindSceneReturn( &SubWil018::Scene00009Return ) );
+  }
+
+  void Scene00009Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00010( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 10, HIDE_HOTBAR, bindSceneReturn( &SubWil018::Scene00010Return ) );
+  }
+
+  void Scene00010Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    Scene00011(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00011( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 11, HIDE_HOTBAR, bindSceneReturn( &SubWil018::Scene00011Return ) );
+  }
+
+  void Scene00011Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    checkQuestCompletion(quest, player);
+    quest.setBitFlag8(4, true);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00012( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 12, HIDE_HOTBAR, bindSceneReturn( &SubWil018::Scene00012Return ) );
+  }
+
+  void Scene00012Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00013( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 13, HIDE_HOTBAR, bindSceneReturn( &SubWil018::Scene00013Return ) );
+  }
+
+  void Scene00013Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    Scene00014(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00014( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 14, HIDE_HOTBAR, bindSceneReturn( &SubWil018::Scene00014Return ) );
+  }
+
+  void Scene00014Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    checkQuestCompletion(quest, player);
+    quest.setBitFlag8(5, true);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00015( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 15, HIDE_HOTBAR, bindSceneReturn( &SubWil018::Scene00015Return ) );
+  }
+
+  void Scene00015Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00016( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 16, HIDE_HOTBAR, bindSceneReturn( &SubWil018::Scene00016Return ) );
+  }
+
+  void Scene00016Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if (result.getResult(0) == 1)
+      Scene00017(quest, player);
+    else
+      Scene00018(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00017( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 17, HIDE_HOTBAR, bindSceneReturn( &SubWil018::Scene00017Return ) );
+  }
+
+  void Scene00017Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      if( player.giveQuestRewards( getId(), 0 ) )
+        player.finishQuest( getId() );
+    }
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00018( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 18, HIDE_HOTBAR, bindSceneReturn( &SubWil018::Scene00018Return ) );
+  }
+
+  void Scene00018Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+};
+
+EXPOSE_SCRIPT( SubWil018 );

--- a/src/scripts/quest/subquest/uldah/SubWil019.cpp
+++ b/src/scripts/quest/subquest/uldah/SubWil019.cpp
@@ -1,0 +1,100 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubWil019_00392
+// Quest Name: Decisions, Decisions
+// Quest ID: 65928
+// Start NPC: 1001680
+// End NPC: 1001691
+
+using namespace Sapphire;
+
+class SubWil019 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // UI8AL
+
+    /// Countable Num: 1 Seq: 255 Event: 1 Listener: 1001691
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1001680;
+    static constexpr auto Actor1 = 1001691;
+
+  public:
+    SubWil019() : Sapphire::ScriptAPI::QuestScript( 65928 ){}; 
+    ~SubWil019() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        Scene00000(quest, player);
+        break;
+      }
+      case Actor1:
+      {
+        Scene00001(quest, player);
+        break;
+      }
+    }
+  }
+
+
+  private:
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &SubWil019::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      quest.setSeq(SeqFinish);
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, HIDE_HOTBAR, bindSceneReturn( &SubWil019::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      if( player.giveQuestRewards( getId(), 0 ) )
+        player.finishQuest( getId() );
+    }
+
+  }
+
+};
+
+EXPOSE_SCRIPT( SubWil019 );

--- a/src/scripts/quest/subquest/uldah/SubWil020.cpp
+++ b/src/scripts/quest/subquest/uldah/SubWil020.cpp
@@ -1,0 +1,531 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubWil020_00393
+// Quest Name: Vox Populi
+// Quest ID: 65929
+// Start NPC: 1001685
+// End NPC: 1001945
+
+using namespace Sapphire;
+
+class SubWil020 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // BitFlag8
+    // UI8AH
+    // UI8AL
+    // UI8BH
+
+    /// Countable Num: 8 Seq: 1 Event: 1 Listener: 1001940
+    /// Countable Num: 1 Seq: 1 Event: 1 Listener: 1001937
+    /// Countable Num: 0 Seq: 255 Event: 1 Listener: 1001939
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      Seq1 = 1,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1001685;
+    static constexpr auto Actor1 = 1001940;
+    static constexpr auto Actor2 = 1001937;
+    static constexpr auto Actor3 = 1001939;
+    static constexpr auto Actor4 = 1001942;
+    static constexpr auto Actor5 = 1001949;
+    static constexpr auto Actor6 = 1003902;
+    static constexpr auto Actor7 = 1001914;
+    static constexpr auto Actor8 = 1003899;
+    static constexpr auto Actor9 = 1001945;
+
+  public:
+    SubWil020() : Sapphire::ScriptAPI::QuestScript( 65929 ){}; 
+    ~SubWil020() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    //Some of these feel wrong
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        Scene00000(quest, player);
+        break;
+      }
+      case Actor1:
+      {
+        if (!quest.getBitFlag8(1))
+          Scene00001(quest, player);
+        else
+          Scene00002(quest, player);
+        break;
+      }
+      case Actor2:
+      {
+        if (!quest.getBitFlag8(2))
+          Scene00003(quest, player);
+        else
+          Scene00004(quest, player);
+        break;
+      }
+      case Actor3:
+      {
+        if (!quest.getBitFlag8(3))
+          Scene00005(quest, player);
+        else
+          Scene00006(quest, player);
+        break;
+      }
+      case Actor4:
+      {
+        if (!quest.getBitFlag8(4))
+          Scene00007(quest, player);
+        else
+          Scene00008(quest, player);
+        break;
+      }
+      case Actor5:
+      {
+        if (!quest.getBitFlag8(5))
+          Scene00009(quest, player);
+        else
+          Scene00010(quest, player);
+        break;
+      }
+      case Actor6:
+      {
+        if (!quest.getBitFlag8(6))
+          Scene00011(quest, player);
+        else
+          Scene00012(quest, player);
+        break;
+      }
+      case Actor7:
+      {
+        if (!quest.getBitFlag8(7))
+          Scene00013(quest, player);
+        else
+          Scene00014(quest, player);
+        break;
+      }
+      case Actor8:
+      {
+        if (!quest.getBitFlag8(0))
+          Scene00015(quest, player);
+        else
+          Scene00016(quest, player);
+        break;
+      }
+      case Actor9:
+      {
+        Scene00017(quest, player);
+        break;
+      }
+    }
+  }
+
+
+  private:
+
+    void checkQuestProgression(World::Quest& quest, Entity::Player& player)
+    {
+      if (quest.getUI8AL() == 6 && quest.getUI8BH() == 2)
+      {
+        quest.setSeq(SeqFinish);
+      }
+    }
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, NONE, bindSceneReturn( &SubWil020::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      quest.setSeq(Seq1);
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, NONE, bindSceneReturn( &SubWil020::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    auto hustCount = quest.getUI8AL();
+    hustCount += 1;
+    quest.setUI8AL(hustCount);
+    player.sendEventNotice(getId(), 0, 2, hustCount, 6);
+    quest.setBitFlag8(1, true);
+    checkQuestProgression(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00002( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 2, NONE, bindSceneReturn( &SubWil020::Scene00002Return ) );
+  }
+
+  void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    auto hustCount = quest.getUI8AL();
+    hustCount += 1;
+    quest.setUI8AL(hustCount);
+    player.sendEventNotice(getId(), 0, 2, hustCount, 6);
+    quest.setBitFlag8(2, true);
+    checkQuestProgression(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00003( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 3, NONE, bindSceneReturn( &SubWil020::Scene00003Return ) );
+  }
+
+  void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    auto hustCount = quest.getUI8AL();
+    hustCount += 1;
+    quest.setUI8AL(hustCount);
+    player.sendEventNotice(getId(), 0, 2, hustCount, 6);
+    quest.setBitFlag8(3, true);
+    checkQuestProgression(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00004( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 4, NONE, bindSceneReturn( &SubWil020::Scene00004Return ) );
+  }
+
+  void Scene00004Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    auto hustCount = quest.getUI8AL();
+    hustCount += 1;
+    quest.setUI8AL(hustCount);
+    player.sendEventNotice(getId(), 0, 2, hustCount, 6);
+    quest.setBitFlag8(4, true);
+    checkQuestProgression(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00005( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 5, NONE, bindSceneReturn( &SubWil020::Scene00005Return ) );
+  }
+
+  void Scene00005Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    auto hustCount = quest.getUI8AL();
+    hustCount += 1;
+    quest.setUI8AL(hustCount);
+    player.sendEventNotice(getId(), 0, 2, hustCount, 6);
+    quest.setBitFlag8(5, true);
+    checkQuestProgression(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00006( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 6, NONE, bindSceneReturn( &SubWil020::Scene00006Return ) );
+  }
+
+  void Scene00006Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    auto hustCount = quest.getUI8AL();
+    hustCount += 1;
+    quest.setUI8AL(hustCount);
+    player.sendEventNotice(getId(), 0, 2, hustCount, 6);
+    quest.setBitFlag8(6, true);
+    checkQuestProgression(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00007( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 7, NONE, bindSceneReturn( &SubWil020::Scene00007Return ) );
+  }
+
+  void Scene00007Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    auto hustCount = quest.getUI8AL();
+    hustCount += 1;
+    quest.setUI8AL(hustCount);
+    player.sendEventNotice(getId(), 0, 2, hustCount, 6);
+    quest.setBitFlag8(7, true);
+    checkQuestProgression(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00008( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 8, NONE, bindSceneReturn( &SubWil020::Scene00008Return ) );
+  }
+
+  void Scene00008Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    auto hustCount = quest.getUI8AL();
+    hustCount += 1;
+    quest.setUI8AL(hustCount);
+    player.sendEventNotice(getId(), 0, 2, hustCount, 6);
+    quest.setBitFlag8(8, true);
+    checkQuestProgression(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00009( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 9, NONE, bindSceneReturn( &SubWil020::Scene00009Return ) );
+  }
+
+  void Scene00009Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00010( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 10, NONE, bindSceneReturn( &SubWil020::Scene00010Return ) );
+  }
+
+  void Scene00010Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00011( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 11, NONE, bindSceneReturn( &SubWil020::Scene00011Return ) );
+  }
+
+  void Scene00011Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00012( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 12, NONE, bindSceneReturn( &SubWil020::Scene00012Return ) );
+  }
+
+  void Scene00012Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00013( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 13, NONE, bindSceneReturn( &SubWil020::Scene00013Return ) );
+  }
+
+  void Scene00013Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00014( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 14, NONE, bindSceneReturn( &SubWil020::Scene00014Return ) );
+  }
+
+  void Scene00014Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00015( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 15, NONE, bindSceneReturn( &SubWil020::Scene00015Return ) );
+  }
+
+  void Scene00015Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00016( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 16, NONE, bindSceneReturn( &SubWil020::Scene00016Return ) );
+  }
+
+  void Scene00016Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00017( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 17, NONE, bindSceneReturn( &SubWil020::Scene00017Return ) );
+  }
+
+  void Scene00017Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      if( player.giveQuestRewards( getId(), 0 ) )
+        player.finishQuest( getId() );
+    }
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00018( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 18, NONE, bindSceneReturn( &SubWil020::Scene00018Return ) );
+  }
+
+  void Scene00018Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00019( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 19, NONE, bindSceneReturn( &SubWil020::Scene00019Return ) );
+  }
+
+  void Scene00019Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00020( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 20, NONE, bindSceneReturn( &SubWil020::Scene00020Return ) );
+  }
+
+  void Scene00020Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00021( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 21, NONE, bindSceneReturn( &SubWil020::Scene00021Return ) );
+  }
+
+  void Scene00021Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00022( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 22, NONE, bindSceneReturn( &SubWil020::Scene00022Return ) );
+  }
+
+  void Scene00022Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00023( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 23, NONE, bindSceneReturn( &SubWil020::Scene00023Return ) );
+  }
+
+  void Scene00023Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00024( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 24, NONE, bindSceneReturn( &SubWil020::Scene00024Return ) );
+  }
+
+  void Scene00024Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00025( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 25, NONE, bindSceneReturn( &SubWil020::Scene00025Return ) );
+  }
+
+  void Scene00025Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+};
+
+EXPOSE_SCRIPT( SubWil020 );

--- a/src/scripts/quest/subquest/uldah/SubWil021.cpp
+++ b/src/scripts/quest/subquest/uldah/SubWil021.cpp
@@ -1,0 +1,134 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubWil021_00394
+// Quest Name: A Luxury Long Lost
+// Quest ID: 65930
+// Start NPC: 1001766
+// End NPC: 1001657
+
+using namespace Sapphire;
+
+class SubWil021 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // UI8AL
+    // UI8BH
+
+    /// Countable Num: 1 Seq: 255 Event: 1 Listener: 1001657
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1001766;
+    static constexpr auto Actor1 = 1001657;
+    static constexpr auto Item0 = 2000196;
+    static constexpr auto Seq0Actor0 = 0;
+    static constexpr auto Seq1Actor1 = 1;
+    static constexpr auto Seq1Actor1Npctradeno = 99;
+    static constexpr auto Seq1Actor1Npctradeok = 100;
+
+  public:
+    SubWil021() : Sapphire::ScriptAPI::QuestScript( 65930 ){}; 
+    ~SubWil021() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        Scene00000(quest, player);
+        break;
+      }
+      case Actor1:
+      {
+        Scene00001(quest, player);
+        break;
+      }
+    }
+  }
+
+
+  private:
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &SubWil021::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      quest.setSeq(SeqFinish);
+      quest.setUI8BH(1);
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, HIDE_HOTBAR, bindSceneReturn( &SubWil021::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if (result.getResult(0) == 1)
+      Scene00100(quest, player);
+    else
+      Scene00099(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00099( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 99, HIDE_HOTBAR, bindSceneReturn( &SubWil021::Scene00099Return ) );
+  }
+
+  void Scene00099Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00100( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 100, HIDE_HOTBAR, bindSceneReturn( &SubWil021::Scene00100Return ) );
+  }
+
+  void Scene00100Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      if( player.giveQuestRewards( getId(), 0 ) )
+        player.finishQuest( getId() );
+    }
+
+  }
+
+};
+
+EXPOSE_SCRIPT( SubWil021 );

--- a/src/scripts/quest/subquest/uldah/SubWil022.cpp
+++ b/src/scripts/quest/subquest/uldah/SubWil022.cpp
@@ -1,0 +1,134 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubWil022_00395
+// Quest Name: The Wealth of Nations
+// Quest ID: 65931
+// Start NPC: 1001657
+// End NPC: 1001679
+
+using namespace Sapphire;
+
+class SubWil022 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // UI8AL
+    // UI8BH
+
+    /// Countable Num: 1 Seq: 255 Event: 1 Listener: 1001679
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1001657;
+    static constexpr auto Actor1 = 1001679;
+    static constexpr auto Item0 = 2000197;
+    static constexpr auto Seq0Actor0 = 0;
+    static constexpr auto Seq1Actor1 = 1;
+    static constexpr auto Seq1Actor1Npctradeno = 99;
+    static constexpr auto Seq1Actor1Npctradeok = 100;
+
+  public:
+    SubWil022() : Sapphire::ScriptAPI::QuestScript( 65931 ){}; 
+    ~SubWil022() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        Scene00000(quest, player);
+        break;
+      }
+      case Actor1:
+      {
+        Scene00001(quest, player);
+        break;
+      }
+    }
+  }
+
+
+  private:
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &SubWil022::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      quest.setSeq(SeqFinish);
+      quest.setUI8BH(1);
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, HIDE_HOTBAR, bindSceneReturn( &SubWil022::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if (result.getResult(0) == 1)
+      Scene00100(quest, player);
+    else
+      Scene00099(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00099( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 99, HIDE_HOTBAR, bindSceneReturn( &SubWil022::Scene00099Return ) );
+  }
+
+  void Scene00099Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00100( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 100, HIDE_HOTBAR, bindSceneReturn( &SubWil022::Scene00100Return ) );
+  }
+
+  void Scene00100Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      if( player.giveQuestRewards( getId(), 0 ) )
+        player.finishQuest( getId() );
+    }
+
+  }
+
+};
+
+EXPOSE_SCRIPT( SubWil022 );

--- a/src/scripts/quest/subquest/uldah/SubWil027.cpp
+++ b/src/scripts/quest/subquest/uldah/SubWil027.cpp
@@ -1,0 +1,100 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubWil027_00595
+// Quest Name: We Must Rebuild
+// Quest ID: 66131
+// Start NPC: 1001353
+// End NPC: 1003995
+
+using namespace Sapphire;
+
+class SubWil027 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // UI8AL
+
+    /// Countable Num: 1 Seq: 255 Event: 1 Listener: 1003995
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1001353;
+    static constexpr auto Actor1 = 1003995;
+
+  public:
+    SubWil027() : Sapphire::ScriptAPI::QuestScript( 66131 ){}; 
+    ~SubWil027() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        Scene00000(quest, player);
+        break;
+      }
+      case Actor1:
+      {
+        Scene00001(quest, player);
+        break;
+      }
+    }
+  }
+
+
+  private:
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &SubWil027::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      quest.setSeq(SeqFinish);
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, HIDE_HOTBAR, bindSceneReturn( &SubWil027::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      if( player.giveQuestRewards( getId(), 0 ) )
+        player.finishQuest( getId() );
+    }
+
+  }
+
+};
+
+EXPOSE_SCRIPT( SubWil027 );

--- a/src/scripts/quest/subquest/uldah/SubWil028.cpp
+++ b/src/scripts/quest/subquest/uldah/SubWil028.cpp
@@ -1,0 +1,130 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubWil028_00389
+// Quest Name: Fantastic Voyage
+// Quest ID: 65925
+// Start NPC: 1001678
+// End NPC: 1001497
+
+using namespace Sapphire;
+
+class SubWil028 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // UI8AL
+    // UI8BH
+
+    /// Countable Num: 1 Seq: 255 Event: 1 Listener: 1001497
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1001678;
+    static constexpr auto Actor1 = 1001497;
+    static constexpr auto Item0 = 2000241;
+
+  public:
+    SubWil028() : Sapphire::ScriptAPI::QuestScript( 65925 ){}; 
+    ~SubWil028() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        Scene00000(quest, player);
+        break;
+      }
+      case Actor1:
+      {
+        Scene00001(quest, player);
+        break;
+      }
+    }
+  }
+
+
+  private:
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &SubWil028::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      quest.setSeq(SeqFinish);
+      quest.setUI8BH(1);
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, HIDE_HOTBAR, bindSceneReturn( &SubWil028::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if (result.getResult(0) == 1)
+      Scene00002(quest, player);
+    else
+      Scene00003(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00002( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 2, HIDE_HOTBAR, bindSceneReturn( &SubWil028::Scene00002Return ) );
+  }
+
+  void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      if( player.giveQuestRewards( getId(), 0 ) )
+        player.finishQuest( getId() );
+    }
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00003( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 3, HIDE_HOTBAR, bindSceneReturn( &SubWil028::Scene00003Return ) );
+  }
+
+  void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+};
+
+EXPOSE_SCRIPT( SubWil028 );

--- a/src/scripts/quest/subquest/uldah/SubWil029.cpp
+++ b/src/scripts/quest/subquest/uldah/SubWil029.cpp
@@ -1,0 +1,151 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubWil029_00390
+// Quest Name: Catch Your Breath
+// Quest ID: 65926
+// Start NPC: 1001313
+// End NPC: 1001992
+
+using namespace Sapphire;
+
+class SubWil029 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // UI8AL
+    // UI8BH
+
+    /// Countable Num: 1 Seq: 1 Event: 1 Listener: 1001390
+    /// Countable Num: 1 Seq: 255 Event: 1 Listener: 1001992
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      Seq1 = 1,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1001313;
+    static constexpr auto Actor1 = 1001390;
+    static constexpr auto Actor2 = 1001992;
+    static constexpr auto Item0 = 2000410;
+
+  public:
+    SubWil029() : Sapphire::ScriptAPI::QuestScript( 65926 ){}; 
+    ~SubWil029() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        Scene00000(quest, player);
+        break;
+      }
+      case Actor1:
+      {
+        Scene00001(quest, player);
+        break;
+      }
+      case Actor2:
+      {
+        Scene00002(quest, player);
+        break;
+      }
+    }
+  }
+
+
+  private:
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &SubWil029::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      quest.setSeq(Seq1);
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, HIDE_HOTBAR, bindSceneReturn( &SubWil029::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setSeq(SeqFinish);
+    quest.setUI8BH(1);
+    player.sendEventNotice(getId(), 0, 2, 0, 0);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00002( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 2, HIDE_HOTBAR, bindSceneReturn( &SubWil029::Scene00002Return ) );
+  }
+
+  void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if (result.getResult(0) == 1)
+      Scene00003(quest, player);
+    else
+      Scene00004(quest, player);
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00003( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 3, HIDE_HOTBAR, bindSceneReturn( &SubWil029::Scene00003Return ) );
+  }
+
+  void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      if( player.giveQuestRewards( getId(), 0 ) )
+        player.finishQuest( getId() );
+    }
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00004( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 4, HIDE_HOTBAR, bindSceneReturn( &SubWil029::Scene00004Return ) );
+  }
+
+  void Scene00004Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    //Empty
+  }
+
+};
+
+EXPOSE_SCRIPT( SubWil029 );


### PR DESCRIPTION
Because as per the discussion in discord those two functions need to be modified for 3.0's changes.