### PR TITLE
Fixed lambda functions not running during some starting quests and added HIDE_HOTBAR to some Limsa sidequests

### DIFF
--- a/src/scripts/quest/ManSea003.cpp
+++ b/src/scripts/quest/ManSea003.cpp
@@ -64,7 +64,7 @@ public:
   {
     if( actorId == Actor0 )
     {
-      Scene00000( player );
+      Scene00000( quest, player );
     }
     else if( actorId == Aetheryte0 )
     {
@@ -74,27 +74,27 @@ public:
                                      eventMgr().sendEventNotice( player, 0x050002, 0, 1, 0, 0 );
                                      player.registerAetheryte( 2 );
                                      player.setRewardFlag( Common::UnlockEntry::Return );
-                                     Scene00002( player );
+                                     Scene00002( quest, player );
                                    },
                                    nullptr, getId() );
     }
     else if( actorId == Actor1 )
     {
-      Scene00004( player );
+      Scene00004( quest, player );
     }
     else if( actorId == Actor2 )
     {
-      Scene00006( player );
+      Scene00006( quest, player );
     }
     else if( actorId == Actor3 )
     {
-      Scene00007( player );
+      Scene00007( quest, player );
     }
   }
 
 private:
 
-  void checkQuestCompletion( Entity::Player& player, uint32_t varIdx )
+  void checkQuestCompletion( World::Quest& quest, Entity::Player& player, uint32_t varIdx )
   {
     if( varIdx == 1 )
     {
@@ -121,110 +121,121 @@ private:
 
     if( QUEST_VAR_ATTUNE == 1 && QUEST_VAR_CLASS == 1 && QUEST_VAR_TRADE == 1 )
     {
-      pQuest->setSeq( SeqFinish );
+      quest.setSeq( SeqFinish );
     }
   }
 
-  void Scene00000( Entity::Player& player )
+  void Scene00000( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playScene( player, getId(), 0, HIDE_HOTBAR,
-                          [ & ]( Entity::Player& player, const Event::SceneResult& result )
-                          {
-                            if( result.getResult( 0 ) == 1 )
-                            {
-                              Scene00001( player );
-                            }
-                          } );
+    eventMgr().playQuestScene( player, getId(), 0, NONE, bindSceneReturn( &ManSea003::Scene00000Return ) );
   }
 
-  void Scene00001( Entity::Player& player )
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
   {
-    eventMgr().playScene( player, getId(), 1, FADE_OUT | CONDITION_CUTSCENE | HIDE_UI,
-                          [ & ]( Entity::Player& player, const Event::SceneResult& result )
-                          {
-                            auto pQuest = player.getQuest( getId() );
-                            if( !pQuest )
-                              return;
-
-                            pQuest->setSeq( Seq1 );
-                            pQuest->setUI8CH( 1 );
-                          } );
+    if( result.getResult( 0 ) == 1 )// accept quest
+    {
+      Scene00001( quest, player );
+    }
   }
 
-  void Scene00002( Entity::Player& player )
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playScene( player, getId(), 2, HIDE_HOTBAR,
-                          [ & ]( Entity::Player& player, const Event::SceneResult& result )
-                          {
-                            Scene00003( player );
-                          } );
+    eventMgr().playQuestScene( player, getId(), 1, FADE_OUT | CONDITION_CUTSCENE | HIDE_UI, bindSceneReturn( &ManSea003::Scene00001Return ) );
   }
 
-  void Scene00003( Entity::Player& player )
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
   {
-    eventMgr().playScene( player, getId(), 3, SET_EOBJ_BASE | HIDE_HOTBAR | INVIS_EOBJ,
-                          [ & ]( Entity::Player& player, const Event::SceneResult& result )
-                          {
-                            auto pQuest = player.getQuest( getId() );
-                            if( !pQuest )
-                              return;
-                            pQuest->setUI8BL( 1 );
-                            checkQuestCompletion( player, 0 );
-                          } );
+    quest.setSeq( Seq1 );
+    quest.setUI8CH( 1 );
   }
 
-  void Scene00004( Entity::Player& player )
+  //////////////////////////////////////////////////////////////////////
+
+
+  void Scene00002( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playScene( player, getId(), 4, HIDE_HOTBAR,
-                          [ & ]( Entity::Player& player, const Event::SceneResult& result )
-                          {
-                            if( result.getResult( 0 ) == 1 )
-                            {
-                              Scene00005( player );
-                            }
-                            else
-                              return;
-                          } );
+    eventMgr().playQuestScene( player, getId(), 2, HIDE_HOTBAR, bindSceneReturn( &ManSea003::Scene00002Return ) );
   }
 
-  void Scene00005( Entity::Player& player )
+  void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
   {
-    eventMgr().playScene( player, getId(), 5, SET_EOBJ_BASE | HIDE_HOTBAR | INVIS_EOBJ,
-                          [ & ]( Entity::Player& player, const Event::SceneResult& result )
-                          {
-                            auto pQuest = player.getQuest( getId() );
-                            if( !pQuest )
-                              return;
-                            pQuest->setUI8CH( 0 );
-                            pQuest->setUI8BH( 1 );
-                            checkQuestCompletion( player, 1 );
-                          } );
+    Scene00003( quest, player );
   }
 
-  void Scene00006( Entity::Player& player )
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00003( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playScene( player, getId(), 6, HIDE_HOTBAR,
-                          [ & ]( Entity::Player& player, const Event::SceneResult& result )
-                          {
-                            auto pQuest = player.getQuest( getId() );
-                            if( !pQuest )
-                              return;
-                            pQuest->setUI8AL( 1 );
-                            checkQuestCompletion( player, 2 );
-                          } );
+    eventMgr().playQuestScene( player, getId(), 3, SET_EOBJ_BASE | HIDE_HOTBAR | INVIS_EOBJ, bindSceneReturn( &ManSea003::Scene00003Return ) );
   }
 
-  void Scene00007( Entity::Player& player )
+  void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
   {
-    eventMgr().playScene( player, getId(), 7, SET_EOBJ_BASE | HIDE_HOTBAR | INVIS_EOBJ,
-                          [ & ]( Entity::Player& player, const Event::SceneResult& result )
-                          {
-                            if( result.getResult( 0 ) == 1 )
-                            {
-                              player.finishQuest( getId(), result.getResult( 1 ) );
-                            }
-                          } );
+    quest.setUI8BL( 1 );
+    checkQuestCompletion( quest, player, 1 );
   }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00004( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 4, HIDE_HOTBAR, bindSceneReturn( &ManSea003::Scene00004Return ) );
+  }
+
+  void Scene00004Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 )
+    {
+      Scene00005( quest, player );
+    }
+    else
+      return;
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00005( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 5, SET_EOBJ_BASE | HIDE_HOTBAR | INVIS_EOBJ, bindSceneReturn( &ManSea003::Scene00005Return ) );
+  }
+
+  void Scene00005Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setUI8CH( 0 );
+    quest.setUI8BH( 1 );
+    checkQuestCompletion( quest, player, 1 );
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00006( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 6, HIDE_HOTBAR, bindSceneReturn( &ManSea003::Scene00006Return ) );
+  }
+
+  void Scene00006Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setUI8AL( 1 );
+    checkQuestCompletion( quest, player, 2 );
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00007( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 7, SET_EOBJ_BASE | HIDE_HOTBAR | INVIS_EOBJ, bindSceneReturn( &ManSea003::Scene00007Return ) );
+  }
+
+  void Scene00007Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 )
+    {
+      player.finishQuest( getId(), result.getResult( 1 ) );
+    }
+  }
+
 };
 
 EXPOSE_SCRIPT( ManSea003 );

--- a/src/scripts/quest/ManSea003.cpp
+++ b/src/scripts/quest/ManSea003.cpp
@@ -138,8 +138,6 @@ private:
     }
   }
 
-  //////////////////////////////////////////////////////////////////////
-
   void Scene00001( World::Quest& quest, Entity::Player& player )
   {
     eventMgr().playQuestScene( player, getId(), 1, FADE_OUT | CONDITION_CUTSCENE | HIDE_UI, bindSceneReturn( &ManSea003::Scene00001Return ) );
@@ -151,9 +149,6 @@ private:
     quest.setUI8CH( 1 );
   }
 
-  //////////////////////////////////////////////////////////////////////
-
-
   void Scene00002( World::Quest& quest, Entity::Player& player )
   {
     eventMgr().playQuestScene( player, getId(), 2, HIDE_HOTBAR, bindSceneReturn( &ManSea003::Scene00002Return ) );
@@ -163,8 +158,6 @@ private:
   {
     Scene00003( quest, player );
   }
-
-  //////////////////////////////////////////////////////////////////////
 
   void Scene00003( World::Quest& quest, Entity::Player& player )
   {
@@ -176,8 +169,6 @@ private:
     quest.setUI8BL( 1 );
     checkQuestCompletion( quest, player, 1 );
   }
-
-  //////////////////////////////////////////////////////////////////////
 
   void Scene00004( World::Quest& quest, Entity::Player& player )
   {
@@ -194,8 +185,6 @@ private:
       return;
   }
 
-  //////////////////////////////////////////////////////////////////////
-
   void Scene00005( World::Quest& quest, Entity::Player& player )
   {
     eventMgr().playQuestScene( player, getId(), 5, SET_EOBJ_BASE | HIDE_HOTBAR | INVIS_EOBJ, bindSceneReturn( &ManSea003::Scene00005Return ) );
@@ -208,8 +197,6 @@ private:
     checkQuestCompletion( quest, player, 1 );
   }
 
-  //////////////////////////////////////////////////////////////////////
-
   void Scene00006( World::Quest& quest, Entity::Player& player )
   {
     eventMgr().playQuestScene( player, getId(), 6, HIDE_HOTBAR, bindSceneReturn( &ManSea003::Scene00006Return ) );
@@ -220,8 +207,6 @@ private:
     quest.setUI8AL( 1 );
     checkQuestCompletion( quest, player, 2 );
   }
-
-  //////////////////////////////////////////////////////////////////////
 
   void Scene00007( World::Quest& quest, Entity::Player& player )
   {

--- a/src/scripts/quest/ManWil003.cpp
+++ b/src/scripts/quest/ManWil003.cpp
@@ -61,27 +61,25 @@ public:
   {
   };
 
-  ~ManWil003()
-  {
-  };
+  ~ManWil003() = default; 
 
   void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
   {
     if( actorId == Actor0 )
     {
-      Scene00000( player );
+      Scene00000( quest, player );
     }
     else if( actorId == Actor1 )
     {
-      Scene00003( player );
+      Scene00003( quest, player );
     }
     else if( actorId == Actor2 )
     {
-      Scene00004( player );
+      Scene00004( quest, player );
     }
     else if( actorId == Actor3 )
     {
-      Scene00008( player );
+      Scene00008( quest, player );
     }
     else if( actorId == Aetheryte0 )
     {
@@ -91,7 +89,7 @@ public:
                                  eventMgr().sendEventNotice( player, 0x050002, 0, 1, 0, 0 );
                                  player.registerAetheryte( 2 );
                                  player.setRewardFlag( Common::UnlockEntry::Return );
-                                 Scene00001( player );
+                                 Scene00001( quest, player );
                                },
                                nullptr, getId() );
     }
@@ -99,7 +97,7 @@ public:
 
 private:
 
-  void checkQuestCompletion( Entity::Player& player, uint32_t varIdx )
+  void checkQuestCompletion( World::Quest& quest, Entity::Player& player, uint32_t varIdx )
   {
     if( varIdx == 1 )
     {
@@ -114,138 +112,122 @@ private:
       eventMgr().sendEventNotice( player, getId(), 0, 0, 0, 0 );
     }
 
-    auto pQuest = player.getQuest( getId() );
-    if( !pQuest )
-      return;
-
-    auto QUEST_VAR_ATTUNE = pQuest->getUI8AL();
-    auto QUEST_VAR_CLASS = pQuest->getUI8BH();
-    auto QUEST_VAR_TRADE = pQuest->getUI8BL();
+    auto QUEST_VAR_ATTUNE = quest.getUI8AL();
+    auto QUEST_VAR_CLASS = quest.getUI8BH();
+    auto QUEST_VAR_TRADE = quest.getUI8BL();
 
     if( QUEST_VAR_ATTUNE == 1 && QUEST_VAR_CLASS == 1 && QUEST_VAR_TRADE == 1 )
     {
-      pQuest->setSeq( SeqFinish );
+      quest.setSeq( SeqFinish );
     }
   }
 
-  void Scene00000( Entity::Player& player )
+  void Scene00000( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playScene( player, getId(), 0, HIDE_HOTBAR,
-                      [ & ]( Entity::Player& player, const Event::SceneResult& result )
-                      {
-                        if( result.getResult( 0 ) == 1 ) // accept quest
-                        {
-                          Scene00050( player );
-                        }
-                      } );
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &ManWil003::Scene00000Return ) );
   }
 
-  void Scene00001( Entity::Player& player )
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
   {
-    eventMgr().playScene( player, getId(), 1, HIDE_HOTBAR,
-                      [ & ]( Entity::Player& player, const Event::SceneResult& result )
-                      {
-                        Scene00002( player );
-                      } );
+    if( result.getResult( 0 ) == 1 )// accept quest
+    {
+      Scene00050( quest, player );
+    }
   }
 
-  void Scene00002( Entity::Player& player )
+  void Scene00001( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playScene( player, getId(), 2, SET_EOBJ_BASE | HIDE_HOTBAR | INVIS_EOBJ,
-                      [ & ]( Entity::Player& player, const Event::SceneResult& result )
-                      {
-                        auto pQuest = player.getQuest( getId() );
-                        if( !pQuest )
-                          return;
-                        pQuest->setUI8BL( 1 );
-                        checkQuestCompletion( player, 0 );
-                      } );
+    eventMgr().playQuestScene( player, getId(), 1, HIDE_HOTBAR, bindSceneReturn( &ManWil003::Scene00001Return ) );
   }
 
-  void Scene00003( Entity::Player& player )
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
   {
-    eventMgr().playScene( player, getId(), 3, HIDE_HOTBAR,
-                      [ & ]( Entity::Player& player, const Event::SceneResult& result )
-                      {
-                        auto pQuest = player.getQuest( getId() );
-                        if( !pQuest )
-                          return;
-                        pQuest->setUI8AL( 1 );
-                        checkQuestCompletion( player, 1 );
-                      } );
+    Scene00002( quest, player );
   }
 
-  void Scene00004( Entity::Player& player )
+  void Scene00002( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playScene( player, getId(), 4, HIDE_HOTBAR,
-                      [ & ]( Entity::Player& player, const Event::SceneResult& result )
-                      {
-                        if( result.getResult( 0 ) == 1 )
-                        {
-                          Scene00005( player );
-                        }
-                        else
-                          return;
-                      } );
+    eventMgr().playQuestScene( player, getId(), 2, SET_EOBJ_BASE | HIDE_HOTBAR | INVIS_EOBJ, bindSceneReturn( &ManWil003::Scene00002Return ) );
   }
 
-  void Scene00005( Entity::Player& player )
+  void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
   {
-    eventMgr().playScene( player, getId(), 5, SET_EOBJ_BASE | HIDE_HOTBAR | INVIS_EOBJ,
-                      [ & ]( Entity::Player& player, const Event::SceneResult& result )
-                      {
-                        auto pQuest = player.getQuest( getId() );
-                        if( !pQuest )
-                          return;
-                        pQuest->setUI8CH( 0 );
-                        pQuest->setUI8BH( 1 );
-                        checkQuestCompletion( player, 2 );
-                      } );
+    quest.setUI8BL( 1 );
+    checkQuestCompletion( quest, player, 0 );
   }
 
-  void Scene00006( Entity::Player& player )
+  void Scene00003( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playScene( player, getId(), 6, HIDE_HOTBAR,
-                      [ & ]( Entity::Player& player, const Event::SceneResult& result )
-                      {
-                      } );
+    eventMgr().playQuestScene( player, getId(), 3, HIDE_HOTBAR, bindSceneReturn( &ManWil003::Scene00003Return ) );
   }
 
-  void Scene00007( Entity::Player& player )
+  void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
   {
-    eventMgr().playScene( player, getId(), 7, HIDE_HOTBAR,
-                      [ & ]( Entity::Player& player, const Event::SceneResult& result )
-                      {
-                      } );
+    quest.setUI8AL( 1 );
+    checkQuestCompletion( quest, player, 1 );
   }
 
-  void Scene00008( Entity::Player& player )
+  void Scene00004( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playScene( player, getId(), 8, SET_EOBJ_BASE | HIDE_HOTBAR | INVIS_EOBJ,
-                      [ & ]( Entity::Player& player, const Event::SceneResult& result )
-                      {
-                        if( result.getResult( 0 ) == 1 )
-                        {
-                          player.finishQuest( getId(), result.getResult( 1 ) );
-                        }
-                      } );
+    eventMgr().playQuestScene( player, getId(), 4, HIDE_HOTBAR, bindSceneReturn( &ManWil003::Scene00004Return ) );
   }
 
-  void Scene00050( Entity::Player& player )
+  void Scene00004Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
   {
-    eventMgr().playScene( player, getId(), 50, FADE_OUT | CONDITION_CUTSCENE | HIDE_UI,
-                      [ & ]( Entity::Player& player, const Event::SceneResult& result )
-                      {
-                        auto pQuest = player.getQuest( getId() );
-                        if( !pQuest )
-                          return;
-                        // on quest accept
-                        pQuest->setSeq( Seq1 );
-                        pQuest->setUI8CH( 1 ); // receive key item
+    if( result.getResult( 0 ) == 1 )
+    {
+      Scene00005( quest, player );
+    }
+  }
 
-                        // teleport to real ul'dah
-                        warpMgr().requestMoveTerritoryType( player, Common::WarpType::WARP_TYPE_NORMAL, 130 );
-                      } );
+  void Scene00005( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 5, SET_EOBJ_BASE | HIDE_HOTBAR | INVIS_EOBJ, bindSceneReturn( &ManWil003::Scene00005Return ) );
+  }
+
+  void Scene00005Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setUI8CH( 0 );
+    quest.setUI8BH( 1 );
+    checkQuestCompletion( quest, player, 2 );
+  }
+
+  void Scene00006( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 6, HIDE_HOTBAR );
+  }
+
+  void Scene00007( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 7, HIDE_HOTBAR );
+  }
+
+  void Scene00008( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 8, SET_EOBJ_BASE | HIDE_HOTBAR | INVIS_EOBJ, bindSceneReturn( &ManWil003::Scene00008Return ) );
+  }
+
+  void Scene00008Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 )
+    {
+      player.finishQuest( getId(), result.getResult( 1 ) );
+    }
+  }
+
+  void Scene00050( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 50, FADE_OUT | CONDITION_CUTSCENE | HIDE_UI, bindSceneReturn( &ManWil003::Scene00050Return ) );
+  }
+
+  void Scene00050Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    // on quest accept
+    quest.setSeq( Seq1 );
+    quest.setUI8CH( 1 ); // receive key item
+
+    // teleport to real ul'dah
+    warpMgr().requestMoveTerritoryType( player, Common::WarpType::WARP_TYPE_NORMAL, 130 );
   }
 };
 

--- a/src/scripts/quest/subquest/limsa/SubSea003.cpp
+++ b/src/scripts/quest/subquest/limsa/SubSea003.cpp
@@ -80,7 +80,7 @@ class SubSea003 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00000( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 0, NONE, bindSceneReturn( &SubSea003::Scene00000Return ) );
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &SubSea003::Scene00000Return ) );
   }
 
   void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -96,7 +96,7 @@ class SubSea003 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00001( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 1, NONE, bindSceneReturn( &SubSea003::Scene00001Return ) );
+    eventMgr().playQuestScene( player, getId(), 1, HIDE_HOTBAR, bindSceneReturn( &SubSea003::Scene00001Return ) );
   }
 
   void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -111,7 +111,7 @@ class SubSea003 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00002( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 2, NONE, bindSceneReturn( &SubSea003::Scene00002Return ) );
+    eventMgr().playQuestScene( player, getId(), 2, HIDE_HOTBAR, bindSceneReturn( &SubSea003::Scene00002Return ) );
   }
 
   void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -124,7 +124,7 @@ class SubSea003 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00003( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 3, NONE, bindSceneReturn( &SubSea003::Scene00003Return ) );
+    eventMgr().playQuestScene( player, getId(), 3, HIDE_HOTBAR, bindSceneReturn( &SubSea003::Scene00003Return ) );
   }
 
   void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )

--- a/src/scripts/quest/subquest/limsa/SubSea004.cpp
+++ b/src/scripts/quest/subquest/limsa/SubSea004.cpp
@@ -111,7 +111,7 @@ private:
 
   void Scene00000( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 0, NONE, bindSceneReturn( &SubSea004::Scene00000Return ) );
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &SubSea004::Scene00000Return ) );
   }
 
   void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -126,7 +126,7 @@ private:
 
   void Scene00001( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 1, NONE, bindSceneReturn( &SubSea004::Scene00001Return ) );
+    eventMgr().playQuestScene( player, getId(), 1, HIDE_HOTBAR, bindSceneReturn( &SubSea004::Scene00001Return ) );
   }
 
   void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -138,7 +138,7 @@ private:
 
   void Scene00002( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 2, NONE, bindSceneReturn( &SubSea004::Scene00002Return ) );
+    eventMgr().playQuestScene( player, getId(), 2, HIDE_HOTBAR, bindSceneReturn( &SubSea004::Scene00002Return ) );
   }
 
   void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -152,7 +152,7 @@ private:
 
   void Scene00003( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 3, NONE, bindSceneReturn( &SubSea004::Scene00003Return ) );
+    eventMgr().playQuestScene( player, getId(), 3, HIDE_HOTBAR, bindSceneReturn( &SubSea004::Scene00003Return ) );
   }
 
   void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -166,7 +166,7 @@ private:
 
   void Scene00004( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 4, NONE, bindSceneReturn( &SubSea004::Scene00004Return ) );
+    eventMgr().playQuestScene( player, getId(), 4, HIDE_HOTBAR, bindSceneReturn( &SubSea004::Scene00004Return ) );
   }
 
   void Scene00004Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -180,7 +180,7 @@ private:
 
   void Scene00005( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 5, NONE, bindSceneReturn( &SubSea004::Scene00005Return ) );
+    eventMgr().playQuestScene( player, getId(), 5, HIDE_HOTBAR, bindSceneReturn( &SubSea004::Scene00005Return ) );
   }
 
   void Scene00005Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -195,7 +195,7 @@ private:
 
   void Scene00006( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 6, NONE, bindSceneReturn( &SubSea004::Scene00006Return ) );
+    eventMgr().playQuestScene( player, getId(), 6, HIDE_HOTBAR, bindSceneReturn( &SubSea004::Scene00006Return ) );
   }
 
   void Scene00006Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )

--- a/src/scripts/quest/subquest/limsa/SubSea005.cpp
+++ b/src/scripts/quest/subquest/limsa/SubSea005.cpp
@@ -80,7 +80,7 @@ class SubSea005 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00000( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 0, NONE, bindSceneReturn( &SubSea005::Scene00000Return ) );
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR , bindSceneReturn( &SubSea005::Scene00000Return ) );
   }
 
   void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -95,7 +95,7 @@ class SubSea005 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00001( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 1, NONE, bindSceneReturn( &SubSea005::Scene00001Return ) );
+    eventMgr().playQuestScene( player, getId(), 1, HIDE_HOTBAR, bindSceneReturn( &SubSea005::Scene00001Return ) );
   }
 
   void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -108,7 +108,7 @@ class SubSea005 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00002( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 2, NONE, bindSceneReturn( &SubSea005::Scene00002Return ) );
+    eventMgr().playQuestScene( player, getId(), 2, HIDE_HOTBAR, bindSceneReturn( &SubSea005::Scene00002Return ) );
   }
 
   void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -123,7 +123,7 @@ class SubSea005 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00003( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 3, NONE, bindSceneReturn( &SubSea005::Scene00003Return ) );
+    eventMgr().playQuestScene( player, getId(), 3, HIDE_HOTBAR, bindSceneReturn( &SubSea005::Scene00003Return ) );
   }
 
   void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -136,7 +136,7 @@ class SubSea005 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00004( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 4, NONE, bindSceneReturn( &SubSea005::Scene00004Return ) );
+    eventMgr().playQuestScene( player, getId(), 4, HIDE_HOTBAR, bindSceneReturn( &SubSea005::Scene00004Return ) );
   }
 
   void Scene00004Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -151,7 +151,7 @@ class SubSea005 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00005( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 5, NONE, bindSceneReturn( &SubSea005::Scene00005Return ) );
+    eventMgr().playQuestScene( player, getId(), 5, HIDE_HOTBAR, bindSceneReturn( &SubSea005::Scene00005Return ) );
   }
 
   void Scene00005Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )

--- a/src/scripts/quest/subquest/limsa/SubSea007.cpp
+++ b/src/scripts/quest/subquest/limsa/SubSea007.cpp
@@ -85,7 +85,7 @@ class SubSea007 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00000( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 0, NONE, bindSceneReturn( &SubSea007::Scene00000Return ) );
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &SubSea007::Scene00000Return ) );
   }
 
   void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -100,7 +100,7 @@ class SubSea007 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00001( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 1, NONE, bindSceneReturn( &SubSea007::Scene00001Return ) );
+    eventMgr().playQuestScene( player, getId(), 1, HIDE_HOTBAR, bindSceneReturn( &SubSea007::Scene00001Return ) );
   }
 
   void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -112,7 +112,7 @@ class SubSea007 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00002( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 2, NONE, bindSceneReturn( &SubSea007::Scene00002Return ) );
+    eventMgr().playQuestScene( player, getId(), 2, HIDE_HOTBAR, bindSceneReturn( &SubSea007::Scene00002Return ) );
   }
 
   void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -126,7 +126,7 @@ class SubSea007 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00003( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 3, NONE, bindSceneReturn( &SubSea007::Scene00003Return ) );
+    eventMgr().playQuestScene( player, getId(), 3, HIDE_HOTBAR, bindSceneReturn( &SubSea007::Scene00003Return ) );
   }
 
   void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -141,7 +141,7 @@ class SubSea007 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00004( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 4, NONE, bindSceneReturn( &SubSea007::Scene00004Return ) );
+    eventMgr().playQuestScene( player, getId(), 4, HIDE_HOTBAR, bindSceneReturn( &SubSea007::Scene00004Return ) );
   }
 
   void Scene00004Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -154,7 +154,7 @@ class SubSea007 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00005( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 5, NONE, bindSceneReturn( &SubSea007::Scene00005Return ) );
+    eventMgr().playQuestScene( player, getId(), 5, HIDE_HOTBAR, bindSceneReturn( &SubSea007::Scene00005Return ) );
   }
 
   void Scene00005Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )

--- a/src/scripts/quest/subquest/limsa/SubSea008.cpp
+++ b/src/scripts/quest/subquest/limsa/SubSea008.cpp
@@ -104,7 +104,7 @@ private:
 
   void Scene00000( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 0, NONE, bindSceneReturn( &SubSea008::Scene00000Return ) );
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &SubSea008::Scene00000Return ) );
   }
 
   void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -119,7 +119,7 @@ private:
 
   void Scene00001( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 1, NONE, bindSceneReturn( &SubSea008::Scene00001Return ) );
+    eventMgr().playQuestScene( player, getId(), 1, HIDE_HOTBAR, bindSceneReturn( &SubSea008::Scene00001Return ) );
   }
 
   void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -131,7 +131,7 @@ private:
 
   void Scene00002( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 2, NONE, bindSceneReturn( &SubSea008::Scene00002Return ) );
+    eventMgr().playQuestScene( player, getId(), 2, HIDE_HOTBAR, bindSceneReturn( &SubSea008::Scene00002Return ) );
   }
 
   void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -145,7 +145,7 @@ private:
 
   void Scene00003( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 3, NONE, bindSceneReturn( &SubSea008::Scene00003Return ) );
+    eventMgr().playQuestScene( player, getId(), 3, HIDE_HOTBAR, bindSceneReturn( &SubSea008::Scene00003Return ) );
   }
 
   void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -160,7 +160,7 @@ private:
 
   void Scene00004( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 4, NONE, bindSceneReturn( &SubSea008::Scene00004Return ) );
+    eventMgr().playQuestScene( player, getId(), 4, HIDE_HOTBAR, bindSceneReturn( &SubSea008::Scene00004Return ) );
   }
 
   void Scene00004Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -175,7 +175,7 @@ private:
 
   void Scene00005( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 5, NONE, bindSceneReturn( &SubSea008::Scene00005Return ) );
+    eventMgr().playQuestScene( player, getId(), 5, HIDE_HOTBAR, bindSceneReturn( &SubSea008::Scene00005Return ) );
   }
 
   void Scene00005Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -190,7 +190,7 @@ private:
 
   void Scene00006( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 6, NONE, bindSceneReturn( &SubSea008::Scene00006Return ) );
+    eventMgr().playQuestScene( player, getId(), 6, HIDE_HOTBAR, bindSceneReturn( &SubSea008::Scene00006Return ) );
   }
 
   void Scene00006Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -204,7 +204,7 @@ private:
 
   void Scene00007( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 7, NONE, bindSceneReturn( &SubSea008::Scene00007Return ) );
+    eventMgr().playQuestScene( player, getId(), 7, HIDE_HOTBAR, bindSceneReturn( &SubSea008::Scene00007Return ) );
   }
 
   void Scene00007Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )

--- a/src/scripts/quest/subquest/limsa/SubSea011.cpp
+++ b/src/scripts/quest/subquest/limsa/SubSea011.cpp
@@ -69,7 +69,7 @@ class SubSea011 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00000( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 0, NONE, bindSceneReturn( &SubSea011::Scene00000Return ) );
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &SubSea011::Scene00000Return ) );
   }
 
   void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -84,7 +84,7 @@ class SubSea011 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00001( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 1, NONE, bindSceneReturn( &SubSea011::Scene00001Return ) );
+    eventMgr().playQuestScene( player, getId(), 1, HIDE_HOTBAR, bindSceneReturn( &SubSea011::Scene00001Return ) );
   }
 
   void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -96,7 +96,7 @@ class SubSea011 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00002( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 2, NONE, bindSceneReturn( &SubSea011::Scene00002Return ) );
+    eventMgr().playQuestScene( player, getId(), 2, HIDE_HOTBAR, bindSceneReturn( &SubSea011::Scene00002Return ) );
   }
 
   void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )

--- a/src/scripts/quest/subquest/limsa/SubSea013.cpp
+++ b/src/scripts/quest/subquest/limsa/SubSea013.cpp
@@ -88,7 +88,7 @@ class SubSea013 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00000( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 0, NONE, bindSceneReturn( &SubSea013::Scene00000Return ) );
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &SubSea013::Scene00000Return ) );
   }
 
   void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -105,7 +105,7 @@ class SubSea013 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00001( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 1, NONE, bindSceneReturn( &SubSea013::Scene00001Return ) );
+    eventMgr().playQuestScene( player, getId(), 1, HIDE_HOTBAR, bindSceneReturn( &SubSea013::Scene00001Return ) );
   }
 
   void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )

--- a/src/scripts/quest/subquest/limsa/SubSea014.cpp
+++ b/src/scripts/quest/subquest/limsa/SubSea014.cpp
@@ -101,7 +101,7 @@ class SubSea014 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00000( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 0, NONE, bindSceneReturn( &SubSea014::Scene00000Return ) );
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &SubSea014::Scene00000Return ) );
   }
 
   void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -116,7 +116,7 @@ class SubSea014 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00001( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 1, NONE, bindSceneReturn( &SubSea014::Scene00001Return ) );
+    eventMgr().playQuestScene( player, getId(), 1, HIDE_HOTBAR, bindSceneReturn( &SubSea014::Scene00001Return ) );
   }
 
   void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -128,7 +128,7 @@ class SubSea014 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00002( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 2, NONE, bindSceneReturn( &SubSea014::Scene00002Return ) );
+    eventMgr().playQuestScene( player, getId(), 2, HIDE_HOTBAR, bindSceneReturn( &SubSea014::Scene00002Return ) );
   }
 
   void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -141,7 +141,7 @@ class SubSea014 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00003( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 3, NONE, bindSceneReturn( &SubSea014::Scene00003Return ) );
+    eventMgr().playQuestScene( player, getId(), 3, HIDE_HOTBAR, bindSceneReturn( &SubSea014::Scene00003Return ) );
   }
 
   void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -154,7 +154,7 @@ class SubSea014 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00004( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 4, NONE, bindSceneReturn( &SubSea014::Scene00004Return ) );
+    eventMgr().playQuestScene( player, getId(), 4, HIDE_HOTBAR, bindSceneReturn( &SubSea014::Scene00004Return ) );
   }
 
   void Scene00004Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -167,7 +167,7 @@ class SubSea014 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00005( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 5, NONE, bindSceneReturn( &SubSea014::Scene00005Return ) );
+    eventMgr().playQuestScene( player, getId(), 5, HIDE_HOTBAR, bindSceneReturn( &SubSea014::Scene00005Return ) );
   }
 
   void Scene00005Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -180,7 +180,7 @@ class SubSea014 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00006( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 6, NONE, bindSceneReturn( &SubSea014::Scene00006Return ) );
+    eventMgr().playQuestScene( player, getId(), 6, HIDE_HOTBAR, bindSceneReturn( &SubSea014::Scene00006Return ) );
   }
 
   void Scene00006Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -193,7 +193,7 @@ class SubSea014 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00007( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 7, NONE, bindSceneReturn( &SubSea014::Scene00007Return ) );
+    eventMgr().playQuestScene( player, getId(), 7, HIDE_HOTBAR, bindSceneReturn( &SubSea014::Scene00007Return ) );
   }
 
   void Scene00007Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -206,7 +206,7 @@ class SubSea014 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00008( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 8, NONE, bindSceneReturn( &SubSea014::Scene00008Return ) );
+    eventMgr().playQuestScene( player, getId(), 8, HIDE_HOTBAR, bindSceneReturn( &SubSea014::Scene00008Return ) );
   }
 
   void Scene00008Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -219,7 +219,7 @@ class SubSea014 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00009( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 9, NONE, bindSceneReturn( &SubSea014::Scene00009Return ) );
+    eventMgr().playQuestScene( player, getId(), 9, HIDE_HOTBAR, bindSceneReturn( &SubSea014::Scene00009Return ) );
   }
 
   void Scene00009Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -232,7 +232,7 @@ class SubSea014 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00010( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 10, NONE, bindSceneReturn( &SubSea014::Scene00010Return ) );
+    eventMgr().playQuestScene( player, getId(), 10, HIDE_HOTBAR, bindSceneReturn( &SubSea014::Scene00010Return ) );
   }
 
   void Scene00010Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -245,7 +245,7 @@ class SubSea014 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00011( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 11, NONE, bindSceneReturn( &SubSea014::Scene00011Return ) );
+    eventMgr().playQuestScene( player, getId(), 11, HIDE_HOTBAR, bindSceneReturn( &SubSea014::Scene00011Return ) );
   }
 
   void Scene00011Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )

--- a/src/scripts/quest/subquest/limsa/SubSea015.cpp
+++ b/src/scripts/quest/subquest/limsa/SubSea015.cpp
@@ -69,7 +69,7 @@ class SubSea015 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00000( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 0, NONE, bindSceneReturn( &SubSea015::Scene00000Return ) );
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &SubSea015::Scene00000Return ) );
   }
 
   void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -84,7 +84,7 @@ class SubSea015 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00001( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 1, NONE, bindSceneReturn( &SubSea015::Scene00001Return ) );
+    eventMgr().playQuestScene( player, getId(), 1, HIDE_HOTBAR, bindSceneReturn( &SubSea015::Scene00001Return ) );
   }
 
   void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -96,7 +96,7 @@ class SubSea015 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00002( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 2, NONE, bindSceneReturn( &SubSea015::Scene00002Return ) );
+    eventMgr().playQuestScene( player, getId(), 2, HIDE_HOTBAR, bindSceneReturn( &SubSea015::Scene00002Return ) );
   }
 
   void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )

--- a/src/scripts/quest/subquest/limsa/SubSea016.cpp
+++ b/src/scripts/quest/subquest/limsa/SubSea016.cpp
@@ -82,7 +82,7 @@ class SubSea016 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00000( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 0, NONE, bindSceneReturn( &SubSea016::Scene00000Return ) );
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &SubSea016::Scene00000Return ) );
   }
 
   void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -97,7 +97,7 @@ class SubSea016 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00001( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 1, NONE, bindSceneReturn( &SubSea016::Scene00001Return ) );
+    eventMgr().playQuestScene( player, getId(), 1, HIDE_HOTBAR, bindSceneReturn( &SubSea016::Scene00001Return ) );
   }
 
   void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -110,7 +110,7 @@ class SubSea016 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00002( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 2, NONE, bindSceneReturn( &SubSea016::Scene00002Return ) );
+    eventMgr().playQuestScene( player, getId(), 2, HIDE_HOTBAR, bindSceneReturn( &SubSea016::Scene00002Return ) );
   }
 
   void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -125,7 +125,7 @@ class SubSea016 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00003( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 3, NONE, bindSceneReturn( &SubSea016::Scene00003Return ) );
+    eventMgr().playQuestScene( player, getId(), 3, HIDE_HOTBAR, bindSceneReturn( &SubSea016::Scene00003Return ) );
   }
 
   void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -138,7 +138,7 @@ class SubSea016 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00004( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 4, NONE, bindSceneReturn( &SubSea016::Scene00004Return ) );
+    eventMgr().playQuestScene( player, getId(), 4, HIDE_HOTBAR, bindSceneReturn( &SubSea016::Scene00004Return ) );
   }
 
   void Scene00004Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -150,7 +150,7 @@ class SubSea016 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00005( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 5, NONE, bindSceneReturn( &SubSea016::Scene00005Return ) );
+    eventMgr().playQuestScene( player, getId(), 5, HIDE_HOTBAR, bindSceneReturn( &SubSea016::Scene00005Return ) );
   }
 
   void Scene00005Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )


### PR DESCRIPTION
Lambda functions for the Pugilist and Arcanist versions of Close To Home (ManWil003 + ManSea003) wasn't being run, making it so you couldn't take/progress those quests. 
Works with new quest parser template so I just updated it.