### PR TITLE
SubWil/ManWil MSQ and adding Item Icons to quest notices

### DIFF
--- a/src/scripts/instances/questbattles/UnderneaththeSultantree.cpp
+++ b/src/scripts/instances/questbattles/UnderneaththeSultantree.cpp
@@ -142,8 +142,8 @@ public:
     if( pair1Spawnd == 0 && bossHpPercent <= 70 )
     {
       instance.setDirectorVar( SET_1_SPAWNED, 1 );
-      auto a2 = instance.createBNpcFromLayoutId(INIT_POP_01_01, 1440, Common::BNpcType::Enemy);
-      auto a3 = instance.createBNpcFromLayoutId( INIT_POP_01_02, 1440, Common::BNpcType::Enemy );
+      auto a2 = instance.createBNpcFromLayoutId( INIT_POP_01_01, 1440 /*TODO: Find the right value*/, Common::BNpcType::Enemy );
+      auto a3 = instance.createBNpcFromLayoutId( INIT_POP_01_02, 1440 /*TODO: Find the right value*/, Common::BNpcType::Enemy );
       a2->setFlag( Entity::NoDeaggro );
       a3->setFlag( Entity::NoDeaggro );
 
@@ -158,10 +158,10 @@ public:
     if( pair2Spawnd == 0 && bossHpPercent <= 40 )
     {
       instance.setDirectorVar( SET_2_SPAWNED, 1 );
-      auto a2 = instance.createBNpcFromLayoutId( INIT_POP_02_01, 1440, Common::BNpcType::Enemy );
-      auto a3 = instance.createBNpcFromLayoutId( INIT_POP_02_02, 1440, Common::BNpcType::Enemy );
-      auto a4 = instance.createBNpcFromLayoutId( INIT_POP_02_03, 1440, Common::BNpcType::Enemy );
-      auto a5 = instance.createBNpcFromLayoutId( INIT_POP_02_04, 1440, Common::BNpcType::Enemy );
+      auto a2 = instance.createBNpcFromLayoutId( INIT_POP_02_01, 1440 /*TODO: Find the right value*/, Common::BNpcType::Enemy );
+      auto a3 = instance.createBNpcFromLayoutId( INIT_POP_02_02, 1440 /*TODO: Find the right value*/, Common::BNpcType::Enemy );
+      auto a4 = instance.createBNpcFromLayoutId( INIT_POP_02_03, 1440 /*TODO: Find the right value*/, Common::BNpcType::Enemy );
+      auto a5 = instance.createBNpcFromLayoutId( INIT_POP_02_04, 1440 /*TODO: Find the right value*/, Common::BNpcType::Enemy );
       a2->setFlag( Entity::NoDeaggro );
       a3->setFlag( Entity::NoDeaggro );
       a4->setFlag( Entity::NoDeaggro );
@@ -213,8 +213,8 @@ public:
   void onDutyCommence( QuestBattle& instance, Entity::Player& player ) override
   {
     // TODO: Change to correct HP values
-    auto boss = instance.createBNpcFromLayoutId( INIT_POP_BOSS, 10571, Common::BNpcType::Enemy );
-    auto thancred = instance.createBNpcFromLayoutId( INIT_P_POP_01, 27780, Common::BNpcType::Friendly );
+    auto boss = instance.createBNpcFromLayoutId( INIT_POP_BOSS, 10571 /*TODO: Find the right value*/, Common::BNpcType::Enemy );
+    auto thancred = instance.createBNpcFromLayoutId( INIT_P_POP_01, 27780 /*TODO: Find the right value*/, Common::BNpcType::Friendly );
 
     boss->setFlag( Entity::NoDeaggro );
     thancred->setFlag( Entity::NoDeaggro );

--- a/src/scripts/quest/ManWil005.cpp
+++ b/src/scripts/quest/ManWil005.cpp
@@ -1,0 +1,318 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: ManWil005_00550
+// Quest Name: Underneath the Sultantree
+// Quest ID: 66086
+// Start NPC: 1003995 (Papashan)
+// End NPC: 1003995 (Papashan)
+
+using namespace Sapphire;
+
+class ManWil005 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information  
+    // Quest vars / flags used
+    // BitFlag8
+    // UI8AL
+
+    /// Countable Num: 1 Seq: 1 Event: 1 Listener: 1003996
+    /// Countable Num: 1 Seq: 2 Event: 1 Listener: 2001853
+    /// Countable Num: 0 Seq: 255 Event: 15 Listener: 5020000
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      Seq1 = 1,
+      Seq2 = 2,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1003995; // Papashan ( Pos: 75.338402 2.138110 316.362000  Teri: 141 )
+    static constexpr auto Actor1 = 1003996; // Hooded Lalafell ( Pos: 202.662994 14.104900 536.909973  Teri: 141 )
+    static constexpr auto Actor2 = 1003997; // ×次女a ( Pos: 76.674599 2.137120 317.433014  Teri: 141 )
+    static constexpr auto Actor3 = 1003998; // ×近衛a ( Pos: 77.176598 2.137340 315.631989  Teri: 141 )
+    static constexpr auto Actor4 = 1003999; // ×近衛b ( Pos: 77.310501 2.136910 316.973999  Teri: 141 )
+    static constexpr auto Actor5 = 1004000; // ×近衛c ( Pos: 78.402603 2.136520 316.269012  Teri: 141 )
+    static constexpr auto Actor6 = 1004001; // Lilira ( Pos: 76.643402 2.136930 318.191010  Teri: 141 )
+    static constexpr auto Actor20 = 1006171; // Lilira
+    static constexpr auto Actor30 = 1006167; // 侍女a
+    static constexpr auto Actor40 = 1006168; // 近衛a
+    static constexpr auto Actor50 = 1006169; // 近衛b
+    static constexpr auto Actor60 = 1006170; // 近衛c
+    static constexpr auto CutScene02 = 141;
+    static constexpr auto CutScene03 = 56;
+    static constexpr auto CutScene04 = 142;
+    static constexpr auto Eobject0 = 2001853; //  ( Pos: 202.638000 14.137900 536.905029  Teri: 141 )
+    static constexpr auto EventActionSearch = 1; // Interaction
+    static constexpr auto Questbattle0 = 37;
+    static constexpr auto Seq0Actor0Lq = 50; // Goblin Thug
+    static constexpr auto Territorytype0 = 270;
+    static constexpr auto Territorytype1 = 141;
+
+  public:
+    ManWil005() : Sapphire::ScriptAPI::QuestScript( 66086 ){}; 
+    ~ManWil005() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        if (quest.getSeq() == Seq0)
+        {
+          Scene00000( quest, player );
+        }
+        else if (quest.getSeq() == SeqFinish)
+        {
+         Scene00006( quest, player );
+        }
+          
+        break;
+      }
+      case Actor1:
+      {
+        if( quest.getSeq() == Seq1 )
+          Scene00002( quest, player );
+        break;
+      }
+      case Actor2:
+      {
+        break;
+      }
+      case Actor3:
+      {
+        break;
+      }
+      case Actor4:
+      {
+        break;
+      }
+      case Actor5:
+      {
+        break;
+      }
+      case Actor6:
+      {
+        break;
+      }
+      case Actor20:
+      {
+        break;
+      }
+      case Actor30:
+      {
+        break;
+      }
+      case Actor40:
+      {
+        break;
+      }
+      case Actor50:
+      {
+        break;
+      }
+      case Actor60:
+      {
+        break;
+      }
+    }
+  }
+
+  void onEnterTerritory( World::Quest& quest, Entity::Player& player, uint16_t param1, uint16_t param2 ) override
+  {
+    if( quest.getSeq() == Seq2 )
+    {
+      Scene00005( quest, player );
+    }
+  }
+
+
+  private:
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &ManWil005::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      Scene00001( quest, player );
+    }
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, FADE_OUT | CONDITION_CUTSCENE | HIDE_UI, bindSceneReturn( &ManWil005::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setSeq( Seq1 );
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00002( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 2, NONE, bindSceneReturn( &ManWil005::Scene00002Return ) );
+  }
+
+  void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 )
+    {
+      auto& pTeriMgr = Common::Service< Sapphire::World::Manager::TerritoryMgr >::ref();
+
+      eventMgr().eventFinish( player, result.eventId, 0 );
+      pTeriMgr.createAndJoinQuestBattle( player, Questbattle0 );
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00003( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 3, NONE, bindSceneReturn( &ManWil005::Scene00003Return ) );
+  }
+
+  void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00004( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 4, NONE, bindSceneReturn( &ManWil005::Scene00004Return ) );
+  }
+
+  void Scene00004Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00005( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 5, NO_DEFAULT_CAMERA | CONDITION_CUTSCENE | SILENT_ENTER_TERRI_ENV | HIDE_HOTBAR | SILENT_ENTER_TERRI_BGM | SILENT_ENTER_TERRI_SE | DISABLE_STEALTH | 0x00100000 | LOCK_HUD | LOCK_HOTBAR |
+                                                           // todo: wtf is 0x00100000
+                                                           DISABLE_CANCEL_EMOTE,
+                               bindSceneReturn( &ManWil005::Scene00005Return ) );
+  }
+
+  void Scene00005Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setSeq( SeqFinish );
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00006( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 6, FADE_OUT | HIDE_HOTBAR | CONDITION_CUTSCENE | HIDE_UI, bindSceneReturn( &ManWil005::Scene00006Return ) );
+  }
+
+  void Scene00006Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      player.finishQuest( getId(), result.getResult( 1 ) );
+    }
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00007( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 7, NONE, bindSceneReturn( &ManWil005::Scene00007Return ) );
+  }
+
+  void Scene00007Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00008( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 8, NONE, bindSceneReturn( &ManWil005::Scene00008Return ) );
+  }
+
+  void Scene00008Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00009( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 9, NONE, bindSceneReturn( &ManWil005::Scene00009Return ) );
+  }
+
+  void Scene00009Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00010( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 10, NONE, bindSceneReturn( &ManWil005::Scene00010Return ) );
+  }
+
+  void Scene00010Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00011( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 11, NONE, bindSceneReturn( &ManWil005::Scene00011Return ) );
+  }
+
+  void Scene00011Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+};
+
+EXPOSE_SCRIPT( ManWil005 );

--- a/src/scripts/quest/classquest/MIN/ClsMin502.cpp
+++ b/src/scripts/quest/classquest/MIN/ClsMin502.cpp
@@ -45,6 +45,7 @@ private:
   static constexpr auto Actor4 = 1013231;//Hatchling
   static constexpr auto BindActor1 = 5896086;
   static constexpr auto Item0 = 2001726;
+  static constexpr auto Item0Icon = 26177;
   static constexpr auto LocBgm1 = 313;
 
 public:
@@ -137,7 +138,7 @@ private:
   void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
   {
     quest.setUI8BH( 1 );
-    eventMgr().sendEventNotice( player, getId(), 0, 0 );//TODO: Item Icon, probably
+    eventMgr().sendNotice( player, getId(), 0, { Item0Icon } );
     quest.setSeq( Seq2 );
   }
 

--- a/src/scripts/quest/classquest/MIN/ClsMin580.cpp
+++ b/src/scripts/quest/classquest/MIN/ClsMin580.cpp
@@ -64,6 +64,7 @@ private:
   static constexpr auto Eobject2 = 2005950;
   static constexpr auto EventActionGatherMiddle = 7;
   static constexpr auto Item0 = 2001728;
+  static constexpr auto Item0Icon = 21223;
   static constexpr auto LocActor1 = 1013860;
   static constexpr auto LocActor2 = 1013870;
   static constexpr auto LocActor3 = 1013871;
@@ -207,7 +208,7 @@ public:
 private:
   void checkQuestCompletion( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().sendEventNotice( player, getId(), 1, 2, quest.getUI8AL(), 3 );//TODO: Item Icon, probably
+    eventMgr().sendNotice( player, getId(), 1, { quest.getUI8AL(), 3, Item0Icon } );
 
     if( quest.getUI8AL() >= 3 )
     {

--- a/src/scripts/quest/classquest/MIN/ClsMin600.cpp
+++ b/src/scripts/quest/classquest/MIN/ClsMin600.cpp
@@ -56,6 +56,7 @@ private:
   static constexpr auto Actor7 = 1013961;//Goblin Trader (Seq5)
   static constexpr auto BindActor1 = 5896328;
   static constexpr auto Item0 = 2001729;
+  static constexpr auto Item0Icon = 25919;
   static constexpr auto LocActor1 = 1013954;
   static constexpr auto LocActor2 = 1013955;
   static constexpr auto LocBgm1 = 313;
@@ -390,7 +391,7 @@ private:
 
   void Scene00019Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
   {
-    eventMgr().sendEventNotice( player, getId(), 5, 0 );//TODO: Item Icon?
+    eventMgr().sendNotice( player, getId(), 5, { Item0Icon } );
     quest.setSeq( SeqFinish );
     quest.setUI8BH( 0 );
   }

--- a/src/scripts/quest/classquest/WHM/JobWhm001.cpp
+++ b/src/scripts/quest/classquest/WHM/JobWhm001.cpp
@@ -13,7 +13,7 @@
 // Quest Script: JobWhm001_01124
 // Quest Name: A Relic Reborn (Thyrus)
 // Quest ID: 66660
-// Start NPC: 1003075
+// Start NPC: 1003075a
 // End NPC: 1003075
 
 using namespace Sapphire;
@@ -101,6 +101,8 @@ private:
   static constexpr auto Item4 = 2001029;
   static constexpr auto Item5 = 2001038;
   static constexpr auto Item6 = 2001047;
+  static constexpr auto Item0Icon = 21003;
+  static constexpr auto Item3Icon = 26002;
   static constexpr auto LocAction0 = 858;
   static constexpr auto LocAction1 = 995;
   static constexpr auto LocAction2 = 936;
@@ -109,6 +111,7 @@ private:
   static constexpr auto Ritem0 = 2049;//Madman's Whispering Rod
   static constexpr auto Ritem1 = 2046;//Unfinished Thyrus
   static constexpr auto Ritem2 = 6267;//Radz-at-Han Quenching Oil
+  static constexpr auto Ritem1Icon = 32627;
 
 public:
   JobWhm001() : Sapphire::ScriptAPI::QuestScript( 66660 ){};
@@ -327,7 +330,7 @@ private:
   void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
   {
     quest.setUI8BH( 1 );
-    eventMgr().sendEventNotice( player, getId(), 0, 0 );//TODO:Item Icon
+    eventMgr().sendNotice( player, getId(), 0, { Item0Icon } );
     quest.setSeq( Seq2 );
   }
 
@@ -469,7 +472,7 @@ private:
 
   void Scene00013Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
   {
-    eventMgr().sendEventNotice( player, getId(), 7, 0 );//TODO: Item Icon
+    eventMgr().sendNotice( player, getId(), 7, { Item3Icon } );
     quest.setSeq( Seq9 );
     quest.setUI8BH( 1 );
   }
@@ -497,7 +500,7 @@ private:
   void Scene00015Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
   {
     quest.setUI8BH( 0 );
-    eventMgr().sendEventNotice( player, getId(), 8, 0 );//TODO: Item Icon?
+    eventMgr().sendNotice( player, getId(), 8, { Ritem1Icon } );
     player.addItem( Ritem1 );
     quest.setSeq( Seq10 );
   }

--- a/src/scripts/quest/classquest/WHM/JobWhm001.cpp
+++ b/src/scripts/quest/classquest/WHM/JobWhm001.cpp
@@ -13,7 +13,7 @@
 // Quest Script: JobWhm001_01124
 // Quest Name: A Relic Reborn (Thyrus)
 // Quest ID: 66660
-// Start NPC: 1003075a
+// Start NPC: 1003075
 // End NPC: 1003075
 
 using namespace Sapphire;

--- a/src/scripts/quest/classquest/WHM/JobWhm450.cpp
+++ b/src/scripts/quest/classquest/WHM/JobWhm450.cpp
@@ -80,6 +80,10 @@ private:
   static constexpr auto Ritem1 = 3894;
   static constexpr auto Ritem2 = 3463;
   static constexpr auto Ritem3 = 2902;
+  static constexpr auto Ritem0Icon = 48242;
+  static constexpr auto Ritem1Icon = 48219;
+  static constexpr auto Ritem2Icon = 45189;
+  static constexpr auto Ritem3Icon = 40616;
   static constexpr auto VfxReaction = 177;
 
 public:
@@ -214,7 +218,7 @@ private:
 
   void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
   {
-    eventMgr().sendEventNotice( player, getId(), 0, 0 );//TODO:Item Icon, Cleric's Gloves
+    eventMgr().sendNotice( player, getId(), 0, { Ritem0Icon } );
     playerMgr().sendLogMessage( player, Logmessage0 );
     quest.setUI8AL( 1 );
     quest.setUI8CH( 0 );
@@ -241,7 +245,7 @@ private:
 
   void Scene00005Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
   {
-    eventMgr().sendEventNotice( player, getId(), 1, 0 );//TODO:Item Icon, Cleric's Culottes
+    eventMgr().sendNotice( player, getId(), 1, { Ritem2Icon } );
     playerMgr().sendLogMessage( player, Logmessage0 );
     quest.setUI8BH( 1 );
     quest.setUI8CL( 0 );
@@ -268,7 +272,7 @@ private:
 
   void Scene00007Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
   {
-    eventMgr().sendEventNotice( player, getId(), 2, 0 );//TODO:Item Icon, Cleric's Boots
+    eventMgr().sendNotice( player, getId(), 2, {Ritem1Icon} );
     playerMgr().sendLogMessage( player, Logmessage0 );
     quest.setUI8BL( 1 );
     quest.setUI8DH( 0 );
@@ -436,7 +440,7 @@ private:
 
   void Scene00021Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
   {
-    eventMgr().sendEventNotice( player, getId(), 6, 0 );//TODO:Item Icon, Cleric's Circlet
+    eventMgr().sendNotice( player, getId(), 6, { Ritem3Icon } );
     playerMgr().sendLogMessage( player, Logmessage0 );
     quest.setSeq( SeqFinish );
     quest.setUI8BH( 0 );

--- a/src/scripts/quest/subquest/blackshroud_central/SubFst033.cpp
+++ b/src/scripts/quest/subquest/blackshroud_central/SubFst033.cpp
@@ -54,6 +54,7 @@ private:
   static constexpr auto Eobject1 = 2000017;//Decaying Tree (South)
   static constexpr auto Eobject2 = 2000018;//Decaying Tree (East)
   static constexpr auto Item0 = 2000061;
+  static constexpr auto Item0Icon = 20661;
   static constexpr auto Seq0Actor0 = 0;
   static constexpr auto Seq1Eobject0 = 1;
   static constexpr auto Seq1Eobject0Useitemno = 99;
@@ -184,7 +185,7 @@ public:
 private:
   void checkQuestCompletion( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().sendEventNotice( player, getId(), 0, 2, quest.getUI8AH(), 3 );//TODO: Probably needs item icon
+    eventMgr().sendNotice( player, getId(), 0, { quest.getUI8AH(), 3, Item0Icon } );
 
     if( quest.getUI8AH() >= 3 )
     {

--- a/src/scripts/quest/subquest/blackshroud_central/SubFst052.cpp
+++ b/src/scripts/quest/subquest/blackshroud_central/SubFst052.cpp
@@ -45,6 +45,8 @@ private:
   static constexpr auto Enemy0 = 54;//Hornet Swarm (INCORRECT: 57)
   static constexpr auto Item0 = 2000099;
   static constexpr auto Item1 = 2000094;
+  static constexpr auto Item0Icon = 22623;
+  static constexpr auto Item1Icon = 24403;
   static constexpr auto Seq0Actor0 = 0;
   static constexpr auto Seq2Actor0 = 1;
   static constexpr auto Seq2Actor0Npctradeno = 99;
@@ -88,7 +90,7 @@ public:
       {
         quest.setUI8BH( quest.getUI8BH() + 1 );
         quest.setUI8AL( quest.getUI8AL() + 1 );
-        eventMgr().sendEventNotice( player, getId(), 0, 2, quest.getUI8AL(), 4 );//TODO: Probably needs item icon
+        eventMgr().sendNotice( player, getId(), 0, { quest.getUI8AL(), 4, Item0Icon } ); // item Icon 2 missing
 
         if( quest.getUI8AL() >= 4 )
         {

--- a/src/scripts/quest/subquest/blackshroud_central/SubFst067.cpp
+++ b/src/scripts/quest/subquest/blackshroud_central/SubFst067.cpp
@@ -53,6 +53,7 @@ private:
   static constexpr auto Eventrange0 = 3841476;
   static constexpr auto EventActionSearch = 1;
   static constexpr auto Item0 = 2000192;
+  static constexpr auto Item0Icon = 22627;
 
 public:
   SubFst067() : Sapphire::ScriptAPI::QuestScript( 65919 ){};
@@ -182,7 +183,7 @@ public:
 private:
   void checkQuestCompletion( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().sendEventNotice( player, getId(), 1, 2, quest.getUI8AL(), 3 );//TODO: Item Icon
+    eventMgr().sendNotice( player, getId(), 1, { quest.getUI8AL(), 3, Item0Icon } );
     if( quest.getUI8AL() >= 3 )
     {
       quest.setUI8AL( 0 );

--- a/src/scripts/quest/subquest/blackshroud_central/SubFst069.cpp
+++ b/src/scripts/quest/subquest/blackshroud_central/SubFst069.cpp
@@ -39,6 +39,7 @@ private:
   static constexpr auto Eobject0 = 2000685;//Well-worn Fishing Rod
   static constexpr auto EventActionSearch = 1;
   static constexpr auto Item0 = 2000185;
+  static constexpr auto Item0Icon = 38201;
   static constexpr auto Seq0Actor0 = 0;
   static constexpr auto Seq1Eobject0 = 1;
   static constexpr auto Seq1Eobject0Eventactionno = 99;
@@ -169,7 +170,7 @@ private:
 
   void Scene00100Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
   {
-    eventMgr().sendEventNotice( player, getId(), 0, 0 );//TODO: Probably Item Icon
+    eventMgr().sendNotice( player, getId(), 0, { Item0Icon } );
     quest.setUI8BH( 1 );
     quest.setSeq( SeqFinish );
   }

--- a/src/scripts/quest/subquest/blackshroud_north/GaiUsa803.cpp
+++ b/src/scripts/quest/subquest/blackshroud_north/GaiUsa803.cpp
@@ -55,6 +55,7 @@ private:
   static constexpr auto EventActionSearchMiddle = 3;
   static constexpr auto Item0 = 2000616;
   static constexpr auto Item1 = 2000617;
+  static constexpr auto Item1Icon = 20005;
 
 public:
   GaiUsa803() : Sapphire::ScriptAPI::QuestScript( 66323 ){};
@@ -140,7 +141,7 @@ public:
 private:
   void checkQuestCompletion( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().sendEventNotice( player, getId(), 1, 2, quest.getUI8AH(), 5 );//TODO:Show Item Icon
+    eventMgr().sendNotice( player, getId(), 1, { quest.getUI8AH(), 5, Item1Icon } );
     if( quest.getUI8AH() >= 5 )
     {
       quest.setUI8BH( quest.getUI8DH() );

--- a/src/scripts/quest/subquest/coerthas_central/GaiUsb808.cpp
+++ b/src/scripts/quest/subquest/coerthas_central/GaiUsb808.cpp
@@ -55,6 +55,7 @@ private:
   static constexpr auto Item0 = 2000720;
   static constexpr auto Item1 = 2000721;
   static constexpr auto Item2 = 2000722;
+  static constexpr auto Item0Icon = 26002;
 
 public:
   GaiUsb808() : Sapphire::ScriptAPI::QuestScript( 66453 ){};
@@ -162,7 +163,7 @@ private:
 
   void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
   {
-    eventMgr().sendEventNotice( player, getId(), 1, 0 );//TODO:Show Item Icon (Needs func update)
+    eventMgr().sendNotice( player, getId(), 1, { Item0Icon } );
     quest.setUI8BH( 1 );
     quest.setSeq( Seq3 );
   }

--- a/src/scripts/quest/subquest/gridania/GaiUsc609.cpp
+++ b/src/scripts/quest/subquest/gridania/GaiUsc609.cpp
@@ -61,6 +61,8 @@ private:
   static constexpr auto EventActionSearch = 1;
   static constexpr auto Item0 = 2000963;
   static constexpr auto Item1 = 2000965;
+  static constexpr auto Item0Icon = 22614;
+  static constexpr auto Item1Icon = 21452;
   static constexpr auto Poprange0 = 3884000;
   static constexpr auto Territorytype0 = 204;
 
@@ -263,7 +265,7 @@ private:
 
   void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
   {
-    eventMgr().sendEventNotice( player, getId(), 0, 0 );
+    eventMgr().sendNotice( player, getId(), 0, { Item0Icon } );
     quest.setUI8BH( 1 );
     quest.setSeq( Seq2 );
   }
@@ -393,7 +395,7 @@ private:
   {
     quest.setSeq( Seq4 );
     quest.setUI8BH( 1 );
-    eventMgr().sendEventNotice( player, getId(), 2, 0 /*1, Item1*/ );//TODO:Item Icon Event Notice
+    eventMgr().sendNotice( player, getId(), 2, { Item1Icon } );
   }
 
   //////////////////////////////////////////////////////////////////////

--- a/src/scripts/quest/subquest/lanoscea_outer/GaiUsb406.cpp
+++ b/src/scripts/quest/subquest/lanoscea_outer/GaiUsb406.cpp
@@ -55,6 +55,8 @@ private:
   static constexpr auto EventActionSearch = 1;
   static constexpr auto Item0 = 2000669;
   static constexpr auto Item1 = 2000929;
+  static constexpr auto Item0Icon = 27241;
+  static constexpr auto Item1Icon = 22301;
 
 public:
   GaiUsb406() : Sapphire::ScriptAPI::QuestScript( 66398 ){};
@@ -143,7 +145,11 @@ private:
   {
     if( quest.getSeq() == Seq1 )
     {
-      eventMgr().sendEventNotice( player, getId(), type, 2, ( type == 0 ) ? quest.getUI8AL() : quest.getUI8BH(), 3 ); //TODO: Item Icons
+      if( type == 0 )
+        eventMgr().sendNotice( player, getId(), type, { quest.getUI8AL(), 3, Item1Icon } );
+      else
+        eventMgr().sendNotice( player, getId(), type, { quest.getUI8BH(), 3, Item0Icon } );
+
       if( quest.getUI8BL() >= 3 && quest.getUI8CH() >= 3 )
       {
         quest.setUI8BH( quest.getUI8BL() );

--- a/src/scripts/quest/subquest/limsa/SubSea002.cpp
+++ b/src/scripts/quest/subquest/limsa/SubSea002.cpp
@@ -8,7 +8,7 @@
 #include <Service.h>
 
 // Quest Script: SubSea002_00112
-// Quest Name: Suspiciously SoberF
+// Quest Name: Suspiciously Sober
 // Quest ID: 65648
 // Start NPC: 1003604 (Ahldskyf)
 // End NPC: 1003275 (Frydwyb)

--- a/src/scripts/quest/subquest/limsa/SubSea004.cpp
+++ b/src/scripts/quest/subquest/limsa/SubSea004.cpp
@@ -145,6 +145,7 @@ private:
   {
     eventMgr().sendEventNotice( player, getId(), 0, 0 );
     quest.setUI8AL( 1 );
+    quest.setBitFlag8( 1, true );
     checkQuestCompletion( quest, player, 1 );
   }
 
@@ -159,6 +160,7 @@ private:
   {
     eventMgr().sendEventNotice( player, getId(), 1, 0 );
     quest.setUI8BH( 1 );
+    quest.setBitFlag8( 2, true );
     checkQuestCompletion( quest, player, 1 );
   }
 
@@ -173,6 +175,7 @@ private:
   {
     eventMgr().sendEventNotice( player, getId(), 2, 0 );
     quest.setUI8BL( 1 );
+    quest.setBitFlag8( 3, true );
     checkQuestCompletion( quest, player, 1 );
   }
 

--- a/src/scripts/quest/subquest/limsa/SubSea007.cpp
+++ b/src/scripts/quest/subquest/limsa/SubSea007.cpp
@@ -41,6 +41,7 @@ class SubSea007 : public Sapphire::ScriptAPI::QuestScript
     static constexpr auto Actor1 = 1000957; // R'sushmo ( Pos: -49.240898 43.991699 -146.380005  Teri: 128 )
     static constexpr auto Actor2 = 1000937; // Godebert ( Pos: -12.222500 44.998798 -251.850006  Teri: 128 )
     static constexpr auto Item0 = 2000455;
+    static constexpr auto Item0Icon = 25906;
 
   public:
     SubSea007() : Sapphire::ScriptAPI::QuestScript( 65653 ){}; 
@@ -117,7 +118,7 @@ class SubSea007 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
   {
-    eventMgr().sendEventNotice( player, getId(), 0, 0 ); // TODO: Show item icon
+    eventMgr().sendNotice( player, getId(), 0, { Item0Icon } );
     quest.setUI8BH( 1 );
     quest.setSeq( Seq2 );
   }

--- a/src/scripts/quest/subquest/limsa/SubSea008.cpp
+++ b/src/scripts/quest/subquest/limsa/SubSea008.cpp
@@ -45,6 +45,7 @@ class SubSea008 : public Sapphire::ScriptAPI::QuestScript
     static constexpr auto Actor2 = 1000938; // Ginnade ( Pos: -4.651690 45.018398 -241.815002  Teri: 128 )
     static constexpr auto Actor3 = 1000947; // Lyngsath ( Pos: -54.642601 43.991699 -151.201996  Teri: 128 )
     static constexpr auto Item0 = 2000451;
+    static constexpr auto Item0Icon = 25919;
 
   public:
     SubSea008() : Sapphire::ScriptAPI::QuestScript( 65654 ){}; 
@@ -58,7 +59,8 @@ class SubSea008 : public Sapphire::ScriptAPI::QuestScript
     {
       case Actor0:
       {
-        Scene00000( quest, player );
+        if( quest.getSeq() == Seq0 )
+          Scene00000( quest, player );
         break;
       }
       case Actor1:
@@ -71,12 +73,14 @@ class SubSea008 : public Sapphire::ScriptAPI::QuestScript
       }
       case Actor2:
       {
-        Scene00003( quest, player );
+        if( quest.getSeq() == Seq2 )
+          Scene00003( quest, player );
         break;
       }
       case Actor3:
       {
-        Scene00005( quest, player );
+        if( quest.getSeq() == Seq2 )
+          Scene00005( quest, player );
         break;
       }
     }
@@ -137,7 +141,7 @@ private:
   void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
   {
     quest.setUI8BL( 1 );
-    eventMgr().sendEventNotice( player, getId(), 0, 0 ); //TODO: add item icon
+    eventMgr().sendNotice( player, getId(), 0, { Item0Icon } );
     quest.setSeq( Seq2 );
   }
 
@@ -167,6 +171,7 @@ private:
   {
     eventMgr().sendEventNotice( player, getId(), 1, 0 );
     quest.setUI8AL( 1 );
+    quest.setBitFlag8( 1, true );
     checkQuestCompletion( quest, player, 1 );
 
   }
@@ -197,6 +202,7 @@ private:
   {
     eventMgr().sendEventNotice( player, getId(), 2, 0 );
     quest.setUI8BH( 1 );
+    quest.setBitFlag8( 2, true );
     checkQuestCompletion( quest, player, 1 );
   }
 

--- a/src/scripts/quest/subquest/limsa/SubSea016.cpp
+++ b/src/scripts/quest/subquest/limsa/SubSea016.cpp
@@ -64,7 +64,8 @@ class SubSea016 : public Sapphire::ScriptAPI::QuestScript
       }
       case Actor1:
       {
-        Scene00002( quest, player );
+        if( quest.getSeq() == Seq1 )
+          Scene00002( quest, player );
         break;
       }
     }
@@ -131,6 +132,7 @@ class SubSea016 : public Sapphire::ScriptAPI::QuestScript
   void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
   {
     eventMgr().sendEventNotice( player, getId(), 0, 0 );
+    quest.setBitFlag8( 1, true );
     quest.setSeq( SeqFinish );
   }
 

--- a/src/scripts/quest/subquest/thanalan_central/SubWil025.cpp
+++ b/src/scripts/quest/subquest/thanalan_central/SubWil025.cpp
@@ -1,0 +1,324 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include "Manager/EventMgr.h"
+#include <Actor/Player.h>
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubWil025_00671
+// Quest Name: Nothing to See Here
+// Quest ID: 66207
+// Start NPC: 1003995 (Papashan)
+// End NPC: 1003995 (Papashan)
+
+using namespace Sapphire;
+
+class SubWil025 : public Sapphire::ScriptAPI::QuestScript
+{
+private:
+  // Basic quest information
+  // Quest vars / flags used
+  // BitFlag8
+  // UI8AH
+  // UI8AL
+  // UI8BH
+  // UI8BL
+  // UI8CH
+  // UI8CL
+
+  /// Countable Num: 0 Seq: 1 Event: 1 Listener: 1004599
+  /// Countable Num: 0 Seq: 255 Event: 1 Listener: 1004600
+  // Steps in this quest ( 0 is before accepting,
+  // 1 is first, 255 means ready for turning it in
+  enum Sequence : uint8_t
+  {
+    Seq0 = 0,
+    Seq1 = 1,
+    SeqFinish = 255,
+  };
+
+  // Entities found in the script data of the quest
+  static constexpr auto Actor0 = 1003995;// Papashan ( Pos: 75.338402 2.138110 316.362000  Teri: 141 )
+  static constexpr auto Actor1 = 1004599;// Stern Sultansworn ( Pos: 89.876198 4.633540 425.415009  Teri: 141 )
+  static constexpr auto Actor2 = 1004600;// Serious Sultansworn ( Pos: 126.024002 14.465300 278.462006  Teri: 141 )
+  static constexpr auto Actor3 = 1004601;// Servile Sultansworn ( Pos: -62.415001 4.641350 261.281006  Teri: 141 )
+  static constexpr auto Item0 = 2000463;
+
+public:
+  SubWil025() : Sapphire::ScriptAPI::QuestScript( 66207 ){};
+  ~SubWil025() = default;
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        if( quest.getSeq() == Seq0 )
+          Scene00000( quest, player );
+        else if( quest.getSeq() == SeqFinish )
+          Scene00010( quest, player );
+        break;
+      }
+
+      case Actor1:
+      {
+        if( quest.getSeq() == Seq1 )
+        {
+          if( quest.getUI8AL() == 0 )
+            Scene00001( quest, player );
+          else
+            Scene00003( quest, player );
+        }
+        else if( quest.getSeq() == SeqFinish )
+        {
+          Scene00011( quest, player );
+        }
+        break;
+      }
+
+      case Actor2:
+      {
+        if( quest.getSeq() == Seq1 )
+        {
+          if( quest.getUI8BH() == 0 )
+            Scene00004( quest, player );
+          else
+            Scene00006( quest, player );
+        }
+        else if( quest.getSeq() == SeqFinish )
+        {
+          Scene00012( quest, player );
+        }
+        break;
+      }
+
+      case Actor3:
+      {
+        if( quest.getSeq() == Seq1 )
+        {
+          if( quest.getUI8BL() == 0 )
+            Scene00007( quest, player );
+          else
+            Scene00009( quest, player );
+        }
+        break;
+      }
+    }
+  }
+
+  void onEventItem( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+  }
+
+
+private:
+  void checkQuestCompletion( World::Quest& quest, Entity::Player& player, uint32_t varIdx )
+  {
+    if( varIdx == 1 )
+    {
+      quest.setUI8AH( quest.getUI8AH() + 1 );
+      quest.setUI8CH( quest.getUI8CH() - 1 );
+      auto actor1Talked = quest.getUI8AL();
+      auto actor2Talked = quest.getUI8BH();
+      auto actor3Talked = quest.getUI8BL();
+      if( actor1Talked && actor2Talked && actor3Talked )
+      {
+        quest.setSeq( SeqFinish );
+      }
+      eventMgr().sendEventNotice( player, getId(), 0, 2, quest.getUI8AH(), 3 );
+    }
+  }
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &SubWil025::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 )// accept quest
+    {
+      quest.setSeq( Seq1 );
+      quest.setUI8CH( 3 );
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, HIDE_HOTBAR, bindSceneReturn( &SubWil025::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 )
+    {
+      Scene00002( quest, player );
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00002( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 2, HIDE_HOTBAR, bindSceneReturn( &SubWil025::Scene00002Return ) );
+  }
+
+  void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setUI8AL( 1 );
+    quest.setBitFlag8( 1, true );
+    checkQuestCompletion( quest, player, 1 );
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00003( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 3, HIDE_HOTBAR, bindSceneReturn( &SubWil025::Scene00003Return ) );
+  }
+
+  void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00004( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 4, HIDE_HOTBAR, bindSceneReturn( &SubWil025::Scene00004Return ) );
+  }
+
+  void Scene00004Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 )
+    {
+      Scene00005( quest, player );
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00005( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 5, HIDE_HOTBAR, bindSceneReturn( &SubWil025::Scene00005Return ) );
+  }
+
+  void Scene00005Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setUI8BH( 1 );
+    quest.setBitFlag8( 2, true );
+    checkQuestCompletion( quest, player, 1 );
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00006( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 6, HIDE_HOTBAR, bindSceneReturn( &SubWil025::Scene00006Return ) );
+  }
+
+  void Scene00006Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00007( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 7, HIDE_HOTBAR, bindSceneReturn( &SubWil025::Scene00007Return ) );
+  }
+
+  void Scene00007Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 )
+    {
+      Scene00008( quest, player );
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00008( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 8, HIDE_HOTBAR, bindSceneReturn( &SubWil025::Scene00008Return ) );
+  }
+
+  void Scene00008Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setUI8BL( 1 );
+    quest.setBitFlag8( 3, true );
+    checkQuestCompletion( quest, player, 1 );
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00009( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 9, HIDE_HOTBAR, bindSceneReturn( &SubWil025::Scene00009Return ) );
+  }
+
+  void Scene00009Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00010( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 10, HIDE_HOTBAR, bindSceneReturn( &SubWil025::Scene00010Return ) );
+  }
+
+  void Scene00010Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      player.finishQuest( getId(), result.getResult( 1 ) );
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00011( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 11, HIDE_HOTBAR, bindSceneReturn( &SubWil025::Scene00011Return ) );
+  }
+
+  void Scene00011Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00012( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 12, HIDE_HOTBAR, bindSceneReturn( &SubWil025::Scene00012Return ) );
+  }
+
+  void Scene00012Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00013( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 13, HIDE_HOTBAR, bindSceneReturn( &SubWil025::Scene00013Return ) );
+  }
+
+  void Scene00013Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+  }
+};
+
+EXPOSE_SCRIPT( SubWil025 );

--- a/src/scripts/quest/subquest/thanalan_central/SubWil026.cpp
+++ b/src/scripts/quest/subquest/thanalan_central/SubWil026.cpp
@@ -1,0 +1,117 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubWil026_00623
+// Quest Name: Takin' What They're Givin'
+// Quest ID: 66159
+// Start NPC: 1001353 (Momodi)
+// End NPC: 1002065 (Dadanen)
+
+using namespace Sapphire;
+
+class SubWil026 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // UI8AL
+
+    /// Countable Num: 1 Seq: 255 Event: 1 Listener: 1002065
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1001353; // Momodi ( Pos: 21.072599 7.450000 -78.782303  Teri: 130 )
+    static constexpr auto Actor1 = 1002065; // Dadanen ( Pos: 60.946701 45.145302 -204.985992  Teri: 140 )
+
+  public:
+    SubWil026() : Sapphire::ScriptAPI::QuestScript( 66159 ){}; 
+    ~SubWil026() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        if( quest.getSeq() == Seq0 )
+          Scene00000( quest, player );
+        break;
+      }
+      case Actor1:
+      {
+        if( quest.getSeq() == SeqFinish )
+          Scene00001( quest, player );
+        break;
+      }
+    }
+  }
+
+  void onEventItem( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+  }
+
+
+  private:
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &SubWil026::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      quest.setUI8AL( 1 );
+      quest.setSeq( SeqFinish );
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, FADE_OUT | CONDITION_CUTSCENE | HIDE_UI, bindSceneReturn( &SubWil026::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    Scene00002( quest, player );
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00002( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 2, HIDE_HOTBAR, bindSceneReturn( &SubWil026::Scene00002Return ) );
+  }
+
+  void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      player.finishQuest( getId(), result.getResult( 1 ) );
+    }
+  }
+
+};
+
+EXPOSE_SCRIPT( SubWil026 );

--- a/src/scripts/quest/subquest/thanalan_central/SubWil060.cpp
+++ b/src/scripts/quest/subquest/thanalan_central/SubWil060.cpp
@@ -1,0 +1,194 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubWil060_00303
+// Quest Name: Step Nine
+// Quest ID: 65839
+// Start NPC: 1001500 (Cicidoa)
+// End NPC: 1001541 (Roger)
+
+using namespace Sapphire;
+
+class SubWil060 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // UI8AL
+    // UI8BH
+    // UI8BL
+
+    /// Countable Num: 1 Seq: 1 Event: 1 Listener: 1001455
+    /// Countable Num: 1 Seq: 255 Event: 1 Listener: 1001541
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      Seq1 = 1,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1001500; // Cicidoa ( Pos: 81.792099 1.050750 311.240997  Teri: 141 )
+    static constexpr auto Actor1 = 1001455; // Gagari ( Pos: 59.952599 0.999894 255.863998  Teri: 141 )
+    static constexpr auto Actor2 = 1001541; // Roger ( Pos: -99.395401 -11.380900 -41.723999  Teri: 141 )
+    static constexpr auto Item0 = 2000199;
+    static constexpr auto Item1 = 2000238;
+    static constexpr auto Item1Icon = 25210;
+
+  public:
+    SubWil060() : Sapphire::ScriptAPI::QuestScript( 65839 ){}; 
+    ~SubWil060() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        if( quest.getSeq() == Seq0 )
+          Scene00000( quest, player );
+        break;
+      }
+      case Actor1:
+      {
+        if( quest.getSeq() == Seq1 )
+          Scene00001( quest, player );
+        break;
+      }
+      case Actor2:
+      {
+        if( quest.getSeq() == SeqFinish )
+          Scene00004( quest, player );
+        break;
+      }
+    }
+  }
+
+  void onEventItem( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+  }
+
+
+  private:
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &SubWil060::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      quest.setUI8BH( 1 );
+      quest.setSeq( Seq1 );
+    }
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, HIDE_HOTBAR, bindSceneReturn( &SubWil060::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 )
+    {
+      Scene00002( quest, player );
+    }
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00002( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 2, HIDE_HOTBAR, bindSceneReturn( &SubWil060::Scene00002Return ) );
+  }
+
+  void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setUI8BH( 0 );
+    quest.setUI8BL( 1 );
+    eventMgr().sendNotice( player, getId(), 0, { Item1Icon } );
+    quest.setSeq( SeqFinish );
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00003( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 3, NONE, bindSceneReturn( &SubWil060::Scene00003Return ) );
+  }
+
+  void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00004( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 4, HIDE_HOTBAR, bindSceneReturn( &SubWil060::Scene00004Return ) );
+  }
+
+  void Scene00004Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 )
+    {
+      Scene00005( quest, player );
+    }
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00005( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 5, HIDE_HOTBAR, bindSceneReturn( &SubWil060::Scene00005Return ) );
+  }
+
+  void Scene00005Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+        player.finishQuest( getId(), result.getResult( 1 ) );
+    }
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00006( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 6, NONE, bindSceneReturn( &SubWil060::Scene00006Return ) );
+  }
+
+  void Scene00006Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+};
+
+EXPOSE_SCRIPT( SubWil060 );

--- a/src/scripts/quest/subquest/thanalan_central/SubWil062.cpp
+++ b/src/scripts/quest/subquest/thanalan_central/SubWil062.cpp
@@ -1,0 +1,171 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include "Manager/EventMgr.h"
+#include <Actor/Player.h>
+#include <Actor/BNpc.h>
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubWil062_00305
+// Quest Name: Until a Quieter Time
+// Quest ID: 65841
+// Start NPC: 1001541 (Roger)
+// End NPC: 1001447 (Warin)
+
+using namespace Sapphire;
+
+class SubWil062 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // UI8AL
+    // UI8BH
+
+    /// Countable Num: 8 Seq: 1 Event: 9 Listener: 432
+    /// Countable Num: 1 Seq: 255 Event: 1 Listener: 1001447
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      Seq1 = 1,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1001541; // Roger ( Pos: -99.395401 -11.380900 -41.723999  Teri: 141 )
+    static constexpr auto Actor1 = 1001447; // Warin ( Pos: -32.639099 -1.033260 -148.485992  Teri: 141 )
+    static constexpr auto Enemy0 = 294; // Antling Worker
+    static constexpr auto Item0 = 2000168;
+    static constexpr auto Item0Icon = 22205;
+
+  public:
+    SubWil062() : Sapphire::ScriptAPI::QuestScript( 65841 ){}; 
+    ~SubWil062() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        if( quest.getSeq() == Seq0 )
+          Scene00000( quest, player );
+        break;
+      }
+      case Actor1:
+      {
+        if( quest.getSeq() == SeqFinish )
+          Scene00002( quest, player );
+        break;
+      }
+    }
+  }
+
+  void onEventItem( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+  }
+
+  void onBNpcKill( World::Quest& quest, Entity::BNpc& bnpc, Entity::Player& player ) override
+  {
+    if( bnpc.getBNpcNameId() != Enemy0 )
+      return;
+
+    unsigned currentKC = quest.getUI8AL() + 1;
+    quest.setUI8BH( currentKC );
+    quest.setUI8AL( currentKC );
+
+    if( currentKC >= 5 )
+      quest.setSeq( SeqFinish );
+
+    eventMgr().sendNotice( player, getId(), 0, { currentKC, 5, Item0Icon } );
+  }
+
+  private:
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, NONE, bindSceneReturn( &SubWil062::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      quest.setUI8AL( 0 );
+      quest.setSeq( Seq1 );
+    }
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, NONE, bindSceneReturn( &SubWil062::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00002( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 2, NONE, bindSceneReturn( &SubWil062::Scene00002Return ) );
+  }
+
+  void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 )
+    {
+      quest.setUI8BH( 0 );
+      Scene00003( quest, player );
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00003( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 3, NONE, bindSceneReturn( &SubWil062::Scene00003Return ) );
+  }
+
+  void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      player.finishQuest( getId(), result.getResult( 1 ) );
+    }
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00004( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 4, NONE, bindSceneReturn( &SubWil062::Scene00004Return ) );
+  }
+
+  void Scene00004Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+};
+
+EXPOSE_SCRIPT( SubWil062 );

--- a/src/scripts/quest/subquest/thanalan_central/SubWil062.cpp
+++ b/src/scripts/quest/subquest/thanalan_central/SubWil062.cpp
@@ -93,7 +93,7 @@ class SubWil062 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00000( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 0, NONE, bindSceneReturn( &SubWil062::Scene00000Return ) );
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &SubWil062::Scene00000Return ) );
   }
 
   void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -103,8 +103,6 @@ class SubWil062 : public Sapphire::ScriptAPI::QuestScript
       quest.setUI8AL( 0 );
       quest.setSeq( Seq1 );
     }
-
-
   }
 
   //////////////////////////////////////////////////////////////////////
@@ -124,7 +122,7 @@ class SubWil062 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00002( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 2, NONE, bindSceneReturn( &SubWil062::Scene00002Return ) );
+    eventMgr().playQuestScene( player, getId(), 2, HIDE_HOTBAR, bindSceneReturn( &SubWil062::Scene00002Return ) );
   }
 
   void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -140,7 +138,7 @@ class SubWil062 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00003( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 3, NONE, bindSceneReturn( &SubWil062::Scene00003Return ) );
+    eventMgr().playQuestScene( player, getId(), 3, HIDE_HOTBAR, bindSceneReturn( &SubWil062::Scene00003Return ) );
   }
 
   void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )

--- a/src/scripts/quest/subquest/thanalan_central/SubWil063.cpp
+++ b/src/scripts/quest/subquest/thanalan_central/SubWil063.cpp
@@ -1,0 +1,103 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubWil063_00306
+// Quest Name: Prudence at This Junction
+// Quest ID: 65842
+// Start NPC: 1001447 (Warin)
+// End NPC: 1001447 (Warin)
+
+using namespace Sapphire;
+
+class SubWil063 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // UI8AL
+
+    /// Countable Num: 1 Seq: 255 Event: 1 Listener: 1001447
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1001447; // Warin ( Pos: -32.639099 -1.033260 -148.485992  Teri: 141 )
+    static constexpr auto Seq0Actor0 = 0; // 
+    static constexpr auto Seq1Actor0 = 1; // 
+
+  public:
+    SubWil063() : Sapphire::ScriptAPI::QuestScript( 65842 ){}; 
+    ~SubWil063() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        if( quest.getSeq() == Seq0 )
+          Scene00000( quest, player );
+        else if( quest.getSeq() == SeqFinish )
+          Scene00001( quest, player );
+        break;
+      }
+    }
+  }
+
+  void onEventItem( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+  }
+
+
+  private:
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, NONE, bindSceneReturn( &SubWil063::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      quest.setSeq( SeqFinish );
+      eventMgr().sendNotice( player, getId(), 0, {} );
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, NONE, bindSceneReturn( &SubWil063::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      player.finishQuest( getId(), result.getResult( 1 ) );
+    }
+
+  }
+
+};
+
+EXPOSE_SCRIPT( SubWil063 );

--- a/src/scripts/quest/subquest/thanalan_central/SubWil063.cpp
+++ b/src/scripts/quest/subquest/thanalan_central/SubWil063.cpp
@@ -69,7 +69,7 @@ class SubWil063 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00000( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 0, NONE, bindSceneReturn( &SubWil063::Scene00000Return ) );
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &SubWil063::Scene00000Return ) );
   }
 
   void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
@@ -85,7 +85,7 @@ class SubWil063 : public Sapphire::ScriptAPI::QuestScript
 
   void Scene00001( World::Quest& quest, Entity::Player& player )
   {
-    eventMgr().playQuestScene( player, getId(), 1, NONE, bindSceneReturn( &SubWil063::Scene00001Return ) );
+    eventMgr().playQuestScene( player, getId(), 1, HIDE_HOTBAR, bindSceneReturn( &SubWil063::Scene00001Return ) );
   }
 
   void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )

--- a/src/scripts/quest/subquest/thanalan_central/SubWil064.cpp
+++ b/src/scripts/quest/subquest/thanalan_central/SubWil064.cpp
@@ -1,0 +1,315 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include "Manager/EventMgr.h"
+#include <Actor/Player.h>
+#include <Actor/BNpc.h>
+#include <ScriptObject.h>
+#include <Service.h>
+
+#include "Actor/BNpc.h"
+#include "Manager/TerritoryMgr.h"
+#include "Territory/Territory.h"
+
+// Quest Script: SubWil064_00307
+// Quest Name: Out of House and Home
+// Quest ID: 65843
+// Start NPC: 1001447 (Warin)
+// End NPC: 1001447 (Warin)
+
+using namespace Sapphire;
+
+class SubWil064 : public Sapphire::ScriptAPI::QuestScript
+{
+private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // BitFlag8
+    // UI8AL
+    // UI8BH
+
+    /// Countable Num: 0 Seq: 1 Event: 1 Listener: 2000268
+    /// Countable Num: 1 Seq: 255 Event: 8 Listener: 2000268
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      Seq1 = 1,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1001447; // Warin ( Pos: -32.639099 -1.033260 -148.485992  Teri: 141 )
+    static constexpr auto Enemy0 = 3785130; // 
+    static constexpr auto Enemy1 = 3785131; // 
+    static constexpr auto Enemy2 = 3785134; // 
+    static constexpr auto Eobject0 = 2000268; // Narrow Fissure ( Pos: 25.690800 13.106300 47.828999  Teri: 141 )
+    static constexpr auto Item0 = 2000212;
+
+  public:
+    SubWil064() : Sapphire::ScriptAPI::QuestScript( 65843 ){}; 
+    ~SubWil064() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        if( quest.getSeq() == Seq0 )
+        {
+          Scene00000( quest, player );
+        }
+        else if( quest.getSeq() == SeqFinish )
+        {
+          Scene00013( quest,player );
+        }
+        break;
+      }
+    }
+  }
+
+  void onEventItem( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    if (actorId == Eobject0)
+    {
+      Scene00002( quest, player );
+    }
+  }
+
+  void onBNpcKill( World::Quest& quest, Entity::BNpc& bnpc, Entity::Player& player ) override
+  {
+    switch( bnpc.getLayoutId() )
+    {
+      case Enemy0:
+      {
+        auto instance = teriMgr().getTerritoryByGuId( player.getTerritoryId() );
+        auto enemy1 = instance->createBNpcFromLayoutId( Enemy1, 1220 /*Find the right value*/, Common::BNpcType::Enemy );
+        auto enemy2 = instance->createBNpcFromLayoutId( Enemy2, 1220 /*Find the right value*/, Common::BNpcType::Enemy );
+
+        enemy1->setTriggerOwnerId( player.getId() );
+        enemy2->setTriggerOwnerId( player.getId() );
+        enemy1->hateListAddDelayed( player.getAsPlayer(), 1 );
+        enemy2->hateListAddDelayed( player.getAsPlayer(), 1 );
+        quest.setUI8AL( 1 );
+        break;
+      }
+      case Enemy1:
+      case Enemy2:
+      {
+        quest.setUI8AL( quest.getUI8AL() + 1 );
+        if( quest.getUI8AL() >= 4 )
+        {
+          quest.setUI8BH( 0 );
+          quest.setUI8AL( 0 );
+          quest.setSeq( SeqFinish );
+          eventMgr().sendNotice( player, getId(), 0, {} );
+        }
+        break;
+      }
+    }
+  }
+
+  private:
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, NONE, bindSceneReturn( &SubWil064::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      Scene00001( quest, player );
+    }
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, NONE, bindSceneReturn( &SubWil064::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setUI8BH( 1 );
+    quest.setSeq( Seq1 );
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00002( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 2, NONE, bindSceneReturn( &SubWil064::Scene00002Return ) );
+  }
+
+  void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setBitFlag8( 1, true );
+    auto instance = teriMgr().getTerritoryByGuId( player.getTerritoryId() );
+    auto enemy0 = instance->createBNpcFromLayoutId( Enemy0, 1220 /*Find the right value*/, Common::BNpcType::Enemy );
+    enemy0->setTriggerOwnerId( player.getId() );
+    enemy0->hateListAddDelayed( player.getAsPlayer(), 1 );
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00003( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 3, NONE, bindSceneReturn( &SubWil064::Scene00003Return ) );
+  }
+
+  void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00004( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 4, NONE, bindSceneReturn( &SubWil064::Scene00004Return ) );
+  }
+
+  void Scene00004Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00005( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 5, NONE, bindSceneReturn( &SubWil064::Scene00005Return ) );
+  }
+
+  void Scene00005Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00006( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 6, NONE, bindSceneReturn( &SubWil064::Scene00006Return ) );
+  }
+
+  void Scene00006Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00007( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 7, NONE, bindSceneReturn( &SubWil064::Scene00007Return ) );
+  }
+
+  void Scene00007Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00008( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 8, NONE, bindSceneReturn( &SubWil064::Scene00008Return ) );
+  }
+
+  void Scene00008Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00009( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 9, NONE, bindSceneReturn( &SubWil064::Scene00009Return ) );
+  }
+
+  void Scene00009Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00010( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 10, NONE, bindSceneReturn( &SubWil064::Scene00010Return ) );
+  }
+
+  void Scene00010Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00011( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 11, NONE, bindSceneReturn( &SubWil064::Scene00011Return ) );
+  }
+
+  void Scene00011Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00012( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 12, NONE, bindSceneReturn( &SubWil064::Scene00012Return ) );
+  }
+
+  void Scene00012Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00013( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 13, NONE, bindSceneReturn( &SubWil064::Scene00013Return ) );
+  }
+
+  void Scene00013Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      player.finishQuest( getId(), result.getResult( 1 ) );
+    }
+
+  }
+
+};
+
+EXPOSE_SCRIPT( SubWil064 );

--- a/src/scripts/quest/subquest/thanalan_central/SubWil070.cpp
+++ b/src/scripts/quest/subquest/thanalan_central/SubWil070.cpp
@@ -1,0 +1,233 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubWil070_00324
+// Quest Name: Disorderly Conduct
+// Quest ID: 65860
+// Start NPC: 1001541 (Roger)
+// End NPC: 1001541 (Roger)
+
+using namespace Sapphire;
+
+class SubWil070 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // BitFlag8
+    // UI8AL
+    // UI8BH
+
+    /// Countable Num: 4 Seq: 1 Event: 1 Listener: 1001462
+    /// Countable Num: 1 Seq: 255 Event: 1 Listener: 1001463
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      Seq1 = 1,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1001541; // Roger ( Pos: -99.395401 -11.380900 -41.723999  Teri: 141 )
+    static constexpr auto Actor1 = 1001462; // Roundelph ( Pos: -93.339500 -11.350300 -41.367199  Teri: 141 )
+    static constexpr auto Actor2 = 1001463; // Adalfuns ( Pos: -72.826401 -12.667800 -54.076199  Teri: 141 )
+    static constexpr auto Actor3 = 1001465; // Solid Trunk ( Pos: -90.043503 -11.398500 -53.666000  Teri: 141 )
+    static constexpr auto Actor4 = 1001466; // Ricard ( Pos: -89.735001 -11.350000 -51.539902  Teri: 141 )
+    static constexpr auto Item0 = 2000234;
+    static constexpr auto Seq0Actor0 = 0;
+    static constexpr auto Seq1Actor1 = 1;
+    static constexpr auto Seq1Actor2 = 2;
+    static constexpr auto Seq1Actor3 = 3; 
+    static constexpr auto Seq1Actor4 = 4; 
+    static constexpr auto Seq2Actor0 = 5; 
+    static constexpr auto Seq2Actor0Npctradeno = 99;
+    static constexpr auto Seq2Actor0Npctradeok = 100;
+
+  public:
+    SubWil070() : Sapphire::ScriptAPI::QuestScript( 65860 ){}; 
+    ~SubWil070() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        if( quest.getSeq() == 0 )
+          Scene00000( quest, player );
+        else if( quest.getSeq() == SeqFinish )
+          Scene00005( quest, player );
+        break;
+      }
+      case Actor1:
+      {
+        if( quest.getSeq() == 1 )
+          Scene00001( quest, player );
+        break;
+      }
+      case Actor2:
+      {
+        if( quest.getSeq() == 1 )
+          Scene00002( quest, player );
+        break;
+      }
+      case Actor3:
+      {
+        if( quest.getSeq() == 1 )
+          Scene00003( quest, player );
+        break;
+      }
+      case Actor4:
+      {
+        if( quest.getSeq() == 1 )
+          Scene00004( quest, player );
+        break;
+      }
+    }
+  }
+
+  void onEventItem( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+  }
+
+
+  private:
+    void checkQuestCompletion( World::Quest& quest, Entity::Player& player, uint32_t varIdx )
+    {
+      if( varIdx == 1 )
+      {
+      quest.setUI8AL( quest.getUI8AL() + 1 );
+      if (quest.getUI8AL() == 4)
+        quest.setSeq( SeqFinish );
+      }
+      eventMgr().sendEventNotice( player, getId(), 0, 2, quest.getUI8AL(), 4 ); // TODO: Add item icon (Oily Order Slip)
+    }
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &SubWil070::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      quest.setUI8BH( 1 );
+      quest.setSeq( Seq1 );
+    }
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, HIDE_HOTBAR, bindSceneReturn( &SubWil070::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    checkQuestCompletion( quest, player, 1 );
+    quest.setBitFlag8( 1, true );
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00002( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 2, HIDE_HOTBAR, bindSceneReturn( &SubWil070::Scene00002Return ) );
+  }
+
+  void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    checkQuestCompletion( quest, player, 1 );
+    quest.setBitFlag8( 2, true );
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00003( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 3, HIDE_HOTBAR, bindSceneReturn( &SubWil070::Scene00003Return ) );
+  }
+
+  void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    checkQuestCompletion( quest, player, 1 );
+    quest.setBitFlag8( 3, true );
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00004( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 4, HIDE_HOTBAR, bindSceneReturn( &SubWil070::Scene00004Return ) );
+  }
+
+  void Scene00004Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    checkQuestCompletion( quest, player, 1 );
+    quest.setBitFlag8( 4, true );
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00005( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 5, NONE, bindSceneReturn( &SubWil070::Scene00005Return ) );
+  }
+
+  void Scene00005Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 )
+    {
+      Scene00100( quest, player );
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00099( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 99, NONE, bindSceneReturn( &SubWil070::Scene00099Return ) );
+  }
+
+  void Scene00099Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00100( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 100, HIDE_HOTBAR, bindSceneReturn( &SubWil070::Scene00100Return ) );
+  }
+
+  void Scene00100Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      player.finishQuest( getId(), result.getResult( 1 ) );
+    }
+
+  }
+
+};
+
+EXPOSE_SCRIPT( SubWil070 );

--- a/src/scripts/quest/subquest/thanalan_central/SubWil070.cpp
+++ b/src/scripts/quest/subquest/thanalan_central/SubWil070.cpp
@@ -42,6 +42,7 @@ class SubWil070 : public Sapphire::ScriptAPI::QuestScript
     static constexpr auto Actor3 = 1001465; // Solid Trunk ( Pos: -90.043503 -11.398500 -53.666000  Teri: 141 )
     static constexpr auto Actor4 = 1001466; // Ricard ( Pos: -89.735001 -11.350000 -51.539902  Teri: 141 )
     static constexpr auto Item0 = 2000234;
+    static constexpr auto Item0Icon = 26153;
     static constexpr auto Seq0Actor0 = 0;
     static constexpr auto Seq1Actor1 = 1;
     static constexpr auto Seq1Actor2 = 2;
@@ -110,7 +111,7 @@ class SubWil070 : public Sapphire::ScriptAPI::QuestScript
       if (quest.getUI8AL() == 4)
         quest.setSeq( SeqFinish );
       }
-      eventMgr().sendEventNotice( player, getId(), 0, 2, quest.getUI8AL(), 4 ); // TODO: Add item icon (Oily Order Slip)
+      eventMgr().sendNotice( player, getId(), 0, { quest.getUI8AL(), 4, Item0Icon } );
     }
   //////////////////////////////////////////////////////////////////////
   // Available Scenes in this quest, not necessarly all are used

--- a/src/scripts/quest/subquest/thanalan_central/SubWil073.cpp
+++ b/src/scripts/quest/subquest/thanalan_central/SubWil073.cpp
@@ -1,0 +1,415 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include "Manager/EventMgr.h"
+#include <Actor/Player.h>
+#include <Actor/BNpc.h>
+#include <ScriptObject.h>
+#include <Service.h>
+
+#include "Actor/BNpc.h"
+#include "Manager/TerritoryMgr.h"
+#include "Territory/Territory.h"
+
+// Quest Script: SubWil073_00327
+// Quest Name: Spriggan Cleaning
+// Quest ID: 65863
+// Start NPC: 1001447 (Warin)
+// End NPC: 1001447 (Warin)
+
+using namespace Sapphire;
+
+class SubWil073 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // BitFlag8
+    // UI8AH
+    // UI8AL
+    // UI8BH
+    // UI8BL
+    // UI8CH
+    // UI8CL
+    // UI8DH
+    // UI8DL
+    // UI8EH
+
+    /// Countable Num: 4 Seq: 1 Event: 1 Listener: 2000377
+    /// Countable Num: 1 Seq: 255 Event: 5 Listener: 100
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      Seq1 = 1,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1001447; // Warin ( Pos: -32.639099 -1.033260 -148.485992  Teri: 141 )
+    static constexpr auto Enemy0 = 3742257; // 
+    static constexpr auto Enemy1 = 3742258; // 
+    static constexpr auto Enemy2 = 3742259; // 
+    static constexpr auto Enemy3 = 3742261; // 
+    static constexpr auto Eobject0 = 2000377; // Pockmarked Silver Ore ( Pos: -134.695999 6.168210 -116.594002  Teri: 141 )
+    static constexpr auto Eobject1 = 2000378; // Pockmarked Silver Ore ( Pos: -95.958298 -1.021940 -163.731003  Teri: 141 )
+    static constexpr auto Eobject2 = 2000379; // Pockmarked Silver Ore ( Pos: -103.938004 0.491295 -213.695007  Teri: 141 )
+    static constexpr auto Eobject3 = 2000380; // Pockmarked Silver Ore ( Pos: -1.174590 -1.322410 -111.265999  Teri: 141 )
+    static constexpr auto EventActionSearch = 1;
+    static constexpr auto Seq0Actor0 = 0; // 
+    static constexpr auto Seq1Eobject0 = 1; // 
+    static constexpr auto Seq1Eobject0Eventactionno = 99; // Hecatoncheir Piledriver
+    static constexpr auto Seq1Eobject0Eventactionok = 100; // Hecatoncheir Blastmaster ( Pos: -135.210007 5.708900 -117.417999  Teri: 141 )
+    static constexpr auto Seq1Eobject1 = 2; // Ruins Runner ( Pos: -5.462710 -1.142520 27.215000  Teri: 5 )
+    static constexpr auto Seq1Eobject1Eventactionno = 97; // Hecatoncheir Stonehauler
+    static constexpr auto Seq1Eobject1Eventactionok = 98; // Hecatoncheir Shockblocker
+    static constexpr auto Seq1Eobject2 = 3; // Antelope Doe
+    static constexpr auto Seq1Eobject2Eventactionno = 95; // Flux Flan
+    static constexpr auto Seq1Eobject2Eventactionok = 96; // Hecatoncheir Overseer
+    static constexpr auto Seq1Eobject3 = 4; // Antelope Stag
+    static constexpr auto Seq1Eobject3Eventactionno = 93; // Sargas
+    static constexpr auto Seq1Eobject3Eventactionok = 94; // Shaula
+    static constexpr auto Seq2Actor0 = 5; // Opo-opo
+
+  public:
+    SubWil073() : Sapphire::ScriptAPI::QuestScript( 65863 ){}; 
+    ~SubWil073() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        if( quest.getSeq() == Seq0 )
+          Scene00000( quest, player );
+        else if( quest.getSeq() == SeqFinish )
+          Scene00005( quest, player );
+        break;
+      }
+      case Eobject0:
+      {
+        eventMgr().eventActionStart(
+                player, getId(), EventActionSearch,
+                [ & ]( Entity::Player& player, uint32_t eventId, uint64_t additional ) {
+                  Scene00094( quest, player );
+                },
+                nullptr, 0 );
+        break;
+
+      }
+      case Eobject1:
+      {
+        eventMgr().eventActionStart(
+                player, getId(), EventActionSearch,
+                [ & ]( Entity::Player& player, uint32_t eventId, uint64_t additional ) {
+                  Scene00095( quest, player );
+                },
+                nullptr, 0 );
+        break;
+      }
+      case Eobject2:
+      {
+        eventMgr().eventActionStart(
+                player, getId(), EventActionSearch,
+                [ & ]( Entity::Player& player, uint32_t eventId, uint64_t additional ) {
+                  Scene00096( quest, player );
+                },
+                nullptr, 0 );
+        break;
+      }
+      case Eobject3:
+      {
+        eventMgr().eventActionStart(
+                player, getId(), EventActionSearch,
+                [ & ]( Entity::Player& player, uint32_t eventId, uint64_t additional ) {
+                  Scene00097( quest, player );
+                },
+                nullptr, 0 );
+        break;
+      }
+    }
+  }
+
+  void onEventItem( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+  }
+
+  void onBNpcKill( World::Quest& quest, Entity::BNpc& bnpc, Entity::Player& player ) override
+  {
+    switch (bnpc.getLayoutId())
+    {
+      case Enemy0:
+      {
+        quest.setUI8AL( 1 );
+        quest.setUI8BH( 1 );
+        checkQuestCompletion( quest, player );
+        break;
+      }
+      case Enemy1:
+      {
+        quest.setUI8BL( 1 );
+        quest.setUI8CH( 1 );
+        checkQuestCompletion( quest, player );
+        break;
+      }
+      case Enemy2:
+      {
+        quest.setUI8CL( 1 );
+        quest.setUI8DH( 1 );
+        checkQuestCompletion( quest, player );
+        break;
+      }
+      case Enemy3:
+      {
+        quest.setUI8DL( 1 );
+        quest.setUI8EH( 1 );
+        checkQuestCompletion( quest, player );
+        break;
+      }
+    }
+  }
+
+  private:
+    void checkQuestCompletion( World::Quest& quest, Entity::Player& player )
+    {
+      quest.setUI8AH( quest.getUI8AH() + 1 );
+      eventMgr().sendEventNotice( player, getId(), 0, 2, quest.getUI8AH(), 4 );
+
+      if( quest.getUI8AH() >= 4 )
+      {
+        quest.setUI8AL( 0 );
+        quest.setUI8BH( 0 );
+        quest.setUI8BL( 0 );
+        quest.setUI8CH( 0 );
+        quest.setUI8CL( 0 );
+        quest.setUI8DH( 0 );
+        quest.setUI8DL( 0 );
+        quest.setUI8EH( 0 );
+        quest.setUI8AH( 0 );
+        quest.setBitFlag8( 1, false );
+        quest.setBitFlag8( 2, false );
+        quest.setBitFlag8( 3, false );
+        quest.setBitFlag8( 4, false );
+        quest.setSeq( SeqFinish );
+      }
+    }
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &SubWil073::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      Scene00001( quest, player );
+    }
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, HIDE_HOTBAR, bindSceneReturn( &SubWil073::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    quest.setSeq( Seq1 );
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00002( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 2, NONE, bindSceneReturn( &SubWil073::Scene00002Return ) );
+  }
+
+  void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00003( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 3, NONE, bindSceneReturn( &SubWil073::Scene00003Return ) );
+  }
+
+  void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00004( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 4, NONE, bindSceneReturn( &SubWil073::Scene00004Return ) );
+  }
+
+  void Scene00004Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00005( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 5, HIDE_HOTBAR, bindSceneReturn( &SubWil073::Scene00005Return ) );
+  }
+
+  void Scene00005Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      player.finishQuest( getId(), result.getResult( 1 ) );
+    }
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00093( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 93, NONE, bindSceneReturn( &SubWil073::Scene00093Return ) );
+  }
+
+  void Scene00093Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00094( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 94, NONE, bindSceneReturn( &SubWil073::Scene00094Return ) );
+  }
+
+  void Scene00094Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    auto instance = teriMgr().getTerritoryByGuId( player.getTerritoryId() );
+    auto enemy = instance->createBNpcFromLayoutId( Enemy0, 1220 /*Find the right value*/, Common::BNpcType::Enemy );
+
+    enemy->setTriggerOwnerId( player.getId() );
+    enemy->hateListAddDelayed( player.getAsPlayer(), 1 );
+    quest.setBitFlag8( 1, true );
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00095( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 95, NONE, bindSceneReturn( &SubWil073::Scene00095Return ) );
+  }
+
+  void Scene00095Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    auto instance = teriMgr().getTerritoryByGuId( player.getTerritoryId() );
+    auto enemy = instance->createBNpcFromLayoutId( Enemy1, 1220 /*Find the right value*/, Common::BNpcType::Enemy );
+
+    enemy->setTriggerOwnerId( player.getId() );
+    enemy->hateListAddDelayed( player.getAsPlayer(), 1 );
+    quest.setBitFlag8( 2, true );
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00096( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 96, NONE, bindSceneReturn( &SubWil073::Scene00096Return ) );
+  }
+
+  void Scene00096Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    auto instance = teriMgr().getTerritoryByGuId( player.getTerritoryId() );
+    auto enemy = instance->createBNpcFromLayoutId( Enemy2, 1220 /*Find the right value*/, Common::BNpcType::Enemy );
+
+    enemy->setTriggerOwnerId( player.getId() );
+    enemy->hateListAddDelayed( player.getAsPlayer(), 1 );
+    quest.setBitFlag8( 3, true );
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00097( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 97, NONE, bindSceneReturn( &SubWil073::Scene00097Return ) );
+  }
+
+  void Scene00097Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    auto instance = teriMgr().getTerritoryByGuId( player.getTerritoryId() );
+    auto enemy = instance->createBNpcFromLayoutId( Enemy3, 1220 /*Find the right value*/, Common::BNpcType::Enemy );
+
+    enemy->setTriggerOwnerId( player.getId() );
+    enemy->hateListAddDelayed( player.getAsPlayer(), 1 );
+    quest.setBitFlag8( 4, true );
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00098( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 98, NONE, bindSceneReturn( &SubWil073::Scene00098Return ) );
+  }
+
+  void Scene00098Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00099( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 99, NONE, bindSceneReturn( &SubWil073::Scene00099Return ) );
+  }
+
+  void Scene00099Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00100( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 100, NONE, bindSceneReturn( &SubWil073::Scene00100Return ) );
+  }
+
+  void Scene00100Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+
+  }
+
+};
+
+EXPOSE_SCRIPT( SubWil073 );

--- a/src/scripts/quest/subquest/thanalan_central/SubWil080.cpp
+++ b/src/scripts/quest/subquest/thanalan_central/SubWil080.cpp
@@ -1,0 +1,136 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include <Actor/Player.h>
+#include "Manager/EventMgr.h"
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: SubWil080_00328
+// Quest Name: Supply and Demands
+// Quest ID: 65864
+// Start NPC: 1002065 (Dadanen)
+// End NPC: 1002061 (Drunken Stag)
+
+using namespace Sapphire;
+
+class SubWil080 : public Sapphire::ScriptAPI::QuestScript
+{
+  private:
+    // Basic quest information 
+    // Quest vars / flags used
+    // UI8AL
+    // UI8BH
+
+    /// Countable Num: 1 Seq: 255 Event: 1 Listener: 1002061
+    // Steps in this quest ( 0 is before accepting, 
+    // 1 is first, 255 means ready for turning it in
+    enum Sequence : uint8_t
+    {
+      Seq0 = 0,
+      SeqFinish = 255,
+    };
+
+    // Entities found in the script data of the quest
+    static constexpr auto Actor0 = 1002065; // Dadanen ( Pos: 60.946701 45.145302 -204.985992  Teri: 140 )
+    static constexpr auto Actor1 = 1002061; // Drunken Stag ( Pos: 240.998993 58.318298 -160.998001  Teri: 140 )
+    static constexpr auto Item0 = 2000368;
+
+  public:
+    SubWil080() : Sapphire::ScriptAPI::QuestScript( 65864 ){}; 
+    ~SubWil080() = default; 
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        if( quest.getSeq() == Seq0 )
+          Scene00000( quest, player );
+        break;
+      }
+      case Actor1:
+      {
+        if( quest.getSeq() == SeqFinish )
+          Scene00001( quest, player );
+        break;
+      }
+    }
+  }
+
+  void onEventItem( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+  }
+
+
+  private:
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &SubWil080::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 ) // accept quest
+    {
+      quest.setUI8BH( 1 );
+      quest.setSeq( SeqFinish );
+    }
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, HIDE_HOTBAR, bindSceneReturn( &SubWil080::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if (result.getResult(0) == 1)
+    {
+      Scene00002( quest, player );
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00002( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 2, NONE, bindSceneReturn( &SubWil080::Scene00002Return ) );
+  }
+
+  void Scene00002Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      player.finishQuest( getId(), result.getResult( 1 ) );
+    }
+
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00003( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 3, NONE, bindSceneReturn( &SubWil080::Scene00003Return ) );
+  }
+
+  void Scene00003Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+  }
+
+};
+
+EXPOSE_SCRIPT( SubWil080 );


### PR DESCRIPTION
Implemented ManWil005 and the quest battle that goes with it (Underneath the Sultantree)

Added Item Icons to all quests that had notices with a TODO for item icons marked beside them.

Implemented more SubWil quests (Ul'dah MSQ)
- SubWil025
- SubWil026
- SubWil060
- SubWil062
- SubWil063
- Subwil064
- SubWil070
- SubWil073
- SubWil080

and some minor side quest fixes (SubSea) with setting BitFlag8