### PR TITLE
Service locator workaround for Visual Studio.

### DIFF
--- a/src/common/Service.cpp
+++ b/src/common/Service.cpp
@@ -1,0 +1,16 @@
+#include <Service.h>
+
+namespace Sapphire::Common
+{
+  ServiceContainer* ServiceContainer::pSvcContainer = nullptr;
+
+  std::shared_ptr< void > ServiceContainer::get( size_t id )
+  {
+    return serviceTable[ id ];
+  }
+  
+  void ServiceContainer::set( size_t id, std::shared_ptr< void > svc )
+  {
+    serviceTable[ id ] = std::move( svc );
+  }
+}

--- a/src/scripts/ScriptLoader.cpp.in
+++ b/src/scripts/ScriptLoader.cpp.in
@@ -1,4 +1,5 @@
 #include <Script/NativeScriptApi.h>
+#include <Service.h>
 
 @ScriptIncludes@
 
@@ -8,7 +9,8 @@ const Sapphire::ScriptAPI::ScriptObject* ptrs[] =
    nullptr
 };
 
-extern "C" EXPORT const Sapphire::ScriptAPI::ScriptObject** getScripts()
+extern "C" EXPORT const Sapphire::ScriptAPI::ScriptObject** getScripts( Sapphire::Common::ServiceContainer* pSc )
 {
+   Sapphire::Common::ServiceContainer::pSvcContainer = pSc;
    return ptrs;
 }

--- a/src/world/Script/ScriptLoader.cpp
+++ b/src/world/Script/ScriptLoader.cpp
@@ -4,6 +4,7 @@
 #include <Config/ConfigMgr.h>
 #include <Util/Util.h>
 #include "ServerMgr.h"
+#include "Service.h"
 
 #include <filesystem>
 
@@ -95,7 +96,7 @@ Sapphire::Scripting::ScriptInfo* Sapphire::Scripting::ScriptLoader::loadModule( 
 
 Sapphire::ScriptAPI::ScriptObject** Sapphire::Scripting::ScriptLoader::getScripts( ModuleHandle handle )
 {
-  using getScripts = Sapphire::ScriptAPI::ScriptObject** ( * )();
+  using getScripts = Sapphire::ScriptAPI::ScriptObject** ( * )( Common::ServiceContainer* );
 
 #ifdef _WIN32
   getScripts func = reinterpret_cast< getScripts >( GetProcAddress( handle, "getScripts" ) );
@@ -105,7 +106,7 @@ Sapphire::ScriptAPI::ScriptObject** Sapphire::Scripting::ScriptLoader::getScript
 
   if( func )
   {
-    auto ptr = func();
+    auto ptr = func( Common::ServiceContainer::pSvcContainer );
 
     return ptr;
   }

--- a/src/world/mainGameServer.cpp
+++ b/src/world/mainGameServer.cpp
@@ -15,6 +15,7 @@ int main( int32_t argc, char* argv[] )
 {
   auto pServer = std::make_shared< ServerMgr >( "world.ini" );
 
+  Common::ServiceContainer::pSvcContainer = new Common::ServiceContainer();
   Common::Service< ServerMgr >::set( pServer );
 
   pServer->run( argc, argv );


### PR DESCRIPTION
After some peeking into 3.x I think I'd just use this old workaround.
Slightly slower since a map lookup is introduced, but no need to add services one by one when they are found crashing.