### PR TITLE
[3.x] LootTable implementation, Loot Drops;

### DIFF
--- a/data/lootTables/debug/testTable.json
+++ b/data/lootTables/debug/testTable.json
@@ -1,53 +1,72 @@
 {
-    "lootTable": "testTable",
-    "pools": [
-      {
-        "duplicates": true,
-        "enabled": true,
-        "entries": [
-          {
-            "item": 9,
-            "weight": 1
-          },
-          {
-            "item": 8,
-            "weight": 1
-          }
-        ],
-        "name": "Loot #1",
-        "pickMax": 1,
-        "pickMin": 1
-      },
-      {
-        "duplicates": false,
-        "enabled": true,
-        "entries": [
-          {
-            "item": 5016,
-            "weight": 1
-          },
-          {
-            "item": 12728,
-            "weight": 1
-          }
-        ],
-        "name": "Pool #2",
-        "pickMax": 2,
-        "pickMin": 2
-      },
-      {
-        "duplicates": true,
-        "enabled": false,
-        "entries": [
-          {
-            "item": 13229,
-            "weight": 1
-          }
-        ],
-        "name": "Pool #3",
-        "pickMax": 1,
-        "pickMin": 1
-      }
-    ],
-    "type": "bNPC"
-  }
+  "lootTable": "testTable",
+  "pools": [
+    {
+      "duplicates": true,
+      "enabled": true,
+      "items": [
+        {
+          "id": 9,
+          "isHq": false,
+          "weight": 1
+        },
+        {
+          "id": 8,
+          "isHq": false,
+          "weight": 1
+        }
+      ],
+      "name": "Test #1 (Standard)",
+      "pickMax": 1,
+      "pickMin": 1
+    },
+    {
+      "duplicates": false,
+      "enabled": true,
+      "items": [
+        {
+          "id": 5016,
+          "isHq": false,
+          "weight": 1
+        },
+        {
+          "id": 12728,
+          "isHq": false,
+          "weight": 1
+        }
+      ],
+      "name": "Test #2 (Duplicates disabled)",
+      "pickMax": 2,
+      "pickMin": 2
+    },
+    {
+      "duplicates": false,
+      "enabled": true,
+      "items": [
+        {
+          "id": 4551,
+          "isHq": true,
+          "weight": 1
+        }
+      ],
+      "name": "Test #3 (HQ Item Test)",
+      "pickMax": 1,
+      "pickMin": 1
+    },
+    {
+      "duplicates": true,
+      "enabled": false,
+      "items": [
+        {
+          "id": 13229,
+          "isHq": false,
+          "weight": 1
+        }
+      ],
+      "name": "Test #4 (Disabled Pool)",
+      "pickMax": 1,
+      "pickMin": 1
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/debug/testTable.json
+++ b/data/lootTables/debug/testTable.json
@@ -1,0 +1,53 @@
+{
+    "lootTable": "testTable",
+    "pools": [
+      {
+        "duplicates": true,
+        "enabled": true,
+        "entries": [
+          {
+            "item": 9,
+            "weight": 1
+          },
+          {
+            "item": 8,
+            "weight": 1
+          }
+        ],
+        "name": "Loot #1",
+        "pickMax": 1,
+        "pickMin": 1
+      },
+      {
+        "duplicates": false,
+        "enabled": true,
+        "entries": [
+          {
+            "item": 5016,
+            "weight": 1
+          },
+          {
+            "item": 12728,
+            "weight": 1
+          }
+        ],
+        "name": "Pool #2",
+        "pickMax": 2,
+        "pickMin": 2
+      },
+      {
+        "duplicates": true,
+        "enabled": false,
+        "entries": [
+          {
+            "item": 13229,
+            "weight": 1
+          }
+        ],
+        "name": "Pool #3",
+        "pickMax": 1,
+        "pickMin": 1
+      }
+    ],
+    "type": "bNPC"
+  }

--- a/src/world/Actor/BNpc.cpp
+++ b/src/world/Actor/BNpc.cpp
@@ -33,6 +33,7 @@
 
 #include <Manager/TerritoryMgr.h>
 #include <Manager/RNGMgr.h>
+#include <Manager/LootTableMgr.h>
 #include <Manager/PlayerMgr.h>
 #include <Manager/TaskMgr.h>
 #include <Manager/MgrUtil.h>
@@ -708,7 +709,11 @@ void BNpc::onDeath()
 
   for( const auto& pHateEntry : m_hateList )
   {
-    // TODO: handle drops 
+    // TODO: handle drops
+    auto& lootTableMgr = Common::Service< World::Manager::LootTableMgr >::ref();
+
+    auto lootResult = lootTableMgr.rollLoot( "testTable" );
+
     auto pPlayer = pHateEntry->m_pChara->getAsPlayer();
     if( pPlayer )
     {

--- a/src/world/Manager/LootTableMgr.cpp
+++ b/src/world/Manager/LootTableMgr.cpp
@@ -1,0 +1,114 @@
+#include <iterator>
+#include <fstream>
+#include <filesystem>
+#include <iostream>
+
+#include <Common.h>
+#include <Service.h>
+#include <Logging/Logger.h>
+
+#include "RNGMgr.h"
+#include "LootTableMgr.h"
+
+using namespace Sapphire;
+using namespace Sapphire::World::Manager;
+namespace fs = std::filesystem;
+
+bool LootTableMgr::cacheLootTables()
+{
+  std::fstream f;
+
+  for( auto& p : fs::recursive_directory_iterator( "data/lootTables/" ) )
+  {
+    if( p.path().extension() == ".json" )
+    {
+      std::ifstream f( p.path() );
+      if( !f )
+        return false;
+
+      nlohmann::json j;
+      f >> j;
+
+      LootTable lootTable = j.get< LootTable >();
+
+      m_lootTableMap.try_emplace( lootTable.lootTable, std::make_shared< LootTable >( lootTable ) );
+    }
+  }
+
+  return true;
+}
+
+LootTablePtr LootTableMgr::getLootTableByName( const std::string& name )
+{
+  auto it = m_lootTableMap.find( name );
+  if( it == m_lootTableMap.end() )
+    return nullptr;
+  else
+    return it->second;
+}
+
+LootTableResult LootTableMgr::rollLoot( const std::string& name )
+{
+  auto& RNGMgr = Common::Service< World::Manager::RNGMgr >::ref();
+
+  LootTableResult result;
+
+  if( auto pLootTable = getLootTableByName( name ); pLootTable )
+  {
+    Logger::info( "LootMgr: Rolling for " + name );
+    result.name = pLootTable->lootTable;
+
+    for( const auto& pool : pLootTable->pools )
+    {
+      if( !pool.enabled )
+        continue;
+
+      auto pickCountGen = RNGMgr.getRandGenerator< uint32_t >( pool.pickMin, pool.pickMax );
+      uint32_t picks = pickCountGen.next();
+
+      std::vector< LootTableItem > available = pool.items;
+
+      for( auto i = 0; i < picks && !available.empty(); ++i )
+      {
+        const auto& item = pickWeightedItem( available );
+
+        result.items.push_back( { item.id, 1, item.isHq } );
+
+        if( !pool.duplicates )
+        {
+          available.erase( std::remove_if( available.begin(), available.end(),
+                  [ & ]( const auto& x ) { return x.id == item.id; } ),
+                  available.end() );
+        }
+      }
+    }
+
+    Logger::debug( "LootMgr: Rolled total of {0} items", result.count() );
+  }
+    
+  return result;
+}
+
+const LootTableItem& LootTableMgr::pickWeightedItem( const std::vector< LootTableItem >& items )
+{
+  auto& RNGMgr = Common::Service< World::Manager::RNGMgr >::ref();
+  // calc total weight
+  uint32_t totalWeight = 0;
+  for( const auto& it : items )
+    totalWeight += it.weight;
+
+  // roll for [1, totalWeight]
+  auto randGen = RNGMgr.getRandGenerator< uint32_t >( 1, totalWeight );
+  uint32_t roll = randGen.next();
+
+  // get item pick
+  uint32_t cumulative = 0;
+  for( const auto& it : items )
+  {
+    cumulative += it.weight;
+    if( roll <= cumulative )
+      return it;
+  }
+
+  throw std::runtime_error( "LootTableMgr: pickWeightedItem roll exceeded total weight" );
+}

--- a/src/world/Manager/LootTableMgr.h
+++ b/src/world/Manager/LootTableMgr.h
@@ -1,0 +1,98 @@
+#pragma once
+
+#include <memory>
+#include <map>
+#include <vector>
+#include "ForwardsZone.h"
+
+#include <nlohmann/json.hpp>
+
+namespace Sapphire::World::Manager
+{
+  struct LootTableItem
+  {
+    uint32_t id;
+    uint32_t weight;
+    bool isHq;
+
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE( LootTableItem, id, weight, isHq )
+  };
+
+  struct LootTablePool
+  {
+    std::string name;
+    bool enabled;
+    bool duplicates;
+    uint32_t pickMin;
+    uint32_t pickMax;
+    std::vector< LootTableItem > items;
+
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE( LootTablePool, name, enabled, duplicates, pickMin, pickMax, items )
+  };
+
+  struct LootTable {
+    std::string lootTable;
+    std::vector< LootTablePool > pools;
+
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE( LootTable, lootTable, pools )
+  };
+
+  struct LootTableResultItem {
+    uint32_t id;
+    uint32_t quantity;
+    bool isHq;
+  };
+
+  struct LootTableResult
+  {
+    std::string name;
+    std::vector< LootTableResultItem > items;
+
+    bool isEmpty() const { return items.empty(); }
+    size_t count() const { return items.size(); }
+  };
+
+  using LootTablePtr = std::shared_ptr< LootTable >;
+
+  class LootTableMgr
+  {
+  public:
+    LootTableMgr() = default;
+    ~LootTableMgr() = default;
+
+    /// <summary>
+    /// initialize loot tables from JSON into a map
+    /// </summary>
+    bool cacheLootTables();
+
+    /// <summary>
+    /// returns LootTable ptr by its name
+    /// </summary>
+    /// <param name="name"></param>
+    /// <returns>ptr to LootTable or null</returns>
+    LootTablePtr getLootTableByName( const std::string& name );
+
+    /// <summary>
+    /// rolls a given loot table by name
+    /// internally processes given pools and items
+    /// returns a LootTableStruct with resolved loot table results
+    /// may throw if loot table is not found
+    /// </summary>
+    /// <param name="name"></param>
+    /// <returns>struct of loot table rolls</returns>
+    LootTableResult rollLoot( const std::string& name );
+
+  private:
+    std::map< std::string, LootTablePtr > m_lootTableMap;
+
+    /// <summary>
+    /// picks a single item per weight out of a total weight of vector of items
+    /// uses weighted system and RNGMgr to select a roll
+    /// may throw if roll > total weight
+    /// </summary>
+    /// <param name="items"></param>
+    /// <returns>singular item pick from given items</returns>
+    const LootTableItem& pickWeightedItem( const std::vector< LootTableItem >& items );
+  };
+
+}

--- a/src/world/WorldServer.cpp
+++ b/src/world/WorldServer.cpp
@@ -33,7 +33,7 @@
 #include <Service.h>
 #include "Manager/AchievementMgr.h"
 #include "Manager/LinkshellMgr.h"
-#include "Manager/TerritoryMgr.h"
+#include "Manager/LootTableMgr.h"
 #include "Manager/HousingMgr.h"
 #include "Manager/DebugCommandMgr.h"
 #include "Manager/PlayerMgr.h"
@@ -252,6 +252,16 @@ void WorldServer::run( int32_t argc, char* argv[] )
     return;
   }
   Common::Service< Manager::AchievementMgr >::set( pAchvMgr );
+
+  auto pLootTableMgr = std::make_shared< Manager::LootTableMgr >();
+
+  Logger::info( "LootTableMgr: Caching loot tables" );
+  if( !pLootTableMgr->cacheLootTables() )
+  {
+    Logger::fatal( "Unable to cache loot tables!" );
+    return;
+  }
+  Common::Service< Manager::LootTableMgr >::set( pLootTableMgr );
 
   Logger::info( "Setting up InstanceObjectCache" );
   auto pInstanceObjCache = std::make_shared< Sapphire::InstanceObjectCache >();


### PR DESCRIPTION
### Summary
This PR implements loot tables and item drops for BNPCs, instances, treasure chests, etc.
A `LootTableMgr`, data structure (a JSON) for loot tables as well as an UI tooling has been implemented for it.

### Definition

LootTables are defined in data/lootTables. On server init, it'll traverse and parse any JSONs found in the folder and add it to a K,V map of <std::string, LootTable>

The loot table is either manually edited or defined by an external UI editor developed outside this repo: https://hkalice.github.io/sapphire_editor/

<img width="1453" height="830" alt="image" src="https://github.com/user-attachments/assets/aadc29a7-b5da-4ed5-a2b3-ae3380812b74" />

- A loot table defines a name that is going to be key for a [key, value] map of loot tables;
- Pools within a loot table definition are rolled with RNG picks (so long as pool->enabled);
- Picks are chosen within [pickMin, pickMax] with RNGMgr;
- Pool items are picked according to a weight system using RNGMgr dist;
- Items may or may not be duplicated depending on pool->duplicates.

### Future goals

This PR will focus on a LootTableMgr implementation so that we can move on to using it within the code and implement features blocked by the lack of a loot table.

Features may include: mob drops, instance loot, treasure chests, quest items.

### Testing

For testing, the PR also includes a "test bed" JSON with most scenarios covered.
- Pool 1 tests a basic 50/50 scenario (1 random item within pool);
- Pool 2 tests 2 rolls with duplicates disabled (should return 1 of each item);
- Pool 3 tests a HQ item (should return a HQ item);
- Pool 4 tests a disabled pool (should NOT return any item).

```
[22:40:57.326] [info] LootMgr: Rolling for testTable
[22:40:57.326] [info] LootMgr: Rolled total of 4 items
```