### PR TITLE
[3.0] action combo work; add support for multiple action ct/tg; fix effectpacket inconsistencies; fix infinite loop on aoe no target;

### DIFF
--- a/src/world/Action/Action.cpp
+++ b/src/world/Action/Action.cpp
@@ -106,10 +106,11 @@ bool Action::Action::init()
       case Common::ClassJob::Bard:
       case Common::ClassJob::Archer:
         m_range = 25;
-
+        break;
         // anything that isnt ranged
       default:
         m_range = 3;
+        break;
     }
   }
 
@@ -431,7 +432,7 @@ void Action::Action::execute()
 
   // set currently casted action as the combo action if it interrupts a combo
   // ignore it otherwise (ogcds, etc.)
-  if( !m_actionData->data().ComboContinue )
+  if( m_actionData->data().ComboContinue )
   {
     // potential combo starter or correct combo from last action, must hit something to progress combo
     if( !m_hitActors.empty() && ( !isComboAction() || isCorrectCombo() ) )
@@ -512,7 +513,7 @@ void Action::Action::buildEffects()
   if( !hasLutEntry || m_hitActors.empty() )
   {
     // send any effect packet added by script or an empty one just to play animation for other players
-    m_effectBuilder->buildAndSendPackets();
+    m_effectBuilder->buildAndSendPackets( m_hitActors );
     return;
   }
 
@@ -533,14 +534,14 @@ void Action::Action::buildEffects()
     if( m_lutEntry.potency > 0 )
     {
       auto dmg = calcDamage( isCorrectCombo() ? m_lutEntry.comboPotency : m_lutEntry.potency );
-      m_effectBuilder->damage( actor, actor, dmg.first, dmg.second );
+      m_effectBuilder->damage( m_pSource, actor, dmg.first, dmg.second );
 
       if( dmg.first > 0 )
         actor->onActionHostile( m_pSource );
 
       if( isCorrectCombo() && shouldApplyComboSucceedEffect )
       {
-        m_effectBuilder->comboSucceed( actor );
+        m_effectBuilder->comboSucceed( m_pSource );
         shouldApplyComboSucceedEffect = false;
       }
 
@@ -558,9 +559,10 @@ void Action::Action::buildEffects()
           shouldRestoreMP = false;
         }
 
-        if ( !m_actionData->data().ComboContinue ) // we need something like m_actionData->hasNextComboAction
+        if( m_actionData->data().ComboContinue ) // we need something like m_actionData->hasNextComboAction
         {
-          m_effectBuilder->startCombo( actor, getId() ); // this is on all targets hit
+          m_effectBuilder->startCombo( m_pSource, getId() ); // this is on all targets hit
+          m_effectBuilder->restoreMP( actor, m_pSource, m_pSource->getMaxMp() );
         }
       }
     }
@@ -582,7 +584,7 @@ void Action::Action::buildEffects()
     }
   }
 
-  m_effectBuilder->buildAndSendPackets();
+  m_effectBuilder->buildAndSendPackets( m_hitActors );
 
   // TODO: disabled, reset kills our queued actions
   // at this point we're done with it and no longer need it

--- a/src/world/Action/Action.cpp
+++ b/src/world/Action/Action.cpp
@@ -562,7 +562,6 @@ void Action::Action::buildEffects()
         if( m_actionData->data().ComboContinue ) // we need something like m_actionData->hasNextComboAction
         {
           m_effectBuilder->startCombo( m_pSource, getId() ); // this is on all targets hit
-          m_effectBuilder->restoreMP( actor, m_pSource, m_pSource->getMaxMp() );
         }
       }
     }

--- a/src/world/Action/EffectBuilder.cpp
+++ b/src/world/Action/EffectBuilder.cpp
@@ -33,159 +33,169 @@ uint64_t EffectBuilder::getResultDelayMs()
   return Common::Util::getTimeMs() + 850;
 }
 
-void EffectBuilder::moveToResultList( Entity::CharaPtr& chara, EffectResultPtr result )
+void EffectBuilder::addResultToActor( Entity::CharaPtr& chara, EffectResultPtr result )
 {
-  auto it = m_resolvedEffects.find( chara->getId() );
-  if( it == m_resolvedEffects.end() )
+  auto it = m_actorEffectsMap.find( chara->getId() );
+  if( it == m_actorEffectsMap.end() )
   {
     // create a new one
-    auto resultList = std::make_shared< std::vector< EffectResultPtr > >();
+    auto resultList = std::vector< EffectResultPtr >();
 
-    m_resolvedEffects[ chara->getId() ] = resultList;
+    resultList.push_back( std::move( result ) );
 
-    resultList->push_back( std::move( result ) );
+    m_actorEffectsMap[ chara->getId() ] = resultList;
 
     return;
   }
 
-  it->second->push_back( std::move( result ) );
+  it->second.push_back( std::move( result ) );
 }
 
 void EffectBuilder::heal( Entity::CharaPtr& effectTarget, Entity::CharaPtr& healingTarget, uint32_t amount, Common::ActionHitSeverityType severity, Common::ActionEffectResultFlag flag )
 {
   EffectResultPtr nextResult = make_EffectResult( healingTarget, getResultDelayMs() );
   nextResult->heal( amount, severity, flag );
-  moveToResultList( effectTarget, nextResult );
+  addResultToActor( effectTarget, nextResult );
 }
 
 void EffectBuilder::restoreMP( Entity::CharaPtr& target, Entity::CharaPtr& restoringTarget, uint32_t amount, Common::ActionEffectResultFlag flag )
 {
   EffectResultPtr nextResult = make_EffectResult( restoringTarget, getResultDelayMs() ); // restore mp source actor
   nextResult->restoreMP( amount, flag );
-  moveToResultList( target, nextResult );
+  addResultToActor( target, nextResult );
 }
 
 void EffectBuilder::damage( Entity::CharaPtr& effectTarget, Entity::CharaPtr& damagingTarget, uint32_t amount, Common::ActionHitSeverityType severity, Common::ActionEffectResultFlag flag )
 {
   EffectResultPtr nextResult = make_EffectResult( damagingTarget, getResultDelayMs() );
   nextResult->damage( amount, severity, flag );
-  moveToResultList( effectTarget, nextResult );
+  addResultToActor( damagingTarget, nextResult );
 }
 
 void EffectBuilder::startCombo( Entity::CharaPtr& target, uint16_t actionId )
 {
   EffectResultPtr nextResult = make_EffectResult( target, 0 );
   nextResult->startCombo( actionId );
-  moveToResultList( target, nextResult );
+  addResultToActor( target, nextResult );
 }
 
 void EffectBuilder::comboSucceed( Entity::CharaPtr& target )
 {
   EffectResultPtr nextResult = make_EffectResult( target, 0 );
   nextResult->comboSucceed();
-  moveToResultList( target, nextResult );
+  addResultToActor( target, nextResult );
 }
 
 void EffectBuilder::applyStatusEffect( Entity::CharaPtr& target, uint16_t statusId, uint8_t param )
 {
   EffectResultPtr nextResult = make_EffectResult( target, 0 );
   nextResult->applyStatusEffect( statusId, param );
-  moveToResultList( target, nextResult );
+  addResultToActor( target, nextResult );
 }
 
 void EffectBuilder::mount( Entity::CharaPtr& target, uint16_t mountId )
 {
   EffectResultPtr nextResult = make_EffectResult( target, getResultDelayMs() );
   nextResult->mount( mountId );
-  moveToResultList( target, nextResult );
+  addResultToActor( target, nextResult );
 }
 
-void EffectBuilder::buildAndSendPackets()
+void EffectBuilder::buildAndSendPackets( const std::vector< Entity::CharaPtr >& targetList )
 {
-  auto targetCount = m_resolvedEffects.size();
   Logger::debug( "EffectBuilder result: " );
-  Logger::debug( "Targets afflicted: {}", targetCount );
-
-  auto globalSequence = m_sourceChara->getCurrentTerritory()->getNextEffectSequence();
+  Logger::debug( "Targets afflicted: {}", targetList.size() );
 
   do // we want to send at least one packet even nothing is hit so other players can see
   {
-    auto packet = buildNextEffectPacket( globalSequence );
+    auto packet = buildNextEffectPacket( targetList );
     m_sourceChara->sendToInRangeSet( packet, true );
   }
-  while( !m_resolvedEffects.empty() );
+  while( !m_actorEffectsMap.empty() );
 }
 
-std::shared_ptr< FFXIVPacketBase > EffectBuilder::buildNextEffectPacket( uint32_t globalSequence )
+std::shared_ptr< FFXIVPacketBase > EffectBuilder::buildNextEffectPacket( const std::vector< Entity::CharaPtr >& targetList )
 {
-  auto remainingTargetCount = m_resolvedEffects.size();
+  auto remainingTargetCount = targetList.size();
+  auto globalSequence = m_sourceChara->getCurrentTerritory()->getNextEffectSequence();
 
   if( remainingTargetCount > 1 ) // use AoeEffect packets
   {
-    auto effectResult = makeZonePacket< FFXIVIpcActionResult >( m_sourceChara->getId() );
-    Common::CalcResultParam* pEntry;
-    uint64_t* pEffectTargetId;
-    
-    effectResult->data().ActionKey = m_actionId;
-    effectResult->data().ActionKind = 1;
-    effectResult->data().Action = static_cast< uint16_t >( m_actionId );
-    effectResult->data().MainTarget = m_sourceChara->getId();
-    effectResult->data().DirTarget = Common::Util::floatToUInt16Rot( m_sourceChara->getRot() );
-    effectResult->data().Flag = Common::ActionEffectDisplayType::ShowActionName;
-    effectResult->data().TargetCount = static_cast< uint8_t >( remainingTargetCount );
-    effectResult->data().RequestId = m_sequence;
-    effectResult->data().ResultId = globalSequence;
+    auto effectPacket = std::make_shared< EffectPacket >( m_sourceChara->getId(), m_actionId );
+    effectPacket->setRotation( Common::Util::floatToUInt16Rot( m_sourceChara->getRot() ) );
+    effectPacket->setSequence( globalSequence, m_sequence );
+    effectPacket->setTargetActor( targetList[ 0 ]->getId() );
 
     uint8_t targetIndex = 0;
-    for( auto it = m_resolvedEffects.begin(); it != m_resolvedEffects.end(); )
+    for( auto it = m_actorEffectsMap.begin(); it != m_actorEffectsMap.end(); )
     {
-      auto resultList = it->second;
-      assert( !resultList->empty() );
-      auto firstResult = resultList->data()[ 0 ];
-      pEffectTargetId[ targetIndex ] = firstResult->getTarget()->getId();
-      Logger::debug( " - id: {}", pEffectTargetId[ targetIndex ] );
+      // get all effect results for an actor
+      auto actorResultList = it->second;
 
-      for( auto i = 0; i < resultList->size(); i++ )
+      for( auto i = 0; i < actorResultList.size(); ++i )
       {
-        auto result = resultList->data()[ i ];
-        pEntry[ targetIndex * 8 + i ] = result->buildEffectEntry();
+        auto result = actorResultList.data()[ i ];
+        auto effect = result->buildEffectEntry();
+
+        // if effect result is a source/caster effect
+        if( result->getTarget() == m_sourceChara )
+        {
+          effectPacket->addSourceEffect( effect );
+        }
+        else
+        {
+          effectPacket->addTargetEffect( effect, result->getTarget()->getId() );
+        }
+        
         m_sourceChara->getCurrentTerritory()->addEffectResult( std::move( result ) );
       }
-      resultList->clear();
 
-      it = m_resolvedEffects.erase( it );
-
+      actorResultList.clear();
+      it = m_actorEffectsMap.erase( it );
       targetIndex++;
 
       if( targetIndex == 15 )
         break;
     }
 
-    return effectResult;
+    return effectPacket;
   }
-  else if ( remainingTargetCount == 1 ) // use Effect for single target
+  else if( remainingTargetCount == 1 ) // use Effect for single target
   {
-    auto resultList = m_resolvedEffects.begin()->second;
-    assert( !resultList->empty() );
-    auto firstResult = resultList->data()[ 0 ];
-    Logger::debug( " - id: {}", firstResult->getTarget()->getId() );
+    Logger::debug( " - id: {}", targetList[0]->getId() );
+    Logger::debug( "------------------------------------------" );
 
-    auto seq = m_sourceChara->getCurrentTerritory()->getNextEffectSequence();
-
-    auto effectPacket = std::make_shared< EffectPacket1 >( m_sourceChara->getId(), firstResult->getTarget()->getId(), m_actionId );
+    auto effectPacket = std::make_shared< EffectPacket1 >( m_sourceChara->getId(), targetList[ 0 ]->getId(), m_actionId );
     effectPacket->setRotation( Common::Util::floatToUInt16Rot( m_sourceChara->getRot() ) );
-    effectPacket->setSequence( seq, m_sequence );
+    effectPacket->setSequence( globalSequence, m_sequence );
 
-    for( int i = 0; i < resultList->size(); i++ )
+    for( auto it = m_actorEffectsMap.begin(); it != m_actorEffectsMap.end(); )
     {
-      auto result = resultList->data()[ i ];
-      effectPacket->addTargetEffect( result->buildEffectEntry() );
-      m_sourceChara->getCurrentTerritory()->addEffectResult( std::move( result ) );
+      // get all effect results for an actor
+      auto actorResultList = it->second;
+
+      for( auto i = 0; i < actorResultList.size(); ++i )
+      {
+        auto result = actorResultList.data()[ i ];
+        auto effect = result->buildEffectEntry();
+
+        // if effect result is a source/caster effect
+        if( result->getTarget() == m_sourceChara )
+        {
+          effectPacket->addSourceEffect( effect );
+        }
+        else
+        {
+          effectPacket->addTargetEffect( effect );
+        }
+        
+        m_sourceChara->getCurrentTerritory()->addEffectResult( std::move( result ) );
+      }
+
+      actorResultList.clear();
+      it = m_actorEffectsMap.erase( it );
     }
 
-    resultList->clear();
-
-    m_resolvedEffects.clear();
+    m_actorEffectsMap.clear();
 
     return effectPacket;
   }
@@ -201,6 +211,8 @@ std::shared_ptr< FFXIVPacketBase > EffectBuilder::buildNextEffectPacket( uint32_
     effectPacket->data().Flag = Common::ActionEffectDisplayType::HideActionName;
     effectPacket->data().RequestId = m_sequence;
     effectPacket->data().ResultId = globalSequence;
+
+    m_actorEffectsMap.clear();
 
     return effectPacket;
   }

--- a/src/world/Action/EffectBuilder.h
+++ b/src/world/Action/EffectBuilder.h
@@ -12,14 +12,14 @@ namespace Sapphire::World::Action
 
     void heal( Entity::CharaPtr& effectTarget, Entity::CharaPtr& healingTarget, uint32_t amount,
                Common::ActionHitSeverityType severity = Common::ActionHitSeverityType::NormalHeal,
-               Common::ActionEffectResultFlag flag = Common::ActionEffectResultFlag::None);
+               Common::ActionEffectResultFlag flag = Common::ActionEffectResultFlag::None );
 
     void restoreMP( Entity::CharaPtr& effectTarget, Entity::CharaPtr& restoringTarget, uint32_t amount,
-                    Common::ActionEffectResultFlag flag = Common::ActionEffectResultFlag::None);
+                    Common::ActionEffectResultFlag flag = Common::ActionEffectResultFlag::None );
 
     void damage( Entity::CharaPtr& effectTarget, Entity::CharaPtr& damagingTarget, uint32_t amount,
                  Common::ActionHitSeverityType severity = Common::ActionHitSeverityType::NormalDamage,
-                 Common::ActionEffectResultFlag flag = Common::ActionEffectResultFlag::None);
+                 Common::ActionEffectResultFlag flag = Common::ActionEffectResultFlag::None );
 
     void startCombo( Entity::CharaPtr& target, uint16_t actionId );
 
@@ -29,22 +29,21 @@ namespace Sapphire::World::Action
 
     void mount( Entity::CharaPtr& target, uint16_t mountId );
 
-    void buildAndSendPackets();
-
+    void buildAndSendPackets( const std::vector< Entity::CharaPtr >& targetList );
 
   private:
-    void moveToResultList( Entity::CharaPtr& chara, EffectResultPtr result );
+    void addResultToActor( Entity::CharaPtr& chara, EffectResultPtr result );
 
     uint64_t getResultDelayMs();
 
-    std::shared_ptr< Sapphire::Network::Packets::FFXIVPacketBase > buildNextEffectPacket( uint32_t globalSequence );
+    std::shared_ptr< Sapphire::Network::Packets::FFXIVPacketBase > buildNextEffectPacket( const std::vector< Entity::CharaPtr >& targetList );
 
   private:
     uint32_t m_actionId;
     uint16_t m_sequence;
 
     Entity::CharaPtr m_sourceChara;
-    std::unordered_map< uint32_t, std::shared_ptr< std::vector< EffectResultPtr > > > m_resolvedEffects;
+    std::unordered_map< uint32_t, std::vector< EffectResultPtr > > m_actorEffectsMap;
   };
 
 }

--- a/src/world/Action/ItemAction.cpp
+++ b/src/world/Action/ItemAction.cpp
@@ -65,11 +65,11 @@ void ItemAction::handleVFXItem()
   effect.Type = Common::ActionEffectType::CALC_RESULT_TYPE_CHECK_BARRIER;
   effect.Value = m_itemAction->data().Calcu0Arg[ 0 ];
 
-  auto effectPacket = std::make_shared< EffectPacket >( getSourceChara()->getId(), getSourceChara()->getId(), getId() );
+  auto effectPacket = std::make_shared< EffectPacket >( getSourceChara()->getId(), getId() );
   effectPacket->setTargetActor( getSourceChara()->getId() );
   effectPacket->setAnimationId( Common::ItemActionType::ItemActionVFX );
   effectPacket->setDisplayType( Common::ActionEffectDisplayType::ShowItemName );
-  effectPacket->addEffect( effect, static_cast< uint64_t >( getSourceChara()->getId() ) );
+  effectPacket->addTargetEffect( effect, static_cast< uint64_t >( getSourceChara()->getId() ) );
 
   m_pSource->sendToInRangeSet( effectPacket, true );
 }

--- a/src/world/Action/MountAction.cpp
+++ b/src/world/Action/MountAction.cpp
@@ -74,5 +74,5 @@ void MountAction::execute()
 
   m_pSource->getAsPlayer()->unsetStateFlag( Common::PlayerStateFlag::Casting );
   m_effectBuilder->mount( m_pSource, m_mountId );
-  m_effectBuilder->buildAndSendPackets();
+  m_effectBuilder->buildAndSendPackets( { m_pSource } );
 }

--- a/src/world/Actor/Chara.cpp
+++ b/src/world/Actor/Chara.cpp
@@ -16,7 +16,7 @@
 #include "Network/PacketWrappers/ActorControlSelfPacket.h"
 #include "Network/PacketWrappers/ActorControlTargetPacket.h"
 #include "Network/PacketWrappers/UpdateHpMpTpPacket.h"
-#include "Network/PacketWrappers/EffectPacket.h"
+#include "Network/PacketWrappers/EffectPacket1.h"
 
 #include "StatusEffect/StatusEffect.h"
 #include "Action/Action.h"
@@ -483,7 +483,6 @@ Will have to be extended for ranged attacks.
 */
 void Sapphire::Entity::Chara::autoAttack( CharaPtr pTarget )
 {
-
   uint64_t tick = Util::getTimeMs();
 
   // todo: this needs to use the auto attack delay for the equipped weapon
@@ -495,19 +494,19 @@ void Sapphire::Entity::Chara::autoAttack( CharaPtr pTarget )
 
     auto damage = static_cast< uint16_t >( 10 + rand() % 12 );
 
-    auto effectPacket = std::make_shared< EffectPacket >( getId(), pTarget->getId(), 7 );
+    auto effectPacket = std::make_shared< EffectPacket1 >( getId(), pTarget->getId(), 7 );
     effectPacket->setRotation( Util::floatToUInt16Rot( getRot() ) );
+
     Common::CalcResultParam effectEntry{};
     effectEntry.Value = static_cast< int16_t >( damage );
     effectEntry.Type = ActionEffectType::CALC_RESULT_TYPE_DAMAGE_HP;
     effectEntry.Arg0 = static_cast< uint8_t >( ActionHitSeverityType::NormalDamage );
     effectEntry.Arg2 = 0x71;
-    effectPacket->addEffect( effectEntry, static_cast< uint64_t >( pTarget->getId() ) );
+    effectPacket->addTargetEffect( effectEntry );
 
     sendToInRangeSet( effectPacket );
 
     pTarget->takeDamage( damage );
-
   }
 }
 

--- a/src/world/Manager/DebugCommandMgr.cpp
+++ b/src/world/Manager/DebugCommandMgr.cpp
@@ -492,15 +492,16 @@ void Sapphire::World::Manager::DebugCommandMgr::add( char* data, Entity::Player&
     uint16_t param1;
     sscanf( params.c_str(), "%hu", &param1 );
 
-    auto effectPacket = std::make_shared< EffectPacket >( player.getId(), player.getTargetId(), param1 );
+    auto effectPacket = std::make_shared< EffectPacket >( player.getId(), param1 );
     effectPacket->setRotation( Common::Util::floatToUInt16Rot( player.getRot() ) );
+    effectPacket->setTargetActor( player.getTargetId() );
 
     Common::CalcResultParam entry{};
     entry.Value = static_cast< int16_t >( param1 );
     entry.Type = Common::ActionEffectType::CALC_RESULT_TYPE_DAMAGE_HP;
     entry.Arg0 = static_cast< uint8_t >( Common::ActionHitSeverityType::NormalDamage );
 
-    effectPacket->addEffect( entry, static_cast< uint64_t >( player.getId() ) );
+    effectPacket->addTargetEffect( entry, static_cast< uint64_t >( player.getId() ) );
 
     auto sequence = player.getCurrentTerritory()->getNextEffectSequence();
     effectPacket->setSequence( sequence );

--- a/src/world/Network/PacketWrappers/EffectPacket.h
+++ b/src/world/Network/PacketWrappers/EffectPacket.h
@@ -14,29 +14,49 @@ namespace Sapphire::Network::Packets::WorldPackets::Server
   class EffectPacket : public ZoneChannelPacket< FFXIVIpcActionResult >
   {
   public:
-    EffectPacket( uint64_t sourceId, uint32_t targetId, uint32_t actionId ) :
-      ZoneChannelPacket< FFXIVIpcActionResult >( static_cast< uint32_t >( sourceId ), targetId )
+    EffectPacket( uint64_t sourceId, uint32_t actionId ) :
+      ZoneChannelPacket< FFXIVIpcActionResult >( static_cast< uint32_t >( sourceId ) )
     {
       m_data.Flag = 0;
       m_data.ActionKey = actionId;
       m_data.Action = static_cast< uint16_t >( actionId );
       m_data.ActionKind = 1;
 
-      m_data.LockTime = 0.6f;
-      m_data.MainTarget = static_cast< uint64_t >( targetId );
+      m_data.MainTarget = Common::INVALID_GAME_OBJECT_ID;
+      m_data.BallistaEntityId = Common::INVALID_GAME_OBJECT_ID;
 
-      m_data.ActionArg = Common::ActionEffectDisplayType::ShowActionName;
+      m_data.LockTime = 0.6f;
+
+      m_data.TargetCount = 0;
 
       std::memset( m_data.CalcResult, 0, sizeof( Common::CalcResult ) * 16 );
     }
 
-    void addEffect( const Common::CalcResultParam& effect, uint64_t targetId = Common::INVALID_GAME_OBJECT_ID64 )
+    void addTargetEffect( const Common::CalcResultParam& effect, uint64_t targetId = Common::INVALID_GAME_OBJECT_ID64 )
     {
-      assert( m_data.TargetCount <= 15 );
+      std::memcpy( &m_data.CalcResult[ m_data.TargetCount ].CalcResultTg[ m_targetEffectCount++ ], &effect, sizeof( Common::CalcResultParam ) );
 
-      std::memcpy( &m_data.CalcResult[ m_data.TargetCount ].CalcResultTg, &effect, sizeof( Common::CalcResultParam ) );
+      // iterate and see if we already have this target added
+      bool targetAlreadyAdded = false;
+      for( int i = 0; i < sizeof( m_data.Target ) / sizeof( uint64_t ); ++i )
+      {
+        if( m_data.Target[ i ] == targetId )
+        {
+          targetAlreadyAdded = true;
+          break;
+        }
+      }
+
       m_data.Target[ m_data.TargetCount ] = targetId;
-      m_data.TargetCount++;
+
+      if( !targetAlreadyAdded )
+        m_data.TargetCount++;
+    }
+
+    void addSourceEffect( const Common::CalcResultParam& effect )
+    {
+      // we associate the source effect with the current target index set
+      std::memcpy( &m_data.CalcResult[ m_data.TargetCount - 1 ].CalcResultCt[ m_sourceEffectCount++ ], &effect, sizeof( Common::CalcResultParam ) );
     }
 
     void setAnimationId( uint16_t animationId )
@@ -71,6 +91,9 @@ namespace Sapphire::Network::Packets::WorldPackets::Server
       m_data.RequestId = static_cast< uint32_t >( sourceSequence );
       m_data.ResultId = static_cast< uint32_t>( sequence );
     }
+  private:
+    uint8_t m_targetEffectCount{ 0 };
+    uint8_t m_sourceEffectCount{ 0 };
   };
 
 }

--- a/src/world/Network/PacketWrappers/EffectPacket1.h
+++ b/src/world/Network/PacketWrappers/EffectPacket1.h
@@ -12,9 +12,6 @@ namespace Sapphire::Network::Packets::WorldPackets::Server
 
   class EffectPacket1 : public ZoneChannelPacket< FFXIVIpcActionResult1 >
   {
-  private:
-    uint8_t m_targetEffectCount{0};
-    uint8_t m_sourceEffectCount{0};
   public:
     EffectPacket1( uint64_t sourceId, uint32_t targetId, uint32_t actionId ) :
       ZoneChannelPacket< FFXIVIpcActionResult1 >( static_cast< uint32_t >( sourceId ), targetId )
@@ -76,6 +73,10 @@ namespace Sapphire::Network::Packets::WorldPackets::Server
       m_data.RequestId = static_cast< uint32_t >( sourceSequence );
       m_data.ResultId = static_cast< uint32_t>( sequence );
     }
+
+  private:
+    uint8_t m_targetEffectCount{ 0 };
+    uint8_t m_sourceEffectCount{ 0 };
   };
 
 }


### PR DESCRIPTION
AoE packets are not fully tested (only on single targets)
currently sheets are broken so combos are forced on, and left for the client to decide (ComboContinue, some canSelfTarget tests)
comparison for EffectPacket1 vs EffectPacket:

![image](https://user-images.githubusercontent.com/30917768/148850013-5af4040e-65e3-4b6d-b176-2fc9c7b6e334.png)

![image](https://user-images.githubusercontent.com/30917768/148850022-bb6ad1ff-1fec-459a-9615-a090702dbcd1.png)
