### PR TITLE
CNJ and SubFst Quests and EventMgr Fixes

### DIFF
--- a/src/scripts/quest/classquest/CNJ/ClsCnj998.cpp
+++ b/src/scripts/quest/classquest/CNJ/ClsCnj998.cpp
@@ -1,0 +1,105 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include "Manager/EventMgr.h"
+#include <Actor/Player.h>
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: ClsCnj998_00133
+// Quest Name: Way of the Conjurer
+// Quest ID: 65669
+// Start NPC: 1000323 (Madelle)
+// End NPC: 1000692 (E-Sumi-Yan)
+
+using namespace Sapphire;
+
+class ClsCnj998 : public Sapphire::ScriptAPI::QuestScript
+{
+private:
+  // Basic quest information
+  // Quest vars / flags used
+  // UI8AL
+
+  /// Countable Num: 1 Seq: 255 Event: 1 Listener: 1000692
+  // Steps in this quest ( 0 is before accepting,
+  // 1 is first, 255 means ready for turning it in
+  enum Sequence : uint8_t
+  {
+    Seq0 = 0,
+    SeqFinish = 255,
+  };
+
+  // Entities found in the script data of the quest
+  static constexpr auto Actor0 = 1000323;// Madelle ( Pos: -234.028000 -4.000220 -11.062800  Teri: 133 )
+  static constexpr auto Actor1 = 1000692;// E-sumi-yan ( Pos: -258.808014 -5.773500 -27.237400  Teri: 133 )
+  static constexpr auto Classjob = 6;
+  static constexpr auto GearsetUnlock = 1905;
+  static constexpr auto LogmessageMonsterNotePageUnlock = 1009;
+  static constexpr auto UnlockImageClassCnj = 25;
+
+public:
+  ClsCnj998() : Sapphire::ScriptAPI::QuestScript( 65669 ){};
+  ~ClsCnj998() = default;
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        if( quest.getSeq() == Seq0 )
+          Scene00000( quest, player );
+        break;
+      }
+      case Actor1:
+      {
+        if( quest.getSeq() == SeqFinish )
+          Scene00001( quest, player );
+        break;
+      }
+    }
+  }
+
+
+private:
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &ClsCnj998::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 )// accept quest
+    {
+      quest.setSeq( SeqFinish );
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00001( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 1, FADE_OUT | HIDE_UI, bindSceneReturn( &ClsCnj998::Scene00001Return ) );
+  }
+
+  void Scene00001Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+
+    if( result.getResult( 0 ) == 1 )
+    {
+      player.finishQuest( getId() );
+      player.setLevelForClass( 1, Sapphire::Common::ClassJob::Conjurer );
+      player.addGearSet();
+    }
+  }
+};
+
+EXPOSE_SCRIPT( ClsCnj998 );

--- a/src/scripts/quest/classquest/CNJ/ClsCnj999.cpp
+++ b/src/scripts/quest/classquest/CNJ/ClsCnj999.cpp
@@ -1,0 +1,72 @@
+// This is an automatically generated C++ script template
+// Content needs to be added by hand to make it function
+// In order for this script to be loaded, move it to the correct folder in <root>/scripts/
+
+#include "Manager/EventMgr.h"
+#include <Actor/Player.h>
+#include <ScriptObject.h>
+#include <Service.h>
+
+// Quest Script: ClsCnj999_00182
+// Quest Name: So You Want to Be a Conjurer
+// Quest ID: 65718
+// Start NPC: 1000323 (Madelle)
+// End NPC: 1000323 (Madelle)
+
+using namespace Sapphire;
+
+class ClsCnj999 : public Sapphire::ScriptAPI::QuestScript
+{
+private:
+  // Basic quest information
+  // Quest vars / flags used
+
+  // Steps in this quest ( 0 is before accepting,
+  // 1 is first, 255 means ready for turning it in
+  enum Sequence : uint8_t
+  {
+  };
+  static constexpr auto Actor0 = 1000323;
+
+
+  // Entities found in the script data of the quest
+
+public:
+  ClsCnj999() : Sapphire::ScriptAPI::QuestScript( 65718 ){};
+  ~ClsCnj999() = default;
+
+  //////////////////////////////////////////////////////////////////////
+  // Event Handlers
+  void onTalk( World::Quest& quest, Entity::Player& player, uint64_t actorId ) override
+  {
+    switch( actorId )
+    {
+      case Actor0:
+      {
+        Scene00000( quest, player );
+        break;
+      }
+    }
+  }
+
+
+private:
+  //////////////////////////////////////////////////////////////////////
+  // Available Scenes in this quest, not necessarly all are used
+  //////////////////////////////////////////////////////////////////////
+
+  void Scene00000( World::Quest& quest, Entity::Player& player )
+  {
+    eventMgr().playQuestScene( player, getId(), 0, HIDE_HOTBAR, bindSceneReturn( &ClsCnj999::Scene00000Return ) );
+  }
+
+  void Scene00000Return( World::Quest& quest, Entity::Player& player, const Event::SceneResult& result )
+  {
+    if( result.getResult( 0 ) == 1 )
+    {
+      player.finishQuest( getId(), 0 );
+    }
+  }
+};
+
+EXPOSE_SCRIPT( ClsCnj999 );

--- a/src/scripts/quest/subquest/gridania/SubFst009.cpp
+++ b/src/scripts/quest/subquest/gridania/SubFst009.cpp
@@ -96,8 +96,6 @@ class SubFst009 : public Sapphire::ScriptAPI::QuestScript
   {
     if (result.getResult(0) == 1)
       Scene00100(quest, player);
-    else
-      Scene00099(quest, player);
   }
 
   //////////////////////////////////////////////////////////////////////

--- a/src/scripts/quest/subquest/gridania/SubFst011.cpp
+++ b/src/scripts/quest/subquest/gridania/SubFst011.cpp
@@ -67,8 +67,11 @@ public:
       case Enemy0:
       {
         auto currentKC = quest.getUI8AL();
-        quest.setUI8AL( currentKC + 1 );
-        eventMgr().sendEventNotice( player, getId(), 0, 2, currentKC + 1, 6 );
+        if( currentKC < 6 )
+        {
+          quest.setUI8AL( currentKC + 1 );
+          eventMgr().sendEventNotice( player, getId(), 0, 2, currentKC + 1, 6 );
+        }
 
         if( currentKC + 1 >= 6 )
           quest.setSeq( SeqFinish );

--- a/src/world/Manager/EventMgr.cpp
+++ b/src/world/Manager/EventMgr.cpp
@@ -552,6 +552,9 @@ void EventMgr::eventFinish( Sapphire::Entity::Player& player, uint32_t eventId, 
 
   if( player.hasCondition( Common::PlayerCondition::WatchingCutscene ) )
     player.removeCondition( Common::PlayerCondition::WatchingCutscene );
+  
+  if( player.hasCondition( Common::PlayerCondition::Casting ))
+    player.removeCondition( Common::PlayerCondition::Casting );
 
   player.removeEvent( pEvent->getId() );
 


### PR DESCRIPTION
- Implemented missing CNJ job quests

- Add bounds checking to SubFst011 to prevent repeated EventNotices being sent when quest conditions are already met

- Remove casting condition from player on eventFinish in EventMgr
This fixes an issue in all quests where using a key item with some cast time on some object results in the player being stuck in a casting state and unable to do anything except move

- Scene00099  in SubFst009 causes the server to infinitely attempt to return from it. Not actually needed here since there's no additional dialogue for cancelling the turn in so I don't think that scene is used.

output from cancelling turn in with Scene00099
```
[11:42:16.053] [debug] 		 TARGET_DECIDE | 3 ( p1:E0000000 p11:E0000000 p12:0 p2:0 p3:0 p4:0 )
[11:42:16.360] [debug] [2097154] Zone IPC : StartTalkEvent ( 01C2 )
[11:42:17.823] [debug] [2097154] Zone IPC : Command ( 0191 )
[11:42:17.823] [debug] 		 TARGET_DECIDE | 3 ( p1:100117A92 p11:117A92 p12:1 p2:0 p3:0 p4:0 )
[11:42:20.608] [debug] [2097154] Zone IPC : ReturnEventScene2 ( 01D7 )
[11:42:22.327] [debug] [2097154] Zone IPC : ReturnEventScene2 ( 01D7 )
[11:42:23.775] [debug] [2097154] Zone IPC : ReturnEventScene2 ( 01D7 )
[11:42:25.537] [debug] [2097154] Zone IPC : ReturnEventScene2 ( 01D7 )
```

