### PR TITLE
[3.0] DelayedEmnityTask and BNpc additions

### DIFF
--- a/src/scripts/quest/classquest/CNJ/ClsCnj001.cpp
+++ b/src/scripts/quest/classquest/CNJ/ClsCnj001.cpp
@@ -198,7 +198,8 @@ private:
     auto& teriMgr = Common::Service< Sapphire::World::Manager::TerritoryMgr >::ref();
     auto instance = teriMgr.getTerritoryByGuId( player.getTerritoryId() );
     auto enemy = instance->createBNpcFromInstanceId( Enemy0, 1220 /*Find the right value*/, Common::BNpcType::Enemy );
-    enemy->hateListAdd( player.getAsPlayer(), 1 );
+    enemy->setTriggerOwnerId( player.getId() );
+    enemy->hateListAddDelayed( player.getAsPlayer(), 1 );
 
     quest.setBitFlag8( 1, true );
   }

--- a/src/scripts/quest/classquest/CNJ/ClsCnj002.cpp
+++ b/src/scripts/quest/classquest/CNJ/ClsCnj002.cpp
@@ -204,7 +204,8 @@ private:
     auto& teriMgr = Common::Service< Sapphire::World::Manager::TerritoryMgr >::ref();
     auto instance = teriMgr.getTerritoryByGuId( player.getTerritoryId() );
     auto enemy = instance->createBNpcFromInstanceId( Enemy0, 1220 /*Find the right value*/, Common::BNpcType::Enemy );
-    enemy->hateListAdd( player.getAsPlayer(), 1 );
+    enemy->setTriggerOwnerId( player.getId() );
+    enemy->hateListAddDelayed( player.getAsPlayer(), 1 );
     quest.setBitFlag8( 1, true );
   }
 

--- a/src/scripts/quest/classquest/CNJ/ClsCnj003.cpp
+++ b/src/scripts/quest/classquest/CNJ/ClsCnj003.cpp
@@ -231,7 +231,7 @@ public:
       return;
     else if( entityId == Enemy0 && quest.getSeq() == Seq1 )
     {
-      eventMgr().sendEventNotice( player, getId(), 1, 0 );
+      eventMgr().sendEventNotice( player, getId(), 0, 0 );
       quest.setUI8BH( 0 );
       quest.setSeq( Seq2 );
     }
@@ -290,7 +290,8 @@ private:
     auto& teriMgr = Common::Service< Sapphire::World::Manager::TerritoryMgr >::ref();
     auto instance = teriMgr.getTerritoryByGuId( player.getTerritoryId() );
     auto enemy = instance->createBNpcFromInstanceId( Enemy0, 319 /*Find the right value*/, Common::BNpcType::Enemy );
-    enemy->hateListAdd( player.getAsPlayer(), 1 );
+    enemy->setTriggerOwnerId( player.getId() );
+    enemy->hateListAddDelayed( player.getAsPlayer(), 1 );
   }
 
   //////////////////////////////////////////////////////////////////////

--- a/src/scripts/quest/classquest/CNJ/ClsCnj004.cpp
+++ b/src/scripts/quest/classquest/CNJ/ClsCnj004.cpp
@@ -328,7 +328,8 @@ private:
     auto& teriMgr = Common::Service< Sapphire::World::Manager::TerritoryMgr >::ref();
     auto instance = teriMgr.getTerritoryByGuId( player.getTerritoryId() );
     auto enemy = instance->createBNpcFromInstanceId( Enemy0, 413 /*TODO: Find the right value*/, Common::BNpcType::Enemy );
-    enemy->hateListAdd( player.getAsPlayer(), 1 );
+    enemy->setTriggerOwnerId( player.getId() );
+    enemy->hateListAddDelayed( player.getAsPlayer(), 1 );
   }
 
   //////////////////////////////////////////////////////////////////////
@@ -354,7 +355,8 @@ private:
     auto& teriMgr = Common::Service< Sapphire::World::Manager::TerritoryMgr >::ref();
     auto instance = teriMgr.getTerritoryByGuId( player.getTerritoryId() );
     auto enemy = instance->createBNpcFromInstanceId( Enemy1, 413 /*TODO: Find the right value*/, Common::BNpcType::Enemy );
-    enemy->hateListAdd( player.getAsPlayer(), 1 );
+    enemy->setTriggerOwnerId( player.getId() );
+    enemy->hateListAddDelayed( player.getAsPlayer(), 1 );
   }
 
   //////////////////////////////////////////////////////////////////////
@@ -380,7 +382,8 @@ private:
     auto& teriMgr = Common::Service< Sapphire::World::Manager::TerritoryMgr >::ref();
     auto instance = teriMgr.getTerritoryByGuId( player.getTerritoryId() );
     auto enemy = instance->createBNpcFromInstanceId( Enemy2, 413 /*TODO: Find the right value*/, Common::BNpcType::Enemy );
-    enemy->hateListAdd( player.getAsPlayer(), 1 );
+    enemy->setTriggerOwnerId( player.getId() );
+    enemy->hateListAddDelayed( player.getAsPlayer(), 1 );
   }
 };
 

--- a/src/scripts/quest/classquest/CNJ/ClsCnj006.cpp
+++ b/src/scripts/quest/classquest/CNJ/ClsCnj006.cpp
@@ -242,7 +242,8 @@ private:
     auto& teriMgr = Common::Service< Sapphire::World::Manager::TerritoryMgr >::ref();
     auto instance = teriMgr.getTerritoryByGuId( player.getTerritoryId() );
     auto enemy = instance->createBNpcFromInstanceId( Enemy0, 413 /*TODO: Find the right value*/, Common::BNpcType::Enemy );
-    enemy->hateListAdd( player.getAsPlayer(), 1 );
+    enemy->setTriggerOwnerId( player.getId() );
+    enemy->hateListAddDelayed( player.getAsPlayer(), 1 );
     quest.setBitFlag8( 1, true );
   }
 
@@ -337,7 +338,8 @@ private:
     auto& teriMgr = Common::Service< Sapphire::World::Manager::TerritoryMgr >::ref();
     auto instance = teriMgr.getTerritoryByGuId( player.getTerritoryId() );
     auto enemy = instance->createBNpcFromInstanceId( Enemy1, 413 /*TODO: Find the right value*/, Common::BNpcType::Enemy );
-    enemy->hateListAdd( player.getAsPlayer(), 1 );
+    enemy->setTriggerOwnerId( player.getId() );
+    enemy->hateListAddDelayed( player.getAsPlayer(), 1 );
     quest.setBitFlag8( 1, true );
   }
 
@@ -432,7 +434,8 @@ private:
     auto& teriMgr = Common::Service< Sapphire::World::Manager::TerritoryMgr >::ref();
     auto instance = teriMgr.getTerritoryByGuId( player.getTerritoryId() );
     auto enemy = instance->createBNpcFromInstanceId( Enemy2, 413 /*TODO: Find the right value*/, Common::BNpcType::Enemy );
-    enemy->hateListAdd( player.getAsPlayer(), 1 );
+    enemy->setTriggerOwnerId( player.getId() );
+    enemy->hateListAddDelayed( player.getAsPlayer(), 1 );
 
     quest.setBitFlag8( 1, true );
   }

--- a/src/world/Actor/BNpc.cpp
+++ b/src/world/Actor/BNpc.cpp
@@ -41,6 +41,7 @@
 #include <Manager/TaskMgr.h>
 #include <Task/RemoveBNpcTask.h>
 #include <Task/FadeBNpcTask.h>
+#include <Task/DelayedEmnityTask.h>
 #include <Service.h>
 
 using namespace Sapphire::Common;
@@ -478,6 +479,13 @@ void Sapphire::Entity::BNpc::hateListAdd( const Sapphire::Entity::CharaPtr& pCha
     auto pPlayer = pChara->getAsPlayer();
     pPlayer->hateListAdd( *this );
   }
+}
+
+void Sapphire::Entity::BNpc::hateListAddDelayed( const Sapphire::Entity::CharaPtr& pChara, int32_t hateAmount )
+{
+  auto& taskMgr = Common::Service< World::Manager::TaskMgr >::ref();
+  auto delayedEmnityTask = std::make_shared< Sapphire::World::DelayedEmnityTask >( 5000, getAsBNpc(), pChara, hateAmount );
+  taskMgr.queueTask( delayedEmnityTask );
 }
 
 void Sapphire::Entity::BNpc::hateListUpdate( const Sapphire::Entity::CharaPtr& pChara, int32_t hateAmount )

--- a/src/world/Actor/BNpc.h
+++ b/src/world/Actor/BNpc.h
@@ -105,6 +105,7 @@ namespace Sapphire::Entity
     void hateListClear();
     CharaPtr hateListGetHighest();
     void hateListAdd( const CharaPtr& pChara, int32_t hateAmount );
+    void hateListAddDelayed( const CharaPtr& pChara, int32_t hateAmount );
     void hateListUpdate( const CharaPtr& pChara, int32_t hateAmount );
     void hateListRemove( const CharaPtr& pChara );
     bool hateListHasActor( const CharaPtr& pChara );

--- a/src/world/Task/DelayedEmnityTask.cpp
+++ b/src/world/Task/DelayedEmnityTask.cpp
@@ -1,0 +1,31 @@
+#include "DelayedEmnityTask.h"
+
+#include <Actor/BNpc.h>
+#include <Logging/Logger.h>
+
+using namespace Sapphire::World;
+
+
+Sapphire::World::DelayedEmnityTask::DelayedEmnityTask( uint64_t delayTime, Entity::BNpcPtr bnpc, Entity::CharaPtr chara, int32_t hateAmount ) :
+  Task(delayTime),
+  m_pBNpc(std::move(bnpc)),
+  m_pChara(std::move(chara)),
+  m_hateAmount( std::move(hateAmount) )
+{
+}
+
+
+void DelayedEmnityTask::onQueue()
+{
+  Logger::debug( { __FUNCTION__ } );
+}
+
+void DelayedEmnityTask::execute()
+{
+  m_pBNpc->hateListAdd( m_pChara, m_hateAmount );
+}
+
+std::string DelayedEmnityTask::toString()
+{
+  return fmt::format( "DelayedEmnityTask: BNpc#{}, Chara Name: {}, Hate Amount: {}, ElapsedTimeMs: {}", m_pBNpc->getId(), m_pChara->getName(), m_hateAmount, getDelayTimeMs() );
+}

--- a/src/world/Task/DelayedEmnityTask.h
+++ b/src/world/Task/DelayedEmnityTask.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include "Task.h"
+
+namespace Sapphire::World
+{
+
+  class DelayedEmnityTask : public Task
+  {
+  public:
+    DelayedEmnityTask( uint64_t delayTime, Entity::BNpcPtr bnpc, Entity::CharaPtr chara, int32_t hateAmount );
+
+    void onQueue() override;
+    void execute() override;
+    std::string toString() override;
+
+  private:
+    Entity::BNpcPtr m_pBNpc;
+    Entity::CharaPtr m_pChara;
+    int32_t m_hateAmount;
+  };
+
+}


### PR DESCRIPTION
Add a task that delays adding the player to a BNpc's hate list, so that we can be the same as retail for quests that interacting with an EObj spawns BNpcs.