### PR TITLE
Implemented more Limsa Sidequests

### DIFF
--- a/src/scripts/quest/subquest/limsa/SubSea002.cpp
+++ b/src/scripts/quest/subquest/limsa/SubSea002.cpp
@@ -1,0 +1,133 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubSea002_00112
+// Quest Name: Suspiciously SoberF
+// Quest ID: 65648
+// Start NPC: 1003604 (Ahldskyf)
+// End NPC: 1003275 (Frydwyb)
+
+using namespace Sapphire;
+
+class SubSea002 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // UI8AL
+
+    /// Countable Num: 1 Seq: 1 Event: 1 Listener: 1003274
+    /// Countable Num: 0 Seq: 255 Event: 1 Listener: 1003275
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      Seq1 = 1,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1003604; // Ahldskyf ( Pos: -60.441002 17.990400 -4.318360  Teri: 129 )
+    static constexpr auto Actor1 = 1003274; // Glazrael ( Pos: -110.459999 17.990400 15.701500  Teri: 129 )
+    static constexpr auto Actor2 = 1003275; // Frydwyb ( Pos: -147.087997 18.200001 14.382000  Teri: 129 )
+
+  public:
+    SubSea002() : Sapphire::ScriptAPI::QuestScript( 65648 ){}; 
+    ~SubSea002() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        Scene00000( quest, player );
+        break;
+      }
+      case Actor1:
+      {
+        Scene00002( quest, player );
+        break;
+      }
+      case Actor2:
+      {
+        Scene00003( quest, player );
+        break;
+      }
+    }
+  }
+
+
+  private:
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, NONE, bindSceneReturn( &SubSea002::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      Scene00001( quest, player );
+    }
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, NONE, bindSceneReturn( &SubSea002::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setSeq( Seq1 );
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00002( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 2, NONE, bindSceneReturn( &SubSea002::Scene00002Return ) );
+  }
+
+  void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setSeq( SeqFinish );
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00003( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 3, NONE, bindSceneReturn( &SubSea002::Scene00003Return ) );
+  }
+
+  void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      player.finishQuest( getId() );
+    }
+
+  }
+
+};
+
+EXPOSE_SCRIPT( SubSea002 );

--- a/src/scripts/quest/subquest/limsa/SubSea003.cpp
+++ b/src/scripts/quest/subquest/limsa/SubSea003.cpp
@@ -118,6 +118,7 @@ class SubSea003 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
   {
+    eventMgr().sendEventNotice( player, getId(), 0, 0 );
     quest.setSeq( SeqFinish );
   }
 

--- a/src/scripts/quest/subquest/limsa/SubSea003.cpp
+++ b/src/scripts/quest/subquest/limsa/SubSea003.cpp
@@ -90,8 +90,6 @@ class SubSea003 : public Sapphire::ScriptAPI::QuestScript
       quest.setUI8BH( 1 );
       quest.setSeq( Seq1 );
     }
-
-
   }
 
   //////////////////////////////////////////////////////////////////////
@@ -131,12 +129,10 @@ class SubSea003 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
   {
-
     if( result.getResult( 0 ) == 1 )
     {
       player.finishQuest( getId() );
     }
-
   }
 
 };

--- a/src/scripts/quest/subquest/limsa/SubSea003.cpp
+++ b/src/scripts/quest/subquest/limsa/SubSea003.cpp
@@ -54,7 +54,7 @@ class SubSea003 : public Sapphire::ScriptAPI::QuestScript
     {
       case Actor0:
       {
-        if( !player.hasQuest( getId() ) )
+        if( quest.getSeq() == Seq0 )
           Scene00000( quest, player );
         else if( quest.getSeq() == SeqFinish )
           Scene00003( quest, player );

--- a/src/scripts/quest/subquest/limsa/SubSea003.cpp
+++ b/src/scripts/quest/subquest/limsa/SubSea003.cpp
@@ -1,0 +1,143 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubSea003_00113
+// Quest Name: Proper Procedure
+// Quest ID: 65649
+// Start NPC: 1001209 (Sweetnix Rosycheeks)
+// End NPC: 1001209 (Sweetnix Rosycheeks)
+
+using namespace Sapphire;
+
+class SubSea003 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // UI8AL
+    // UI8BH
+
+    /// Countable Num: 1 Seq: 1 Event: 1 Listener: 1000898
+    /// Countable Num: 1 Seq: 255 Event: 1 Listener: 1001209
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      Seq1 = 1,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto ActionTimelineGobEventItem = 759;
+    static constexpr auto ActionTimelineGobEventJoyBig = 945;
+    static constexpr auto ActionTimelineGobEventTrouble = 944;
+    static constexpr auto Actor0 = 1001209; // Sweetnix Rosycheeks ( Pos: -103.746002 18.500299 16.067699  Teri: 129 )
+    static constexpr auto Actor1 = 1000898; // P'tahjha ( Pos: -342.188995 12.909000 3.519940  Teri: 129 )
+    static constexpr auto Item0 = 2000448;
+
+  public:
+    SubSea003() : Sapphire::ScriptAPI::QuestScript( 65649 ){}; 
+    ~SubSea003() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        if( !player.hasQuest( getId() ) )
+          Scene00000( quest, player );
+        else if( quest.getSeq() == SeqFinish )
+          Scene00003( quest, player );
+        break;
+      }
+      case Actor1:
+      {
+        Scene00001( quest, player );
+        break;
+      }
+    }
+  }
+
+  void onEventItem( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+  }
+
+
+  private:
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, NONE, bindSceneReturn( &SubSea003::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      quest.setUI8BH( 1 );
+      quest.setSeq( Seq1 );
+    }
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, NONE, bindSceneReturn( &SubSea003::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 )
+    {
+      Scene00002( quest, player );
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00002( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 2, NONE, bindSceneReturn( &SubSea003::Scene00002Return ) );
+  }
+
+  void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setSeq( SeqFinish );
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00003( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 3, NONE, bindSceneReturn( &SubSea003::Scene00003Return ) );
+  }
+
+  void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      player.finishQuest( getId() );
+    }
+
+  }
+
+};
+
+EXPOSE_SCRIPT( SubSea003 );

--- a/src/scripts/quest/subquest/limsa/SubSea004.cpp
+++ b/src/scripts/quest/subquest/limsa/SubSea004.cpp
@@ -104,7 +104,6 @@ private:
         quest.setUI8CH( 1 );
       }
     }
-      
   }
   //////////////////////////////////////////////////////////////////////
   // Available Scenes in this quest, not necessarly all are used
@@ -121,8 +120,6 @@ private:
     {
       Scene00001( quest, player );
     }
-
-
   }
 
   //////////////////////////////////////////////////////////////////////
@@ -208,7 +205,6 @@ private:
     {
       player.finishQuest( getId() );
     }
-
   }
 
 };

--- a/src/scripts/quest/subquest/limsa/SubSea004.cpp
+++ b/src/scripts/quest/subquest/limsa/SubSea004.cpp
@@ -1,0 +1,219 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubSea004_00114
+// Quest Name: The Right Price
+// Quest ID: 65650
+// Start NPC: 1001217 (Swozblaet)
+// End NPC: 1003272 (Baensyng)
+
+using namespace Sapphire;
+
+class SubSea004 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // BitFlag8
+    // UI8AL
+    // UI8BH
+    // UI8BL
+    // UI8CH
+
+    /// Countable Num: 4 Seq: 1 Event: 1 Listener: 1001203
+    /// Countable Num: 1 Seq: 1 Event: 1 Listener: 1001208
+    /// Countable Num: 0 Seq: 1 Event: 1 Listener: 1003254
+    /// Countable Num: 0 Seq: 255 Event: 1 Listener: 1003272
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      Seq1 = 1,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1001217; // Swozblaet ( Pos: -140.856003 18.173401 17.013700  Teri: 129 )
+    static constexpr auto Actor1 = 1001203; // Iron Thunder ( Pos: -156.602997 18.173401 20.920000  Teri: 129 )
+    static constexpr auto Actor2 = 1001208; // Kyokyoroon ( Pos: -228.167999 15.976100 50.644600  Teri: 129 )
+    static constexpr auto Actor3 = 1003254; // Syneyhil ( Pos: -246.600998 16.189800 37.125099  Teri: 129 )
+    static constexpr auto Actor4 = 1003272; // Baensyng ( Pos: -262.928009 16.159300 51.407600  Teri: 129 )
+    static constexpr auto Item0 = 2000460;
+
+  public:
+    SubSea004() : Sapphire::ScriptAPI::QuestScript( 65650 ){}; 
+    ~SubSea004() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        Scene00000( quest, player );
+        break;
+      }
+      case Actor1:
+      {
+        Scene00002( quest, player );
+        break;
+      }
+      case Actor2:
+      {
+        Scene00003( quest, player );
+        break;
+      }
+      case Actor3:
+      {
+        Scene00004( quest, player );
+        break;
+      }
+      case Actor4:
+      {
+        Scene00005( quest, player );
+        break;
+      }
+    }
+  }
+
+  void onEventItem( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+  }
+
+
+private:
+  void checkQuestCompletion( World::Quest& quest, Entity::Player& player, uint32_t varIdx )
+  {
+    if (varIdx == 1)
+    {
+      auto actor1Talked = quest.getUI8AL();
+      auto actor2Talked = quest.getUI8BH();
+      auto actor3Talked = quest.getUI8BL();
+      if( actor1Talked && actor2Talked && actor3Talked )
+      {
+        quest.setSeq( SeqFinish );
+        quest.setUI8CH( 1 );
+        //quest.setUI8AL( 0 );
+        //quest.setUI8BH( 0 );
+        //quest.setUI8BL( 0 );
+      }
+    }
+      
+  }
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, NONE, bindSceneReturn( &SubSea004::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      Scene00001( quest, player );
+    }
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, NONE, bindSceneReturn( &SubSea004::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setSeq( Seq1 );
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00002( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 2, NONE, bindSceneReturn( &SubSea004::Scene00002Return ) );
+  }
+
+  void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    eventMgr().sendEventNotice( player, getId(), 0, 0 );
+    quest.setUI8AL( 1 );
+    checkQuestCompletion( quest, player, 1 );
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00003( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 3, NONE, bindSceneReturn( &SubSea004::Scene00003Return ) );
+  }
+
+  void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    eventMgr().sendEventNotice( player, getId(), 1, 0 );
+    quest.setUI8BH( 1 );
+    checkQuestCompletion( quest, player, 1 );
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00004( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 4, NONE, bindSceneReturn( &SubSea004::Scene00004Return ) );
+  }
+
+  void Scene00004Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    eventMgr().sendEventNotice( player, getId(), 2, 0 );
+    quest.setUI8BL( 1 );
+    checkQuestCompletion( quest, player, 1 );
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00005( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 5, NONE, bindSceneReturn( &SubSea004::Scene00005Return ) );
+  }
+
+  void Scene00005Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // hand in item
+    {
+      Scene00006( quest, player );
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00006( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 6, NONE, bindSceneReturn( &SubSea004::Scene00006Return ) );
+  }
+
+  void Scene00006Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      player.finishQuest( getId() );
+    }
+
+  }
+
+};
+
+EXPOSE_SCRIPT( SubSea004 );

--- a/src/scripts/quest/subquest/limsa/SubSea004.cpp
+++ b/src/scripts/quest/subquest/limsa/SubSea004.cpp
@@ -102,9 +102,6 @@ private:
       {
         quest.setSeq( SeqFinish );
         quest.setUI8CH( 1 );
-        //quest.setUI8AL( 0 );
-        //quest.setUI8BH( 0 );
-        //quest.setUI8BL( 0 );
       }
     }
       

--- a/src/scripts/quest/subquest/limsa/SubSea005.cpp
+++ b/src/scripts/quest/subquest/limsa/SubSea005.cpp
@@ -89,8 +89,6 @@ class SubSea005 : public Sapphire::ScriptAPI::QuestScript
     {
       Scene00001( quest, player );
     }
-
-
   }
 
   //////////////////////////////////////////////////////////////////////
@@ -158,12 +156,10 @@ class SubSea005 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00005Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
   {
-
     if( result.getResult( 0 ) == 1 )
     {
       player.finishQuest( getId() );
     }
-
   }
 
 };

--- a/src/scripts/quest/subquest/limsa/SubSea005.cpp
+++ b/src/scripts/quest/subquest/limsa/SubSea005.cpp
@@ -1,0 +1,171 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubSea005_00115
+// Quest Name: Duty Calls
+// Quest ID: 65651
+// Start NPC: 1000898 (P'tahjha)
+// End NPC: 1001537 (Latisha)
+
+using namespace Sapphire;
+
+class SubSea005 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // UI8AL
+    // UI8BH
+
+    /// Countable Num: 1 Seq: 1 Event: 1 Listener: 1001023
+    /// Countable Num: 1 Seq: 255 Event: 1 Listener: 1001537
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      Seq1 = 1,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1000898; // P'tahjha ( Pos: -342.188995 12.909000 3.519940  Teri: 129 )
+    static constexpr auto Actor1 = 1001023; // Sundhimal ( Pos: -78.629799 18.000299 -22.629200  Teri: 129 )
+    static constexpr auto Actor2 = 1001537; // Latisha ( Pos: -58.854099 42.282700 -164.050003  Teri: 128 )
+    static constexpr auto Item0 = 2000449;
+
+  public:
+    SubSea005() : Sapphire::ScriptAPI::QuestScript( 65651 ){}; 
+    ~SubSea005() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        Scene00000( quest, player );
+        break;
+      }
+      case Actor1:
+      {
+        Scene00002( quest, player );
+        break;
+      }
+      case Actor2:
+      {
+        Scene00004( quest, player );
+        break;
+      }
+    }
+  }
+
+  void onEventItem( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+  }
+
+
+  private:
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, NONE, bindSceneReturn( &SubSea005::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      Scene00001( quest, player );
+    }
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, NONE, bindSceneReturn( &SubSea005::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setUI8BH( 1 );
+    quest.setSeq( Seq1 );
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00002( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 2, NONE, bindSceneReturn( &SubSea005::Scene00002Return ) );
+  }
+
+  void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 )
+    {
+      Scene00003( quest, player );
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00003( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 3, NONE, bindSceneReturn( &SubSea005::Scene00003Return ) );
+  }
+
+  void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    eventMgr().sendEventNotice( player, getId(), 0, 0 );
+    quest.setSeq( SeqFinish );
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00004( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 4, NONE, bindSceneReturn( &SubSea005::Scene00004Return ) );
+  }
+
+  void Scene00004Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 )
+    {
+      Scene00005( quest, player );
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00005( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 5, NONE, bindSceneReturn( &SubSea005::Scene00005Return ) );
+  }
+
+  void Scene00005Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      player.finishQuest( getId() );
+    }
+
+  }
+
+};
+
+EXPOSE_SCRIPT( SubSea005 );

--- a/src/scripts/quest/subquest/limsa/SubSea007.cpp
+++ b/src/scripts/quest/subquest/limsa/SubSea007.cpp
@@ -159,12 +159,10 @@ class SubSea007 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00005Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
   {
-
     if( result.getResult( 0 ) == 1 )
     {
       player.finishQuest( getId() );
     }
-
   }
 
 };

--- a/src/scripts/quest/subquest/limsa/SubSea007.cpp
+++ b/src/scripts/quest/subquest/limsa/SubSea007.cpp
@@ -1,0 +1,172 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubSea007_00117
+// Quest Name: A Thousand Words
+// Quest ID: 65653
+// Start NPC: 1001537 (Latisha)
+// End NPC: 1000957 (R'sushmo)
+
+using namespace Sapphire;
+
+class SubSea007 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // UI8AL
+    // UI8BH
+
+    /// Countable Num: 1 Seq: 1 Event: 1 Listener: 1000957
+    /// Countable Num: 1 Seq: 2 Event: 1 Listener: 1000937
+    /// Countable Num: 0 Seq: 255 Event: 1 Listener: 1000957
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      Seq1 = 1,
+      Seq2 = 2,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1001537; // Latisha ( Pos: -58.854099 42.282700 -164.050003  Teri: 128 )
+    static constexpr auto Actor1 = 1000957; // R'sushmo ( Pos: -49.240898 43.991699 -146.380005  Teri: 128 )
+    static constexpr auto Actor2 = 1000937; // Godebert ( Pos: -12.222500 44.998798 -251.850006  Teri: 128 )
+    static constexpr auto Item0 = 2000455;
+
+  public:
+    SubSea007() : Sapphire::ScriptAPI::QuestScript( 65653 ){}; 
+    ~SubSea007() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        Scene00000( quest, player );
+        break;
+      }
+      case Actor1:
+      {
+        if( quest.getSeq() == Seq1 )
+          Scene00002( quest, player );
+        else
+          Scene00005( quest, player );
+        break;
+      }
+      case Actor2:
+      {
+        Scene00003( quest, player );
+        break;
+      }
+    }
+  }
+
+  void onEventItem( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+  }
+
+
+  private:
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, NONE, bindSceneReturn( &SubSea007::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      Scene00001( quest, player );
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, NONE, bindSceneReturn( &SubSea007::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setSeq( Seq1 );
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00002( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 2, NONE, bindSceneReturn( &SubSea007::Scene00002Return ) );
+  }
+
+  void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    eventMgr().sendEventNotice( player, getId(), 0, 0 ); // TODO: Show item icon
+    quest.setUI8BH( 1 );
+    quest.setSeq( Seq2 );
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00003( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 3, NONE, bindSceneReturn( &SubSea007::Scene00003Return ) );
+  }
+
+  void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 )
+    {
+      Scene00004( quest, player );
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00004( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 4, NONE, bindSceneReturn( &SubSea007::Scene00004Return ) );
+  }
+
+  void Scene00004Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    eventMgr().sendEventNotice( player, getId(), 1, 0 );
+    quest.setSeq( SeqFinish );
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00005( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 5, NONE, bindSceneReturn( &SubSea007::Scene00005Return ) );
+  }
+
+  void Scene00005Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      player.finishQuest( getId() );
+    }
+
+  }
+
+};
+
+EXPOSE_SCRIPT( SubSea007 );

--- a/src/scripts/quest/subquest/limsa/SubSea008.cpp
+++ b/src/scripts/quest/subquest/limsa/SubSea008.cpp
@@ -1,0 +1,220 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubSea008_00118
+// Quest Name: Licensed to Reave
+// Quest ID: 65654
+// Start NPC: 1000916 (Mordyn)
+// End NPC: 1000915 (Carvallain)
+
+using namespace Sapphire;
+
+class SubSea008 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // BitFlag8
+    // UI8AL
+    // UI8BH
+    // UI8BL
+
+    /// Countable Num: 1 Seq: 1 Event: 1 Listener: 1000915
+    /// Countable Num: 1 Seq: 2 Event: 1 Listener: 1000938
+    /// Countable Num: 1 Seq: 2 Event: 1 Listener: 1000947
+    /// Countable Num: 0 Seq: 255 Event: 1 Listener: 1000915
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      Seq1 = 1,
+      Seq2 = 2,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1000916; // Mordyn ( Pos: 1.778540 44.000000 -164.205002  Teri: 128 )
+    static constexpr auto Actor1 = 1000915; // Carvallain ( Pos: 18.387100 47.592899 -162.097000  Teri: 128 )
+    static constexpr auto Actor2 = 1000938; // Ginnade ( Pos: -4.651690 45.018398 -241.815002  Teri: 128 )
+    static constexpr auto Actor3 = 1000947; // Lyngsath ( Pos: -54.642601 43.991699 -151.201996  Teri: 128 )
+    static constexpr auto Item0 = 2000451;
+
+  public:
+    SubSea008() : Sapphire::ScriptAPI::QuestScript( 65654 ){}; 
+    ~SubSea008() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        Scene00000( quest, player );
+        break;
+      }
+      case Actor1:
+      {
+        if( quest.getSeq() == Seq1 )
+          Scene00002( quest, player );
+        else if( quest.getSeq() == SeqFinish )
+          Scene00007( quest, player );
+        break;
+      }
+      case Actor2:
+      {
+        Scene00003( quest, player );
+        break;
+      }
+      case Actor3:
+      {
+        Scene00005( quest, player );
+        break;
+      }
+    }
+  }
+
+  void onEventItem( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+  }
+
+
+private:
+  void checkQuestCompletion( World::Quest& quest, Entity::Player& player, uint32_t varIdx )
+  {
+    if( varIdx == 1 )
+    {
+      if( quest.getUI8AL() && quest.getUI8BH() )
+      {
+        quest.setSeq( SeqFinish );
+      }
+    }
+  }
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, NONE, bindSceneReturn( &SubSea008::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      Scene00001( quest, player );
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, NONE, bindSceneReturn( &SubSea008::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setSeq( Seq1 );
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00002( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 2, NONE, bindSceneReturn( &SubSea008::Scene00002Return ) );
+  }
+
+  void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setUI8BL( 1 );
+    eventMgr().sendEventNotice( player, getId(), 0, 0 ); //TODO: add item icon
+    quest.setSeq( Seq2 );
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00003( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 3, NONE, bindSceneReturn( &SubSea008::Scene00003Return ) );
+  }
+
+  void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 )
+    {
+      Scene00004( quest, player );
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00004( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 4, NONE, bindSceneReturn( &SubSea008::Scene00004Return ) );
+  }
+
+  void Scene00004Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    eventMgr().sendEventNotice( player, getId(), 1, 0 );
+    quest.setUI8AL( 1 );
+    checkQuestCompletion( quest, player, 1 );
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00005( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 5, NONE, bindSceneReturn( &SubSea008::Scene00005Return ) );
+  }
+
+  void Scene00005Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 )
+    {
+      Scene00006( quest, player );
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00006( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 6, NONE, bindSceneReturn( &SubSea008::Scene00006Return ) );
+  }
+
+  void Scene00006Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    eventMgr().sendEventNotice( player, getId(), 2, 0 );
+    quest.setUI8BH( 1 );
+    checkQuestCompletion( quest, player, 1 );
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00007( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 7, NONE, bindSceneReturn( &SubSea008::Scene00007Return ) );
+  }
+
+  void Scene00007Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 )
+    {
+      player.finishQuest( getId() );
+    }
+  }
+
+};
+
+EXPOSE_SCRIPT( SubSea008 );

--- a/src/scripts/quest/subquest/limsa/SubSea009.cpp
+++ b/src/scripts/quest/subquest/limsa/SubSea009.cpp
@@ -1,0 +1,130 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubSea009_00119
+// Quest Name: Lost and Found
+// Quest ID: 65655
+// Start NPC: 1000938 (Ginnade)
+// End NPC: 1002433 (N'delika)
+
+using namespace Sapphire;
+
+class SubSea009 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // UI8BH
+
+    /// Countable Num: 1 Seq: 255 Event: 1 Listener: 1002433
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1000938; // Ginnade ( Pos: -4.651690 45.018398 -241.815002  Teri: 128 )
+    static constexpr auto Actor1 = 1002433; // N'delika ( Pos: -6.698790 20.309700 -0.747742  Teri: 129 )
+    static constexpr auto Item0 = 2000453;
+
+  public:
+    SubSea009() : Sapphire::ScriptAPI::QuestScript( 65655 ){}; 
+    ~SubSea009() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        Scene00000( quest, player );
+        break;
+      }
+      case Actor1:
+      {
+        Scene00002( quest, player );
+        break;
+      }
+    }
+  }
+
+  void onEventItem( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+  }
+
+
+  private:
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, NONE, bindSceneReturn( &SubSea009::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      Scene00001( quest, player );
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, NONE, bindSceneReturn( &SubSea009::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setUI8BH( 1 );
+    quest.setSeq( SeqFinish );
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00002( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 2, NONE, bindSceneReturn( &SubSea009::Scene00002Return ) );
+  }
+
+  void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 )
+    {
+      Scene00003( quest, player );
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00003( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 3, NONE, bindSceneReturn( &SubSea009::Scene00003Return ) );
+  }
+
+  void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 )
+    {
+      player.finishQuest( getId() );
+    }
+  }
+
+};
+
+EXPOSE_SCRIPT( SubSea009 );

--- a/src/scripts/quest/subquest/limsa/SubSea011.cpp
+++ b/src/scripts/quest/subquest/limsa/SubSea011.cpp
@@ -1,0 +1,112 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubSea011_00121
+// Quest Name: Back in the Water
+// Quest ID: 65657
+// Start NPC: 1000857 (Sisipu)
+// End NPC: 1001000 (H'naanza)
+
+using namespace Sapphire;
+
+class SubSea011 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+
+    /// Countable Num: 1 Seq: 255 Event: 1 Listener: 1001000
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1000857; // Sisipu ( Pos: -165.270004 5.233830 164.294006  Teri: 129 )
+    static constexpr auto Actor1 = 1001000; // H'naanza ( Pos: -32.011700 41.500000 208.397003  Teri: 128 )
+
+  public:
+    SubSea011() : Sapphire::ScriptAPI::QuestScript( 65657 ){}; 
+    ~SubSea011() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        Scene00000( quest, player );
+        break;
+      }
+      case Actor1:
+      {
+        Scene00002( quest, player );
+        break;
+      }
+    }
+  }
+
+  void onEventItem( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+  }
+
+
+  private:
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, NONE, bindSceneReturn( &SubSea011::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      Scene00001( quest, player );
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, NONE, bindSceneReturn( &SubSea011::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setSeq( SeqFinish );
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00002( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 2, NONE, bindSceneReturn( &SubSea011::Scene00002Return ) );
+  }
+
+  void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 )
+    {
+      player.finishQuest( getId(), result.getResult( 1 ) );
+    }
+  }
+
+};
+
+EXPOSE_SCRIPT( SubSea011 );

--- a/src/scripts/quest/subquest/limsa/SubSea012.cpp
+++ b/src/scripts/quest/subquest/limsa/SubSea012.cpp
@@ -41,7 +41,7 @@ private:
   static constexpr auto Actor0 = 1003601;
   static constexpr auto Actor1 = 1001024;
   static constexpr auto Actor2 = 1000972;
-  static constexpr auto Enemy0 = 324;
+  static constexpr auto Enemy0 = 563;
   static constexpr auto Item0 = 2000454;
 
 public:
@@ -82,9 +82,14 @@ public:
     quest.setUI8AL( currentKC );
 
     if( currentKC >= 4 )
+    {
+      eventMgr().sendEventNotice( player, getId(), 1, 2, currentKC + 1, 4 );
       quest.setSeq( SeqFinish );
+    }
     else
+    {
       eventMgr().sendEventNotice( player, getId(), 1, 2, currentKC, 4 );
+    }
   }
 
 private:
@@ -126,6 +131,7 @@ private:
 
   void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
   {
+    eventMgr().sendEventNotice( player, getId(), 0, 0 );
     quest.setSeq( Seq2 );
   }
 

--- a/src/scripts/quest/subquest/limsa/SubSea013.cpp
+++ b/src/scripts/quest/subquest/limsa/SubSea013.cpp
@@ -1,0 +1,123 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include "Manager/EventMgr.h"
+#include <Actor/Player.h>
+#include <Actor/BNpc.h>
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubSea013_00661
+// Quest Name: The Rats in the Wharf
+// Quest ID: 66197
+// Start NPC: 1001000 (H'naanza)
+// End NPC: 1000972 (Baderon)
+
+using namespace Sapphire;
+
+class SubSea013 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // UI8AL
+
+    /// Countable Num: 0 Seq: 1 Event: 5 Listener: 347
+    /// Countable Num: 0 Seq: 255 Event: 1 Listener: 1000972
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      Seq1 = 1,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1001000; // H'naanza ( Pos: -32.011700 41.500000 208.397003  Teri: 128 )
+    static constexpr auto Actor1 = 1000972; // Baderon ( Pos: 20.297800 40.199902 -6.102400  Teri: 128 )
+    static constexpr auto Enemy0 = 417;
+
+  public:
+    SubSea013() : Sapphire::ScriptAPI::QuestScript( 66197 ){}; 
+    ~SubSea013() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        Scene00000( quest, player );
+        break;
+      }
+      case Actor1:
+      {
+        Scene00001( quest, player );
+        break;
+      }
+    }
+  }
+
+  void onBNpcKill( World::Quest& quest, Sapphire::Entity::BNpc& bnpc, Sapphire::Entity::Player& player ) override
+  {
+    if( bnpc.getBNpcNameId() != Enemy0 )
+      return;
+
+    auto currentKC = quest.getUI8AL();
+
+    if( currentKC + 1 >= 5 )
+    {
+      eventMgr().sendEventNotice( player, getId(), 0, 2, currentKC + 1, 5 );
+      quest.setSeq( SeqFinish );
+    }
+    else
+    {
+      quest.setUI8AL( currentKC + 1 );
+      eventMgr().sendEventNotice( player, getId(), 0, 2, currentKC + 1, 5 );
+    }
+  }
+
+  private:
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, NONE, bindSceneReturn( &SubSea013::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      quest.setSeq( Seq1 );
+    }
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, NONE, bindSceneReturn( &SubSea013::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 ) // complete quest
+    {
+      player.finishQuest( getId(), result.getResult( 1 ) );
+    }
+
+  }
+
+};
+
+EXPOSE_SCRIPT( SubSea013 );

--- a/src/scripts/quest/subquest/limsa/SubSea014.cpp
+++ b/src/scripts/quest/subquest/limsa/SubSea014.cpp
@@ -1,0 +1,261 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+#include <string> 
+// Quest Script: SubSea014_00662
+// Quest Name: Soothing the Savage Siren
+// Quest ID: 66198
+// Start NPC: 1000919 (O'kalkaya)
+// End NPC: 1000919 (O'kalkaya)
+
+using namespace Sapphire;
+
+class SubSea014 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // UI8AL
+
+    /// Countable Num: 0 Seq: 1 Event: 1 Listener: 1000918
+    /// Countable Num: 0 Seq: 2 Event: 2 Listener: 1000918
+    /// Countable Num: 0 Seq: 3 Event: 1 Listener: 1000918
+    /// Countable Num: 0 Seq: 255 Event: 2 Listener: 1000918
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      Seq1 = 1,
+      Seq2 = 2,
+      Seq3 = 3,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1000919; // O'kalkaya ( Pos: 46.677399 44.659901 137.102005  Teri: 128 )
+    static constexpr auto Actor1 = 1000918; // Rhoswen ( Pos: 84.114304 44.428001 132.360001  Teri: 128 )
+    static constexpr auto FirstQuest = 65643;
+    static constexpr auto EmoteKneel = 19;
+    static constexpr auto EmoteDisappointed = 49;
+    static constexpr auto EmoteRally = 34;
+
+  public:
+    SubSea014() : Sapphire::ScriptAPI::QuestScript( 66198 ){}; 
+    ~SubSea014() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        if( quest.getSeq() == Seq0 )
+          Scene00000( quest, player );
+        else if( quest.getSeq() == SeqFinish )
+          Scene00011( quest, player );
+        break;
+      }
+      case Actor1:
+      {
+        if( quest.getSeq() == Seq1 )
+          Scene00002( quest, player );
+        else if( quest.getSeq() == Seq2 )
+          Scene00007( quest, player );
+        else if( quest.getSeq() == Seq3 )
+          Scene00010( quest, player );
+        break;
+      }
+    }
+  }
+
+  void onEmote( World::Quest& quest, uint64_t actorId, uint32_t emoteId, Entity::Player& player ) override
+  {
+    std::string s = std::to_string( emoteId );
+    Sapphire::World::Manager::PlayerMgr::sendDebug( player, s );
+    if( emoteId == EmoteKneel && quest.getSeq() == Seq1 )
+    {
+      Scene00003( quest, player );
+    }
+    else if (emoteId == EmoteDisappointed && quest.getSeq() == Seq2) {
+      Scene00006( quest, player );
+    }
+    else if( emoteId == EmoteRally && quest.getSeq() == Seq3 )
+    {
+      Scene00009( quest, player );
+    }
+  }
+
+
+  private:
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, NONE, bindSceneReturn( &SubSea014::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      Scene00001( quest, player );
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, NONE, bindSceneReturn( &SubSea014::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setSeq( Seq1 );
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00002( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 2, NONE, bindSceneReturn( &SubSea014::Scene00002Return ) );
+  }
+
+  void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00003( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 3, NONE, bindSceneReturn( &SubSea014::Scene00003Return ) );
+  }
+
+  void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    eventMgr().sendEventNotice( player, getId(), 0, 0 );
+    quest.setSeq( Seq2 );    
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00004( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 4, NONE, bindSceneReturn( &SubSea014::Scene00004Return ) );
+  }
+
+  void Scene00004Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00005( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 5, NONE, bindSceneReturn( &SubSea014::Scene00005Return ) );
+  }
+
+  void Scene00005Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00006( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 6, NONE, bindSceneReturn( &SubSea014::Scene00006Return ) );
+  }
+
+  void Scene00006Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    eventMgr().sendEventNotice( player, getId(), 0, 1 );
+    quest.setSeq( Seq3 );    
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00007( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 7, NONE, bindSceneReturn( &SubSea014::Scene00007Return ) );
+  }
+
+  void Scene00007Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00008( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 8, NONE, bindSceneReturn( &SubSea014::Scene00008Return ) );
+  }
+
+  void Scene00008Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00009( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 9, NONE, bindSceneReturn( &SubSea014::Scene00009Return ) );
+  }
+
+  void Scene00009Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    eventMgr().sendEventNotice( player, getId(), 0, 2 );
+    quest.setSeq( SeqFinish );
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00010( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 10, NONE, bindSceneReturn( &SubSea014::Scene00010Return ) );
+  }
+
+  void Scene00010Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00011( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 11, NONE, bindSceneReturn( &SubSea014::Scene00011Return ) );
+  }
+
+  void Scene00011Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 )
+    {
+      player.finishQuest( getId() );
+    }
+  }
+
+};
+
+EXPOSE_SCRIPT( SubSea014 );

--- a/src/scripts/quest/subquest/limsa/SubSea015.cpp
+++ b/src/scripts/quest/subquest/limsa/SubSea015.cpp
@@ -1,0 +1,114 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubSea015_00663
+// Quest Name: Fool Me Once
+// Quest ID: 66199
+// Start NPC: 1000981 (Niniya)
+// End NPC: 1002605 (Ancreta)
+
+using namespace Sapphire;
+
+class SubSea015 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+
+    /// Countable Num: 0 Seq: 255 Event: 1 Listener: 1002605
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1000981; // Niniya ( Pos: 8.525760 39.517601 3.576400  Teri: 128 )
+    static constexpr auto Actor1 = 1002605; // Ancreta ( Pos: 277.960999 45.144100 33.661400  Teri: 135 )
+
+  public:
+    SubSea015() : Sapphire::ScriptAPI::QuestScript( 66199 ){}; 
+    ~SubSea015() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        Scene00000( quest, player );
+        break;
+      }
+      case Actor1:
+      {
+        Scene00002( quest, player );
+        break;
+      }
+    }
+  }
+
+  void onEventItem( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+  }
+
+
+  private:
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, NONE, bindSceneReturn( &SubSea015::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      Scene00001( quest, player );
+    }
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, NONE, bindSceneReturn( &SubSea015::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setSeq( SeqFinish );
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00002( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 2, NONE, bindSceneReturn( &SubSea015::Scene00002Return ) );
+  }
+
+  void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 )
+    {
+      player.finishQuest( getId() );
+    }
+
+  }
+};
+
+EXPOSE_SCRIPT( SubSea015 );

--- a/src/scripts/quest/subquest/limsa/SubSea015.cpp
+++ b/src/scripts/quest/subquest/limsa/SubSea015.cpp
@@ -78,8 +78,6 @@ class SubSea015 : public Sapphire::ScriptAPI::QuestScript
     {
       Scene00001( quest, player );
     }
-
-
   }
 
   //////////////////////////////////////////////////////////////////////

--- a/src/scripts/quest/subquest/limsa/SubSea016.cpp
+++ b/src/scripts/quest/subquest/limsa/SubSea016.cpp
@@ -1,0 +1,165 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubSea016_00323
+// Quest Name: Edelweiss, Edelweiss
+// Quest ID: 65859
+// Start NPC: 1003355 (J'nasshym)
+// End NPC: 1003355 (J'nasshym)
+
+using namespace Sapphire;
+
+class SubSea016 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // BitFlag8
+    // UI8AL
+    // UI8BH
+
+    /// Countable Num: 1 Seq: 1 Event: 1 Listener: 1009944
+    /// Countable Num: 1 Seq: 255 Event: 1 Listener: 1003355
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      Seq1 = 1,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1003355; // J'nasshym ( Pos: -60.856499 18.000299 7.495960  Teri: 129 )
+    static constexpr auto Actor1 = 1009944; // Lonwoerd ( Pos: -152.656006 2.856240 243.188004  Teri: 129 )
+    static constexpr auto EvtAction1 = 1061;
+    static constexpr auto Item0 = 2001513;
+    static constexpr auto QstClsrog011 = 65638;
+
+  public:
+    SubSea016() : Sapphire::ScriptAPI::QuestScript( 65859 ){}; 
+    ~SubSea016() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        if( quest.getSeq() == Seq0 )
+          Scene00000( quest, player );
+        else if( quest.getSeq() == Seq1 )
+          Scene00004( quest, player );
+        else if( quest.getSeq() == SeqFinish )
+          Scene00005( quest, player );
+        break;
+      }
+      case Actor1:
+      {
+        Scene00002( quest, player );
+        break;
+      }
+    }
+  }
+
+  void onEventItem( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+  }
+
+
+  private:
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, NONE, bindSceneReturn( &SubSea016::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      Scene00001( quest, player );
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, NONE, bindSceneReturn( &SubSea016::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setUI8BH( 1 );
+    quest.setSeq( Seq1 );
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00002( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 2, NONE, bindSceneReturn( &SubSea016::Scene00002Return ) );
+  }
+
+  void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 )
+    {
+      Scene00003( quest, player );
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00003( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 3, NONE, bindSceneReturn( &SubSea016::Scene00003Return ) );
+  }
+
+  void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    eventMgr().sendEventNotice( player, getId(), 0, 0 );
+    quest.setSeq( SeqFinish );
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00004( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 4, NONE, bindSceneReturn( &SubSea016::Scene00004Return ) );
+  }
+
+  void Scene00004Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00005( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 5, NONE, bindSceneReturn( &SubSea016::Scene00005Return ) );
+  }
+
+  void Scene00005Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 )
+    {
+      player.finishQuest( getId() );
+    }
+  }
+};
+
+EXPOSE_SCRIPT( SubSea016 );


### PR DESCRIPTION
Implemented:
- SubSea002 - Suspiciously Sober
- SubSea003 - Proper Procedure
- SubSea004 - The Right Price
- SubSea005 - Duty Calls
- SubSea007 - A Thousand Words
- SubSea008 - Licensed To Reave
- SubSea009 - Lost and Found
- SubSea011 - Back in the Water
- SubSea013 - The Rats in the Wharf
- SubSea014 - Soothing the Savage Siren
- SubSea015 - Fool Me Once
- SubSea016 - Edelweiss, Edelweiss

Updated:
- SubSea012 - Glory Days
    > Fixed Enemy0 Id and added EventNotices for onBNpcKill and onTalk