### PR TITLE
Minor ItemAction and Player Title fixes

### DIFF
--- a/src/common/Common.h
+++ b/src/common/Common.h
@@ -1023,6 +1023,7 @@ namespace Sapphire::Common
     ItemActionCompanion = 853,
     ItemActionVFX2 = 944,
     ItemActionMount = 1322,
+    ItemActionSong = 5845,
   };
 
   enum ActionEffectDisplayType : uint8_t

--- a/src/world/Action/ItemAction.cpp
+++ b/src/world/Action/ItemAction.cpp
@@ -67,6 +67,13 @@ void ItemAction::execute()
 
       break;
     }
+
+    case Common::ItemActionType::ItemActionSong:
+    {
+      handleSongItem();
+
+      break;
+    }
   }
 }
 
@@ -101,5 +108,13 @@ void ItemAction::handleMountItem()
   auto player = getSourceChara()->getAsPlayer();
 
   player->unlockMount( m_itemAction->data().Calcu0Arg[ 0 ] );
+  player->dropInventoryItem( static_cast< Common::InventoryType >( m_itemSourceContainer ), static_cast< uint8_t >( m_itemSourceSlot ) );
+}
+
+void ItemAction::handleSongItem()
+{
+  auto player = getSourceChara()->getAsPlayer();
+
+  player->learnSong( m_itemAction->data().Calcu0Arg[ 0 ], m_id );
   player->dropInventoryItem( static_cast< Common::InventoryType >( m_itemSourceContainer ), static_cast< uint8_t >( m_itemSourceSlot ) );
 }

--- a/src/world/Action/ItemAction.h
+++ b/src/world/Action/ItemAction.h
@@ -31,6 +31,8 @@ namespace Sapphire::World::Action
 
     void handleMountItem();
 
+    void handleSongItem();
+
   private:
     std::shared_ptr< Excel::ExcelStruct< Excel::ItemAction > > m_itemAction;
 

--- a/src/world/Actor/Player.cpp
+++ b/src/world/Actor/Player.cpp
@@ -1183,7 +1183,7 @@ void Player::setTitle( uint16_t titleId )
   uint8_t value;
   Util::valueToFlagByteIndexValue( titleId, value, index );
 
-  if( ( m_titleList[ index ] & value ) == 0 )   // Player doesn't have title - bail
+  if( ( m_titleList[ index ] & value ) == 0 && titleId != 0 )   // Player doesn't have title and is not "no title" - bail
     return;
 
   m_activeTitle = titleId;


### PR DESCRIPTION
- Added missing `handleSongItem` item action. The function to register an orchestrion roll was already implemented in Player.cpp but was just missing the handler function.

- Added additional condition to allow for currently equipped title to be removed. titleID = 0 corresponds to the "None" entry in the title selection menu, all players already have this