### PR TITLE
getEventItemIcon function 

### DIFF
--- a/src/world/Actor/Player.h
+++ b/src/world/Actor/Player.h
@@ -103,6 +103,8 @@ namespace Sapphire::Entity
 
     int16_t getQuestTracking( uint8_t index ) const;
 
+    uint16_t getQuestItemIcon( uint32_t itemId );
+
     /*! finish a given quest */
     void finishQuest( uint16_t questId, uint32_t optionalChoice = 0 );
 

--- a/src/world/Actor/PlayerQuest.cpp
+++ b/src/world/Actor/PlayerQuest.cpp
@@ -211,7 +211,12 @@ Player::QuestComplete& Player::getQuestCompleteFlags()
   return m_questCompleteFlags;
 }
 
+uint16_t Player::getQuestItemIcon( uint32_t itemId )
+{
+  auto& questMgr = Common::Service< Manager::QuestMgr >::ref();
 
+  return questMgr.getItemIcon( itemId );
+}
 
 
 

--- a/src/world/Manager/QuestMgr.cpp
+++ b/src/world/Manager/QuestMgr.cpp
@@ -141,3 +141,10 @@ void QuestMgr::sendQuestsInfo( Entity::Player &player )
   sendQuestTracker( player );
 }
 
+uint16_t QuestMgr::getItemIcon(uint32_t itemId)
+{
+  auto& exdData = Common::Service< Data::ExdData >::ref();
+  auto eventItem = exdData.getRow< Excel::EventItem >( itemId );
+
+  return eventItem->_data.Icon;
+}

--- a/src/world/Manager/QuestMgr.h
+++ b/src/world/Manager/QuestMgr.h
@@ -26,6 +26,7 @@ namespace Sapphire::World::Manager
 
     bool giveQuestRewards( Entity::Player& player, uint16_t questId, uint32_t optionalChoice );
 
+    uint16_t getItemIcon( uint32_t itemId );
   };
 
 }


### PR DESCRIPTION
This function provides the EventItem icon, which can then be used by the sendNotice function in quests.

Example:
`static constexpr auto Item0 = 2000148;`
`eventMgr().sendNotice( player, getId(), 0, { quest.getUI8AH(), 3, player.getQuestItemIcon( Item0 ) } );`