### PR TITLE
Fixed fly text of action scripts

### DIFF
--- a/src/world/Action/Action.cpp
+++ b/src/world/Action/Action.cpp
@@ -525,7 +525,7 @@ void Action::Action::buildActionResults()
   if( !m_enableGenericHandler || !hasLutEntry || m_hitActors.empty() )
   {
     // send any effect packet added by script or an empty one just to play animation for other players
-    m_actionResultBuilder->sendActionResults( {} );
+    m_actionResultBuilder->sendActionResults( { m_hitActors } );
     return;
   }
 


### PR DESCRIPTION
We now always send a package with all targets regardless if the list is emtpty or if there is no lut info. Doing this will always send the package after the script (which we must do always anyway). If there is no valid lut, then it will apply nothing to all targets. If there are no targets, then the it behaves the same as before (empty list)