### PR TITLE
World initialization performance

### DIFF
--- a/deps/datReader/Exd.h
+++ b/deps/datReader/Exd.h
@@ -94,6 +94,10 @@ namespace xiv::exd
 
     ~Exd();
 
+    // Prevent implicit copying
+    Exd( const Exd& ) = delete;
+    Exd& operator=( const Exd& ) = delete;
+
     // Get a row by its id
     const std::vector< Field > get_row( uint32_t id );
 
@@ -376,7 +380,7 @@ namespace xiv::exd
     std::map< uint32_t, std::vector< Field > > _data;
     std::vector< std::shared_ptr< dat::File > > _files;
     std::shared_ptr< Exh > _exh;
-    std::map< uint32_t, ExdCacheEntry > _idCache;
+    std::unordered_map< uint32_t, ExdCacheEntry > _idCache;
   };
 
 }

--- a/deps/datReader/ExdCat.cpp
+++ b/deps/datReader/ExdCat.cpp
@@ -62,12 +62,12 @@ namespace xiv::exd
     return _name;
   }
 
-  const Exh& Cat::get_header() const
+  Exh& Cat::get_header()
   {
     return *_header;
   }
 
-  const Exd& Cat::get_data_ln( Language i_language ) const
+  Exd& Cat::get_data_ln( Language i_language )
   {
     auto ln_it = _data.find( i_language );
     if( ln_it == _data.end() )
@@ -78,7 +78,7 @@ namespace xiv::exd
     return *( ln_it->second );
   }
 
-  const Exd& Cat::get_data( Language language ) const
+  Exd& Cat::get_data( Language language )
   {
     auto ln_it = _data.find( language );
     if( ln_it == _data.end() )

--- a/deps/datReader/ExdCat.h
+++ b/deps/datReader/ExdCat.h
@@ -45,12 +45,12 @@ namespace xiv
          const std::string& get_name() const;
 
          // Returns the header
-         const Exh& get_header() const;
+         Exh& get_header();
 
          // Returns data for a specific language
-         const Exd& get_data_ln( Language i_language = Language::none ) const;
+         Exd& get_data_ln( Language i_language = Language::none );
 
-         const Exd& get_data( Language language = Language::none ) const;
+         Exd& get_data( Language language = Language::none );
       protected:
          const std::string _name;
 

--- a/deps/datReader/ExdData.cpp
+++ b/deps/datReader/ExdData.cpp
@@ -60,7 +60,7 @@ const std::vector< std::string >& ExdData::get_cat_names() const
   return _cat_names;
 }
 
-const Cat& ExdData::get_category( const std::string& i_cat_name )
+Cat& ExdData::get_category( const std::string& i_cat_name )
 {
   // Get the category from its name
   auto cat_it = _cats.find( i_cat_name );

--- a/deps/datReader/ExdData.h
+++ b/deps/datReader/ExdData.h
@@ -32,7 +32,7 @@ namespace xiv
           const std::vector<std::string>& get_cat_names() const;
 
           // Get a category by its name
-          const Cat& get_category(const std::string& i_cat_name);
+          Cat& get_category(const std::string& i_cat_name);
 
           // Export in csv in base flder i_ouput_path
           void export_as_csvs(const std::filesystem::path& i_output_path);

--- a/src/tools/nav_export/main.cpp
+++ b/src/tools/nav_export/main.cpp
@@ -82,10 +82,10 @@ std::string getEobjSgbPath( uint32_t eobjId )
     return exportedSgMap[ eobjSgbPaths[ eobjId ] ];
 
   auto& eobjCat = eData->get_category( "EObj" );
-  auto eObjExd = static_cast< xiv::exd::Exd >( eobjCat.get_data_ln( xiv::exd::Language::en ) );
+  auto& eObjExd = eobjCat.get_data_ln( xiv::exd::Language::en );
 
   auto& exportedSgCat = eData->get_category( "ExportedSG" );
-  auto exportedSgExd = static_cast< xiv::exd::Exd >( exportedSgCat.get_data_ln( xiv::exd::Language::none ) );
+  auto& exportedSgExd = exportedSgCat.get_data_ln( xiv::exd::Language::none );
 
   for( auto& row : exportedSgExd.get_rows() )
   {
@@ -114,7 +114,7 @@ std::string zoneNameToPath( const std::string& name )
   bool found = false;
 
   auto& cat = eData->get_category( "TerritoryType" );
-  auto exd = static_cast< xiv::exd::Exd >( cat.get_data_ln( xiv::exd::Language::none ) );
+  auto& exd = cat.get_data_ln( xiv::exd::Language::none );
   for( auto& row : exd.get_rows() )
   {
     auto& fields = row.second;

--- a/src/tools/pcb_reader/main.cpp
+++ b/src/tools/pcb_reader/main.cpp
@@ -84,10 +84,10 @@ std::string getEobjSgbPath( uint32_t eobjId )
     return exportedSgMap[ eobjSgbPaths[ eobjId ] ];
 
   auto& eobjCat = eData->get_category( "EObj" );
-  auto eObjExd = static_cast< xiv::exd::Exd >( eobjCat.get_data_ln( xiv::exd::Language::none ) );
+  auto& eObjExd = eobjCat.get_data_ln( xiv::exd::Language::none );
 
   auto& exportedSgCat = eData->get_category( "ExportedSG" );
-  auto exportedSgExd = static_cast< xiv::exd::Exd >( exportedSgCat.get_data_ln( xiv::exd::Language::none ) );
+  auto& exportedSgExd = exportedSgCat.get_data_ln( xiv::exd::Language::none );
 
   for( auto& row : exportedSgExd.get_rows() )
   {
@@ -116,7 +116,7 @@ std::string zoneNameToPath( const std::string& name )
   bool found = false;
 
   auto& cat = eData->get_category( "TerritoryType" );
-  auto exd = static_cast< xiv::exd::Exd >( cat.get_data_ln( xiv::exd::Language::none ) );
+  auto& exd = cat.get_data_ln( xiv::exd::Language::none );
   for( auto& row : exd.get_rows() )
   {
     auto& fields = row.second;

--- a/src/world/WorldServer.cpp
+++ b/src/world/WorldServer.cpp
@@ -157,6 +157,8 @@ void WorldServer::run( int32_t argc, char* argv[] )
 {
   using namespace Sapphire;
 
+  auto start = Common::Util::getTimeMs();
+
   Logger::init( "log/world" );
 
   printBanner();
@@ -351,6 +353,7 @@ void WorldServer::run( int32_t argc, char* argv[] )
   Common::Service< ContentFinder >::set( contentFinder );
   Common::Service< Manager::TaskMgr >::set( taskMgr );
 
+  Logger::debug( "Initialization took {0}ms", Common::Util::getTimeMs() - start );
 
   Logger::info( "World server running on {0}:{1}", m_ip, m_port );
 


### PR DESCRIPTION
Before:

<img width="979" height="512" alt="image" src="https://github.com/user-attachments/assets/10cfc0ba-dac5-403b-a8ba-a7aad1d40004" />

After:

<img width="979" height="512" alt="image" src="https://github.com/user-attachments/assets/7b467c24-f0dd-4074-a9ce-99cee752e6c1" />

Every call to `getRow` would copy all data of that category and then immediately destruct it again, causing tons of allocations/deallocations.