### PR TITLE
[3.x] fix warpmgr argument on no aetherytes/teleport found;

### DIFF
--- a/src/world/Network/Handlers/GMCommandHandlers.cpp
+++ b/src/world/Network/Handlers/GMCommandHandlers.cpp
@@ -539,8 +539,7 @@ void Sapphire::Network::GameConnection::gmCommandHandler( const Packets::FFXIVAR
         else
         {
           auto& warpMgr = Common::Service< WarpMgr >::ref();
-          warpMgr.requestMoveTerritory( *targetPlayer, WarpType::WARP_TYPE_GM,
-                                        targetPlayer->getTerritoryId(), targetPlayer->getPos(), 0 );
+          warpMgr.requestMoveTerritory( *targetPlayer, WarpType::WARP_TYPE_GM, teriMgr.getZoneByTerritoryTypeId( param1 )->getGuId(), targetPlayer->getPos(), 0);
         }
 
         PlayerMgr::sendServerNotice( player, "{0} was warped to zone {1}", targetPlayer->getName(), param1, pZone->getName() );


### PR DESCRIPTION
ignore branch name, i was looking into mariadb 11 again