### PR TITLE
Dummy aggro fix

### DIFF
--- a/src/world/AI/Fsm/StateCombat.cpp
+++ b/src/world/AI/Fsm/StateCombat.cpp
@@ -48,6 +48,11 @@ void AI::Fsm::StateCombat::onUpdate( Entity::BNpc& bnpc, uint64_t tickCount )
     bnpc.moveTo( *pHatedActor );
   }
 
+  if (bnpc.hasFlag(Entity::Immobile) && distance > 30.0f )
+  {
+    bnpc.deaggro( pHatedActor );
+  }
+
   if( pNaviProvider->syncPosToChara( bnpc ) )
     bnpc.sendPositionUpdate();
 

--- a/src/world/AI/Fsm/StateCombat.cpp
+++ b/src/world/AI/Fsm/StateCombat.cpp
@@ -38,7 +38,7 @@ void AI::Fsm::StateCombat::onUpdate( Entity::BNpc& bnpc, uint64_t tickCount )
   // All possibilities to automatically lose aggro go here
   if( !bnpc.hasFlag( Entity::NoDeaggro ) )
   {
-    if( bnpc.hasFlag( Entity::Immobile ) && distance > 30.0f )
+    if( bnpc.hasFlag( Entity::Immobile ) && distance > 40.0f )
     {
       bnpc.deaggro( pHatedActor );
     }

--- a/src/world/AI/Fsm/StateCombat.cpp
+++ b/src/world/AI/Fsm/StateCombat.cpp
@@ -35,6 +35,11 @@ void AI::Fsm::StateCombat::onUpdate( Entity::BNpc& bnpc, uint64_t tickCount )
 
   auto distance = Common::Util::distance( bnpc.getPos(), pHatedActor->getPos() );
 
+  if( bnpc.hasFlag( Entity::Immobile ) && distance > 30.0f )
+  {
+    bnpc.deaggro( pHatedActor );
+  }
+
   if( !bnpc.hasFlag( Entity::NoDeaggro ) )
   {
 
@@ -46,11 +51,6 @@ void AI::Fsm::StateCombat::onUpdate( Entity::BNpc& bnpc, uint64_t tickCount )
       pNaviProvider->setMoveTarget( bnpc, pHatedActor->getPos() );
 
     bnpc.moveTo( *pHatedActor );
-  }
-
-  if (bnpc.hasFlag(Entity::Immobile) && distance > 30.0f )
-  {
-    bnpc.deaggro( pHatedActor );
   }
 
   if( pNaviProvider->syncPosToChara( bnpc ) )

--- a/src/world/AI/Fsm/StateCombat.cpp
+++ b/src/world/AI/Fsm/StateCombat.cpp
@@ -35,14 +35,13 @@ void AI::Fsm::StateCombat::onUpdate( Entity::BNpc& bnpc, uint64_t tickCount )
 
   auto distance = Common::Util::distance( bnpc.getPos(), pHatedActor->getPos() );
 
-  if( bnpc.hasFlag( Entity::Immobile ) && distance > 30.0f )
-  {
-    bnpc.deaggro( pHatedActor );
-  }
-
+  // All possibilities to automatically lose aggro go here
   if( !bnpc.hasFlag( Entity::NoDeaggro ) )
   {
-
+    if( bnpc.hasFlag( Entity::Immobile ) && distance > 30.0f )
+    {
+      bnpc.deaggro( pHatedActor );
+    }
   }
 
   if( !bnpc.hasFlag( Entity::Immobile ) && distance > ( bnpc.getNaviTargetReachedDistance() + pHatedActor->getRadius() ) )

--- a/src/world/Actor/BNpc.cpp
+++ b/src/world/Actor/BNpc.cpp
@@ -449,7 +449,7 @@ void BNpc::hateListClear()
     if( isInRangeSet( listEntry->m_pChara ) )
     {
       if( listEntry->m_pChara->isPlayer() )
-        notifyPlayerDeaggro( listEntry->m_pChara )
+        BNpc::notifyPlayerDeaggro( listEntry->m_pChara );
     }
   }
   m_hateList.clear();
@@ -630,7 +630,7 @@ void BNpc::deaggro( const CharaPtr& pChara )
     hateListRemove( pChara );
 
   if( pChara->isPlayer() )
-    notifyPlayerDeaggro(pChara)
+    notifyPlayerDeaggro( pChara );
 }
 
 void BNpc::notifyPlayerDeaggro(const CharaPtr& pChara)

--- a/src/world/Actor/BNpc.cpp
+++ b/src/world/Actor/BNpc.cpp
@@ -449,7 +449,7 @@ void BNpc::hateListClear()
     if( isInRangeSet( listEntry->m_pChara ) )
     {
       if( listEntry->m_pChara->isPlayer() )
-        BNpc::notifyPlayerDeaggro( listEntry->m_pChara );
+        notifyPlayerDeaggro( listEntry->m_pChara );
     }
   }
   m_hateList.clear();

--- a/src/world/Actor/BNpc.h
+++ b/src/world/Actor/BNpc.h
@@ -115,6 +115,7 @@ namespace Sapphire::Entity
 
     void aggro( const CharaPtr& pChara );
     void deaggro( const CharaPtr& pChara );
+    void notifyPlayerDeaggro( const CharaPtr& pChara );
 
     void update( uint64_t tickCount ) override;
     void onTick() override;


### PR DESCRIPTION
Striking dummies (and all other immobile entities) will now deaggro when moving more than 30 units away (instead of never).

I don't know which distance they used in retail during HW but the current live version has a significantly increased deaggro distance for dummies since they added a reset aggro context menu. So I used 30y> because it's longer than all player attacks.