### PR TITLE
Rewrite MySQL find algorithm on Windows

### DIFF
--- a/cmake/FindMySQL.cmake
+++ b/cmake/FindMySQL.cmake
@@ -71,34 +71,25 @@ if( UNIX )
     list( APPEND MYSQL_ADD_LIBRARIES "mysqlclient_r" )
     list( APPEND MYSQL_ADD_LIBRARIES "mariadbclient" )
   endif()
-endif()
 
-if( WIN32 )
-  file(
-    GLOB MYSQL_INCLUDE_DIRS
-    "$ENV{ProgramW6432}/MariaDB */include/mysql"
-    "$ENV{ProgramW6432}/MySQL/MySQL Server */include"
+  find_path( MYSQL_INCLUDE_DIR
+    NAMES
+      mysql.h
+    PATHS
+      ${MYSQL_ADD_INCLUDE_PATH}
+      /usr/include
+      /usr/include/mariadb
+      /usr/include/mysql
+      /usr/local/include
+      /usr/local/include/mysql
+      /usr/local/mysql/include
+      ${MYSQL_INCLUDE_DIRS}
+      "$ENV{MYSQL_ROOT}/include"
+    DOC
+      "Specify the directory containing mysql.h."
+    REQUIRED
   )
-endif()
 
-find_path( MYSQL_INCLUDE_DIR
-  NAMES
-    mysql.h
-  PATHS
-    ${MYSQL_ADD_INCLUDE_PATH}
-    /usr/include
-    /usr/include/mariadb
-    /usr/include/mysql
-    /usr/local/include
-    /usr/local/include/mysql
-    /usr/local/mysql/include
-    ${MYSQL_INCLUDE_DIRS}
-    "$ENV{MYSQL_ROOT}/include"
-  DOC
-    "Specify the directory containing mysql.h."
-)
-
-if( UNIX )
   foreach( LIB ${MYSQL_ADD_LIBRARIES} )
     find_library( MYSQL_LIBRARY
       NAMES
@@ -114,36 +105,14 @@ if( UNIX )
       DOC "Specify the location of the mysql library here."
     )
   endforeach()
-endif()
 
-if( WIN32 )
-  file(
-    GLOB MYSQL_LIBRARY_DIRS
-    "$ENV{ProgramW6432}/MariaDB */lib"
-    "$ENV{ProgramW6432}/MySQL/MySQL Server */lib"
-    "$ENV{ProgramW6432}/MySQL/MySQL Server */lib/opt"
-  )
-  find_library( MYSQL_LIBRARY
-    NAMES
-      libmysql
-      libmariadb
-    PATHS
-      ${MYSQL_ADD_LIBRARIES_PATH}
-      ${MYSQL_LIBRARY_DIRS}
-      "$ENV{ProgramW6432}/MySQL/lib"
-      "$ENV{MYSQL_ROOT}/lib"
-    DOC "Specify the location of the mysql library here."
-  )
+  if( NOT MYSQL_LIBRARY )
+    message( FATAL_ERROR "Could not find the MySQL libraries! Please install the development libraries and headers" )
+  endif()
 
-  STRING( REGEX REPLACE "(.lib)$" ".dll" MYSQL_DLL ${MYSQL_LIBRARY} )
+  # On Windows you typically don't need to include any extra libraries
+  # to build MYSQL stuff.
 
-  file( COPY ${MYSQL_DLL} DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/bin" )
-endif()
-
-# On Windows you typically don't need to include any extra libraries
-# to build MYSQL stuff.
-
-if( NOT WIN32 )
   find_library( MYSQL_EXTRA_LIBRARIES
     NAMES
       z zlib
@@ -153,11 +122,7 @@ if( NOT WIN32 )
     DOC
       "if more libraries are necessary to link in a MySQL client (typically zlib), specify them here."
   )
-else()
-  set( MYSQL_EXTRA_LIBRARIES "" )
-endif()
 
-if( UNIX )
   find_program( MYSQL_EXECUTABLE mysql
     PATHS
       ${MYSQL_CONFIG_PREFER_PATH}
@@ -166,38 +131,114 @@ if( UNIX )
       /usr/bin/
     DOC
       "path to your mysql binary."
+    REQUIRED
   )
-endif()
+elseif( WIN32 )
+  function( check_mysql dir out_found out_include out_library out_executable )
+    set( MYSQL_INCLUDE_DIR "${dir}/include/mysql" )
+    if( NOT EXISTS "${MYSQL_INCLUDE_DIR}/mysql.h" )
+      set( ${out_found} FALSE PARENT_SCOPE )
+      return()
+    endif()
 
-if( WIN32 )
-  file(
-    GLOB MYSQL_BIN_DIRS
-    "$ENV{ProgramW6432}/MariaDB */bin"
-    "$ENV{ProgramW6432}/MySQL/MySQL Server */bin"
-    "$ENV{ProgramW6432}/MySQL/MySQL Server */bin/opt"
-  )
-  find_program( MYSQL_EXECUTABLE mysql
-    PATHS
-      ${MYSQL_BIN_DIRS}
-      "${PROGRAM_FILES_64}/MySQL/bin"
-      "$ENV{MYSQL_ROOT}/bin"
-    DOC
-      "path to your mysql binary."
-  )
-endif()
+    set( MYSQL_LIBRARY "${dir}/lib/libmysql.lib" )
+    if( NOT EXISTS "${MYSQL_LIBRARY}" )
+      set( MYSQL_LIBRARY "${dir}/lib/libmariadb.lib" )
+      if( NOT EXISTS "${MYSQL_LIBRARY}" )
+        set( ${out_found} OFF PARENT_SCOPE )
+        return()
+      endif()
+    endif()
 
-if( MYSQL_LIBRARY )
-  if( MYSQL_INCLUDE_DIR )
-    set( MYSQL_FOUND 1 )
-    message( STATUS "Found MySQL library: ${MYSQL_LIBRARY}" )
-    message( STATUS "Found MySQL headers: ${MYSQL_INCLUDE_DIR}" )
+    set( MYSQL_EXECUTABLE "${dir}/bin/mysql.exe" )
+    if( NOT EXISTS "${MYSQL_EXECUTABLE}" )
+      set( ${out_found} OFF PARENT_SCOPE )
+      return()
+    endif()
+
+    set( ${out_include} "${MYSQL_INCLUDE_DIR}" PARENT_SCOPE )
+    set( ${out_library} "${MYSQL_LIBRARY}" PARENT_SCOPE )
+    set( ${out_executable} "${MYSQL_EXECUTABLE}" PARENT_SCOPE )
+    set( ${out_found} ON PARENT_SCOPE )
+  endfunction()
+
+  if( NOT MYSQL_ROOT AND DEFINED ENV{MYSQL_ROOT} )
+    message( STATUS "Using MySQL root from environment variable MYSQL_ROOT" )
+    set( MYSQL_ROOT $ENV{MYSQL_ROOT} )
+  endif()
+  if( MYSQL_ROOT )
+    check_mysql( "${MYSQL_ROOT}" MYSQL_FOUND MYSQL_INCLUDE_DIR MYSQL_LIBRARY MYSQL_EXECUTABLE )
+    if( NOT MYSQL_FOUND )
+      message( FATAL_ERROR "Invalid MySQL root: ${MYSQL_ROOT}" )
+    endif()
+    set( MYSQL_DIR ${MYSQL_ROOT} )
   else()
-    message( FATAL_ERROR "Could not find MySQL headers! Please install the development libraries and headers" )
+    file( GLOB MYSQL_DIRS "$ENV{ProgramW6432}/MariaDB *" )
+    if( MYSQL_DIRS )
+      set( MYSQL_HIGHEST_VERSION "" )
+      foreach( MYSQL_DIR ${MYSQL_DIRS} )
+        string( REPLACE "\\" "/" MYSQL_DIR ${MYSQL_DIR} )
+        string( REGEX MATCH "MariaDB ([0-9.]+)" MYSQL_VERSION_MATCH "${MYSQL_DIR}" )
+        if( NOT MYSQL_DIR MATCHES "MariaDB ([0-9.]+)" )
+          continue()
+        endif()
+        set( MYSQL_VERSION ${CMAKE_MATCH_1} )
+
+        check_mysql( "${MYSQL_DIR}" MYSQL_FOUND MYSQL_INCLUDE_DIR MYSQL_LIBRARY MYSQL_EXECUTABLE )
+        if( NOT MYSQL_FOUND )
+          continue()
+        endif()
+        
+        if( NOT MYSQL_HIGHEST_VERSION OR MYSQL_VERSION VERSION_GREATER MYSQL_HIGHEST_VERSION )
+          set( MYSQL_HIGHEST_VERSION ${MYSQL_VERSION} )
+          set( MYSQL_HIGHEST_DIR ${MYSQL_DIR} )
+        endif()
+      endforeach()
+
+      set( MYSQL_DIR ${MYSQL_HIGHEST_DIR} )
+    endif()
+
+    if( NOT MYSQL_DIR )
+      file( GLOB MYSQL_DIRS "$ENV{ProgramW6432}/MySQL/MySQL Server *" )
+      if( MYSQL_DIRS )
+        set( MYSQL_HIGHEST_VERSION "" )
+        foreach( MYSQL_DIR ${MYSQL_DIRS} )
+          string( REPLACE "\\" "/" MYSQL_DIR ${MYSQL_DIR} )
+          string( REGEX MATCH "MySQL Server ([0-9.]+)" MYSQL_VERSION_MATCH "${MYSQL_DIR}" )
+          if( NOT MYSQL_DIR MATCHES "MySQL Server ([0-9.]+)" )
+            continue()
+          endif()
+          set( MYSQL_VERSION ${CMAKE_MATCH_1} )
+
+          check_mysql( "${MYSQL_DIR}" MYSQL_FOUND MYSQL_INCLUDE_DIR MYSQL_LIBRARY MYSQL_EXECUTABLE )
+          if( NOT MYSQL_FOUND )
+            continue()
+          endif()
+          
+          if( NOT MYSQL_HIGHEST_VERSION OR MYSQL_VERSION VERSION_GREATER MYSQL_HIGHEST_VERSION )
+            set( MYSQL_HIGHEST_VERSION ${MYSQL_VERSION} )
+            set( MYSQL_HIGHEST_DIR ${MYSQL_DIR} )
+          endif()
+        endforeach()
+
+        set( MYSQL_DIR ${MYSQL_HIGHEST_DIR} )
+      endif()
+    endif()
   endif()
-  if( MYSQL_EXECUTABLE )
-    message( STATUS "Found MySQL executable: ${MYSQL_EXECUTABLE}" )
+
+  check_mysql( "${MYSQL_DIR}" MYSQL_FOUND MYSQL_INCLUDE_DIR MYSQL_LIBRARY MYSQL_EXECUTABLE )
+  if( NOT MYSQL_FOUND )
+    message( FATAL_ERROR "Could not find MySQL!" )
   endif()
-  mark_as_advanced( MYSQL_FOUND MYSQL_LIBRARY MYSQL_EXTRA_LIBRARIES MYSQL_INCLUDE_DIR MYSQL_EXECUTABLE )
+
+  STRING( REGEX REPLACE "(.lib)$" ".dll" MYSQL_DLL ${MYSQL_LIBRARY} )
+  file( COPY ${MYSQL_DLL} DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/bin" )
 else()
-  message( FATAL_ERROR "Could not find the MySQL libraries! Please install the development libraries and headers" )
+  message( FATAL_ERROR "Unsupported platform!" )
 endif()
+
+set( MYSQL_FOUND 1 )
+message( STATUS "Found MySQL library: ${MYSQL_LIBRARY}" )
+message( STATUS "Found MySQL headers: ${MYSQL_INCLUDE_DIR}" )
+message( STATUS "Found MySQL executable: ${MYSQL_EXECUTABLE}" )
+mark_as_advanced( MYSQL_FOUND MYSQL_LIBRARY MYSQL_EXTRA_LIBRARIES MYSQL_INCLUDE_DIR MYSQL_EXECUTABLE )


### PR DESCRIPTION
On Linux/macos there are no changes.

This was after a discussion with Malek Bael who found that an old MySQL version would be detected. I changed the algorithm to prioritize MariaDB over MySQL and pick the newest version. You can specify `-DMYSQL_ROOT=xxx` to force a specific MySQL version too (or set an environment variable with the same name).