### PR TITLE
Supply status effect itself for onTick script

### DIFF
--- a/src/world/Script/NativeScriptApi.cpp
+++ b/src/world/Script/NativeScriptApi.cpp
@@ -38,7 +38,7 @@ namespace Sapphire::ScriptAPI
   {
   }
 
-  void StatusEffectScript::onTick( Entity::Chara& actor )
+  void StatusEffectScript::onTick( Entity::Chara& actor, Sapphire::StatusEffect::StatusEffect& effect )
   {
   }
 

--- a/src/world/Script/NativeScriptApi.h
+++ b/src/world/Script/NativeScriptApi.h
@@ -71,7 +71,7 @@ namespace Sapphire::ScriptAPI
     *
     * @param actor the actor the status effect is ticking on
     */
-    virtual void onTick( Sapphire::Entity::Chara& actor );
+    virtual void onTick( Sapphire::Entity::Chara& actor, Sapphire::StatusEffect::StatusEffect& effect );
 
     /*!
     * @brief Called when the status effect is applied to an actor

--- a/src/world/Script/ScriptMgr.cpp
+++ b/src/world/Script/ScriptMgr.cpp
@@ -644,7 +644,7 @@ bool Sapphire::Scripting::ScriptMgr::onStatusTick( Entity::CharaPtr pChara, Sapp
   auto script = m_nativeScriptMgr->getScript< Sapphire::ScriptAPI::StatusEffectScript >( effect.getId() );
   if( script )
   {
-    script->onTick( *pChara );
+    script->onTick( *pChara, effect );
     return true;
   }
 


### PR DESCRIPTION
This will be required for eg. dot procs on BRD so we know who applied the dot. The status information may also include snapshot information for correct damage calculations which we'd need here.

I made this small change its own PR because I think it can easily break stuff on other branches and I didn't want to mix this into my big pile of BRD skills that come later