### PR TITLE
[3.x] Add debug manual seeding to RNGMgr;

### DIFF
--- a/src/world/Manager/RNGMgr.h
+++ b/src/world/Manager/RNGMgr.h
@@ -95,6 +95,18 @@ namespace Sapphire::World::Manager
       return RandGenerator< T >( m_engine );
     }
 
+    /*!
+     * @brief Manually seeds the engine with a given 32-bit seed. Intended *only* for debugging purposes
+     * Seeds ideally need to be <int, STATE_SIZE> - note that this does not guarantee deterministic distribution
+     * Manually seeding with < STATE_SIZE is weird - it'll likely permutate the rest of STATE_SIZE from given seed
+     * @param 32-bit seed value
+     * @return void
+     */
+    void reseedEngine( uint32_t seed )
+    {
+      m_engine->seed( seed );
+    }
+
   private:
 
     template< std::size_t STATE_SIZE >


### PR DESCRIPTION
I forgot to add this when I made RNGMgr years ago.

Quality of RNG is worsened when set (so don't), but this is for testing distribution programmatically (as in within the same scope of the seed set).
Since Sapphire uses RNG in a bunch of places, this will not guarantee your RNG output is always the same. As soon as this call leaves scope you're on your own

More on code docs.