### PR TITLE
[3.x] Add generated BNPC loot data; Add per-item quantity data;

### DIFF
--- a/data/lootTables/bnpc/Adamantoise/bnpc_ironTortoise.json
+++ b/data/lootTables/bnpc/Adamantoise/bnpc_ironTortoise.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_ironTortoise",
+  "pools": [
+    {
+      "name": "Pool #1 (Adamantoise Shell)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5458,
+          "name": "Adamantoise Shell",
+          "weight": 400,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 600,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Adamantoise Shell)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5458,
+          "name": "Adamantoise Shell",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Ahriman/bnpc_milkyEye.json
+++ b/data/lootTables/bnpc/Ahriman/bnpc_milkyEye.json
@@ -1,0 +1,27 @@
+{
+  "lootTable": "bnpc_milkyEye",
+  "pools": [
+    {
+      "name": "Pool #1 (Ahriman Wing)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5553,
+          "name": "Ahriman Wing",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Aldgoat/bnpc_myotragusBilly.json
+++ b/data/lootTables/bnpc/Aldgoat/bnpc_myotragusBilly.json
@@ -1,0 +1,285 @@
+{
+  "lootTable": "bnpc_myotragusBilly",
+  "pools": [
+    {
+      "name": "Pool #1 (Aldgoat Chuck)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4766,
+          "name": "Aldgoat Chuck",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Aldgoat Horn)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5436,
+          "name": "Aldgoat Horn",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #3 (Aldgoat Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5296,
+          "name": "Aldgoat Skin",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #4 (Aldgoat Chuck)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4766,
+          "name": "Aldgoat Chuck",
+          "weight": 262,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 738,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #5 (Aldgoat Horn)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5436,
+          "name": "Aldgoat Horn",
+          "weight": 308,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 692,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #6 (Aldgoat Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5296,
+          "name": "Aldgoat Skin",
+          "weight": 646,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 354,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #7 (Aldgoat Chuck)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4766,
+          "name": "Aldgoat Chuck",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #8 (Aldgoat Horn)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5436,
+          "name": "Aldgoat Horn",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #9 (Aldgoat Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5296,
+          "name": "Aldgoat Skin",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Aldgoat/bnpc_myotragusNanny.json
+++ b/data/lootTables/bnpc/Aldgoat/bnpc_myotragusNanny.json
@@ -1,0 +1,192 @@
+{
+  "lootTable": "bnpc_myotragusNanny",
+  "pools": [
+    {
+      "name": "Pool #1 (Aldgoat Chuck)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4766,
+          "name": "Aldgoat Chuck",
+          "weight": 300,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 700,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Aldgoat Horn)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5436,
+          "name": "Aldgoat Horn",
+          "weight": 352,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 648,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #3 (Aldgoat Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5296,
+          "name": "Aldgoat Skin",
+          "weight": 663,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 337,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #4 (Aldgoat Chuck)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4766,
+          "name": "Aldgoat Chuck",
+          "weight": 356,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 644,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #5 (Aldgoat Horn)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5436,
+          "name": "Aldgoat Horn",
+          "weight": 366,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 634,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #6 (Aldgoat Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5296,
+          "name": "Aldgoat Skin",
+          "weight": 455,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 545,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Aldgoat/bnpc_ravenousBillygoat.json
+++ b/data/lootTables/bnpc/Aldgoat/bnpc_ravenousBillygoat.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_ravenousBillygoat",
+  "pools": [
+    {
+      "name": "Pool #1 (Aldgoat Chuck)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4766,
+          "name": "Aldgoat Chuck",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Aldgoat Chuck)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4766,
+          "name": "Aldgoat Chuck",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Amphiptere/bnpc_amphiptere.json
+++ b/data/lootTables/bnpc/Amphiptere/bnpc_amphiptere.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_amphiptere",
+  "pools": [
+    {
+      "name": "Pool #1 (Amphiptere Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 12572,
+          "name": "Amphiptere Skin",
+          "weight": 367,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 3
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 633,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Antelope/bnpc_antelopeDoe.json
+++ b/data/lootTables/bnpc/Antelope/bnpc_antelopeDoe.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_antelopeDoe",
+  "pools": [
+    {
+      "name": "Pool #1 (Antelope Shank)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4765,
+          "name": "Antelope Shank",
+          "weight": 393,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 607,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Beast Sinew)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5319,
+          "name": "Beast Sinew",
+          "weight": 196,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 804,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Antelope/bnpc_scarredAntelope.json
+++ b/data/lootTables/bnpc/Antelope/bnpc_scarredAntelope.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_scarredAntelope",
+  "pools": [
+    {
+      "name": "Pool #1 (Beast Sinew)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5319,
+          "name": "Beast Sinew",
+          "weight": 240,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 760,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Antelope Shank)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4765,
+          "name": "Antelope Shank",
+          "weight": 360,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 640,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Antling/bnpc_antlingSentry.json
+++ b/data/lootTables/bnpc/Antling/bnpc_antlingSentry.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_antlingSentry",
+  "pools": [
+    {
+      "name": "Pool #1 (Formic Acid)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5497,
+          "name": "Formic Acid",
+          "weight": 320,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 680,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Archaeornis/bnpc_archaeornis.json
+++ b/data/lootTables/bnpc/Archaeornis/bnpc_archaeornis.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_archaeornis",
+  "pools": [
+    {
+      "name": "Pool #1 (Archaeornis Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 12568,
+          "name": "Archaeornis Skin",
+          "weight": 407,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 3
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 593,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Archaeornis/bnpc_grandArchaeornis.json
+++ b/data/lootTables/bnpc/Archaeornis/bnpc_grandArchaeornis.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_grandArchaeornis",
+  "pools": [
+    {
+      "name": "Pool #1 (Archaeornis Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 12568,
+          "name": "Archaeornis Skin",
+          "weight": 419,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 3
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 581,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Bat/bnpc_bloodBat.json
+++ b/data/lootTables/bnpc/Bat/bnpc_bloodBat.json
@@ -1,0 +1,99 @@
+{
+  "lootTable": "bnpc_bloodBat",
+  "pools": [
+    {
+      "name": "Pool #1 (Bat Fang)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5442,
+          "name": "Bat Fang",
+          "weight": 400,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 600,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Bat Wing)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5551,
+          "name": "Bat Wing",
+          "weight": 200,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 800,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #3 (Beastkin Blood)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5492,
+          "name": "Beastkin Blood",
+          "weight": 200,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 800,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Bat/bnpc_giantBat.json
+++ b/data/lootTables/bnpc/Bat/bnpc_giantBat.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_giantBat",
+  "pools": [
+    {
+      "name": "Pool #1 (Bat Fang)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5442,
+          "name": "Bat Fang",
+          "weight": 400,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 600,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Beastkin Blood)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5492,
+          "name": "Beastkin Blood",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Bat/bnpc_lesserKalong.json
+++ b/data/lootTables/bnpc/Bat/bnpc_lesserKalong.json
@@ -1,0 +1,378 @@
+{
+  "lootTable": "bnpc_lesserKalong",
+  "pools": [
+    {
+      "name": "Pool #1 (Bat Fang)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5442,
+          "name": "Bat Fang",
+          "weight": 353,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 647,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Bat Wing)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5551,
+          "name": "Bat Wing",
+          "weight": 176,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 824,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #3 (Spoken Blood)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5494,
+          "name": "Spoken Blood",
+          "weight": 353,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 647,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #4 (Bat Fang)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5442,
+          "name": "Bat Fang",
+          "weight": 339,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 661,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #5 (Bat Wing)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5551,
+          "name": "Bat Wing",
+          "weight": 312,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 688,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #6 (Spoken Blood)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5494,
+          "name": "Spoken Blood",
+          "weight": 286,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 714,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #7 (Bat Fang)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5442,
+          "name": "Bat Fang",
+          "weight": 309,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 691,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #8 (Bat Wing)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5551,
+          "name": "Bat Wing",
+          "weight": 218,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 782,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #9 (Spoken Blood)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5494,
+          "name": "Spoken Blood",
+          "weight": 309,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 691,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #10 (Bat Fang)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5442,
+          "name": "Bat Fang",
+          "weight": 303,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 697,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #11 (Bat Wing)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5551,
+          "name": "Bat Wing",
+          "weight": 98,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 902,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #12 (Spoken Blood)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5494,
+          "name": "Spoken Blood",
+          "weight": 311,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 689,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Bat/bnpc_sunBat.json
+++ b/data/lootTables/bnpc/Bat/bnpc_sunBat.json
@@ -1,0 +1,192 @@
+{
+  "lootTable": "bnpc_sunBat",
+  "pools": [
+    {
+      "name": "Pool #1 (Bat Wing)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5551,
+          "name": "Bat Wing",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Bat Fang)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5442,
+          "name": "Bat Fang",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #3 (Beastkin Blood)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5492,
+          "name": "Beastkin Blood",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #4 (Bat Wing)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5551,
+          "name": "Bat Wing",
+          "weight": 250,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 750,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #5 (Bat Fang)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5442,
+          "name": "Bat Fang",
+          "weight": 283,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 717,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #6 (Beastkin Blood)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5492,
+          "name": "Beastkin Blood",
+          "weight": 300,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 700,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Bat/bnpc_wingrat.json
+++ b/data/lootTables/bnpc/Bat/bnpc_wingrat.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_wingrat",
+  "pools": [
+    {
+      "name": "Pool #1 (Bat Fang)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5442,
+          "name": "Bat Fang",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Bear/bnpc_acornBear.json
+++ b/data/lootTables/bnpc/Bear/bnpc_acornBear.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_acornBear",
+  "pools": [
+    {
+      "name": "Pool #1 (Bear Fat)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 12609,
+          "name": "Bear Fat",
+          "weight": 274,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 3
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 726,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Bear/bnpc_brownBear.json
+++ b/data/lootTables/bnpc/Bear/bnpc_brownBear.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_brownBear",
+  "pools": [
+    {
+      "name": "Pool #1 (Bear Fat)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 12609,
+          "name": "Bear Fat",
+          "weight": 274,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 3
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 726,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Bear Fat)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 12609,
+          "name": "Bear Fat",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Bear/bnpc_sunBear.json
+++ b/data/lootTables/bnpc/Bear/bnpc_sunBear.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_sunBear",
+  "pools": [
+    {
+      "name": "Pool #1 (Bear Fat)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 12609,
+          "name": "Bear Fat",
+          "weight": 526,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 474,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Boar/bnpc_chargingHog.json
+++ b/data/lootTables/bnpc/Boar/bnpc_chargingHog.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_chargingHog",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Hide)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5292,
+          "name": "Animal Hide",
+          "weight": 167,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 2
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 833,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Boar/bnpc_hoglet.json
+++ b/data/lootTables/bnpc/Boar/bnpc_hoglet.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_hoglet",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Hide)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5292,
+          "name": "Animal Hide",
+          "weight": 494,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 3
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 506,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Boar/bnpc_wildHoglet.json
+++ b/data/lootTables/bnpc/Boar/bnpc_wildHoglet.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_wildHoglet",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Hide)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5292,
+          "name": "Animal Hide",
+          "weight": 667,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 3
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 333,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Bomb/bnpc_glowingBomb.json
+++ b/data/lootTables/bnpc/Bomb/bnpc_glowingBomb.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_glowingBomb",
+  "pools": [
+    {
+      "name": "Pool #1 (Bomb Ash)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5528,
+          "name": "Bomb Ash",
+          "weight": 667,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 3
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 333,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Bomb/bnpc_napalm.json
+++ b/data/lootTables/bnpc/Bomb/bnpc_napalm.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_napalm",
+  "pools": [
+    {
+      "name": "Pool #1 (Grenade Ash)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5526,
+          "name": "Grenade Ash",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Bomb/bnpc_voidMine.json
+++ b/data/lootTables/bnpc/Bomb/bnpc_voidMine.json
@@ -1,0 +1,27 @@
+{
+  "lootTable": "bnpc_voidMine",
+  "pools": [
+    {
+      "name": "Pool #1 (Grenade Ash)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5526,
+          "name": "Grenade Ash",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Chigoe/bnpc_biggerChigoe.json
+++ b/data/lootTables/bnpc/Chigoe/bnpc_biggerChigoe.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_biggerChigoe",
+  "pools": [
+    {
+      "name": "Pool #1 (Beastkin Blood)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5492,
+          "name": "Beastkin Blood",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Chigoe/bnpc_buzzingDjigga.json
+++ b/data/lootTables/bnpc/Chigoe/bnpc_buzzingDjigga.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_buzzingDjigga",
+  "pools": [
+    {
+      "name": "Pool #1 (Scalekin Blood)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5493,
+          "name": "Scalekin Blood",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Chigoe/bnpc_evenBiggerChigoe.json
+++ b/data/lootTables/bnpc/Chigoe/bnpc_evenBiggerChigoe.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_evenBiggerChigoe",
+  "pools": [
+    {
+      "name": "Pool #1 (Beastkin Blood)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5492,
+          "name": "Beastkin Blood",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Chigoe/bnpc_jumpingDjigga.json
+++ b/data/lootTables/bnpc/Chigoe/bnpc_jumpingDjigga.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_jumpingDjigga",
+  "pools": [
+    {
+      "name": "Pool #1 (Scalekin Blood)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5493,
+          "name": "Scalekin Blood",
+          "weight": 382,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 618,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Chigoe/bnpc_swollenDjigga.json
+++ b/data/lootTables/bnpc/Chigoe/bnpc_swollenDjigga.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_swollenDjigga",
+  "pools": [
+    {
+      "name": "Pool #1 (Scalekin Blood)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5493,
+          "name": "Scalekin Blood",
+          "weight": 393,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 607,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Coblyn/bnpc_ceruleumCoblyn.json
+++ b/data/lootTables/bnpc/Coblyn/bnpc_ceruleumCoblyn.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_ceruleumCoblyn",
+  "pools": [
+    {
+      "name": "Pool #1 (Iron Ore)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5111,
+          "name": "Iron Ore",
+          "weight": 250,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 750,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Coblyn/bnpc_copperCoblyn.json
+++ b/data/lootTables/bnpc/Coblyn/bnpc_copperCoblyn.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_copperCoblyn",
+  "pools": [
+    {
+      "name": "Pool #1 (Tin Ore)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5107,
+          "name": "Tin Ore",
+          "weight": 300,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 700,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Coblyn/bnpc_leadCoblyn.json
+++ b/data/lootTables/bnpc/Coblyn/bnpc_leadCoblyn.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_leadCoblyn",
+  "pools": [
+    {
+      "name": "Pool #1 (Iron Ore)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5111,
+          "name": "Iron Ore",
+          "weight": 400,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 600,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Coblyn/bnpc_quartzDoblyn.json
+++ b/data/lootTables/bnpc/Coblyn/bnpc_quartzDoblyn.json
@@ -1,0 +1,161 @@
+{
+  "lootTable": "bnpc_quartzDoblyn",
+  "pools": [
+    {
+      "name": "Pool #1 (Iron Ore)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5111,
+          "name": "Iron Ore",
+          "weight": 231,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 769,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Iron Ore)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5111,
+          "name": "Iron Ore",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #3 (Iron Ore)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5111,
+          "name": "Iron Ore",
+          "weight": 700,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 300,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #4 (Iron Ore)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5111,
+          "name": "Iron Ore",
+          "weight": 700,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 300,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #5 (Iron Ore)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5111,
+          "name": "Iron Ore",
+          "weight": 330,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 670,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Coblyn/bnpc_rustyCoblyn.json
+++ b/data/lootTables/bnpc/Coblyn/bnpc_rustyCoblyn.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_rustyCoblyn",
+  "pools": [
+    {
+      "name": "Pool #1 (Tin Ore)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5107,
+          "name": "Tin Ore",
+          "weight": 143,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 857,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Tin Ore)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5107,
+          "name": "Tin Ore",
+          "weight": 250,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 750,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Coblyn/bnpc_schorlDoblyn.json
+++ b/data/lootTables/bnpc/Coblyn/bnpc_schorlDoblyn.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_schorlDoblyn",
+  "pools": [
+    {
+      "name": "Pool #1 (Iron Ore)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5111,
+          "name": "Iron Ore",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Coblyn/bnpc_spheneDoblyn.json
+++ b/data/lootTables/bnpc/Coblyn/bnpc_spheneDoblyn.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_spheneDoblyn",
+  "pools": [
+    {
+      "name": "Pool #1 (Iron Ore)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5111,
+          "name": "Iron Ore",
+          "weight": 250,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 750,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Coblyn/bnpc_syntheticDoblyn.json
+++ b/data/lootTables/bnpc/Coblyn/bnpc_syntheticDoblyn.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_syntheticDoblyn",
+  "pools": [
+    {
+      "name": "Pool #1 (Iron Ore)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5111,
+          "name": "Iron Ore",
+          "weight": 250,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 750,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Coeurl/bnpc_coeurl.json
+++ b/data/lootTables/bnpc/Coeurl/bnpc_coeurl.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_coeurl",
+  "pools": [
+    {
+      "name": "Pool #1 (Coeurl Meat)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 6150,
+          "name": "Coeurl Meat",
+          "weight": 267,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 733,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Coeurl Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5317,
+          "name": "Coeurl Skin",
+          "weight": 400,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 3
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 600,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Coeurl/bnpc_coeurlPup.json
+++ b/data/lootTables/bnpc/Coeurl/bnpc_coeurlPup.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_coeurlPup",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Hide)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5292,
+          "name": "Animal Hide",
+          "weight": 688,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 3
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 312,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Coeurl/bnpc_darkMatterCoeurl.json
+++ b/data/lootTables/bnpc/Coeurl/bnpc_darkMatterCoeurl.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_darkMatterCoeurl",
+  "pools": [
+    {
+      "name": "Pool #1 (Coeurl Meat)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 6150,
+          "name": "Coeurl Meat",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Coeurl Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5317,
+          "name": "Coeurl Skin",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Coeurl/bnpc_deepJungleCoeurlTorama.json
+++ b/data/lootTables/bnpc/Coeurl/bnpc_deepJungleCoeurlTorama.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_deepJungleCoeurlTorama",
+  "pools": [
+    {
+      "name": "Pool #1 (Coeurl Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5317,
+          "name": "Coeurl Skin",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Coeurl/bnpc_patripatan.json
+++ b/data/lootTables/bnpc/Coeurl/bnpc_patripatan.json
@@ -1,0 +1,27 @@
+{
+  "lootTable": "bnpc_patripatan",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Hide)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5292,
+          "name": "Animal Hide",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 3
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Crawler/bnpc_crawler.json
+++ b/data/lootTables/bnpc/Crawler/bnpc_crawler.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_crawler",
+  "pools": [
+    {
+      "name": "Pool #1 (Crawler Cocoon)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 12600,
+          "name": "Crawler Cocoon",
+          "weight": 628,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 3
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 372,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Demon/bnpc_soulCollector.json
+++ b/data/lootTables/bnpc/Demon/bnpc_soulCollector.json
@@ -1,0 +1,27 @@
+{
+  "lootTable": "bnpc_soulCollector",
+  "pools": [
+    {
+      "name": "Pool #1 (Gil)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 1,
+          "name": "Gil",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 43,
+            "max": 57
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Diremite/bnpc_banemite.json
+++ b/data/lootTables/bnpc/Diremite/bnpc_banemite.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_banemite",
+  "pools": [
+    {
+      "name": "Pool #1 (Diremite Sinew)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5320,
+          "name": "Diremite Sinew",
+          "weight": 310,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 2
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 690,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Diremite Web)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5345,
+          "name": "Diremite Web",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 9
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Diremite/bnpc_banemiteStraggler.json
+++ b/data/lootTables/bnpc/Diremite/bnpc_banemiteStraggler.json
@@ -1,0 +1,27 @@
+{
+  "lootTable": "bnpc_banemiteStraggler",
+  "pools": [
+    {
+      "name": "Pool #1 (Diremite Sinew)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5320,
+          "name": "Diremite Sinew",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Diremite/bnpc_heavyBanemite.json
+++ b/data/lootTables/bnpc/Diremite/bnpc_heavyBanemite.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_heavyBanemite",
+  "pools": [
+    {
+      "name": "Pool #1 (Diremite Web)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5345,
+          "name": "Diremite Web",
+          "weight": 333,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 667,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Diremite/bnpc_miteling.json
+++ b/data/lootTables/bnpc/Diremite/bnpc_miteling.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_miteling",
+  "pools": [
+    {
+      "name": "Pool #1 (Diremite Sinew)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5320,
+          "name": "Diremite Sinew",
+          "weight": 325,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 675,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Diremite Web)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5345,
+          "name": "Diremite Web",
+          "weight": 632,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 368,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Diremite/bnpc_mitelingStraggler.json
+++ b/data/lootTables/bnpc/Diremite/bnpc_mitelingStraggler.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_mitelingStraggler",
+  "pools": [
+    {
+      "name": "Pool #1 (Diremite Sinew)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5320,
+          "name": "Diremite Sinew",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Diremite Web)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5345,
+          "name": "Diremite Web",
+          "weight": 375,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 625,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Dragon/bnpc_bloodDragon.json
+++ b/data/lootTables/bnpc/Dragon/bnpc_bloodDragon.json
@@ -1,0 +1,130 @@
+{
+  "lootTable": "bnpc_bloodDragon",
+  "pools": [
+    {
+      "name": "Pool #1 (Dragon Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 12571,
+          "name": "Dragon Skin",
+          "weight": 478,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 3
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 522,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Dragon Fang)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 12576,
+          "name": "Dragon Fang",
+          "weight": 478,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 3
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 522,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #3 (Dragon Blood)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 12630,
+          "name": "Dragon Blood",
+          "weight": 681,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 3
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 319,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #4 (Dragon Scale)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 12627,
+          "name": "Dragon Scale",
+          "weight": 942,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 3
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 58,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Dragon/bnpc_mossDragon.json
+++ b/data/lootTables/bnpc/Dragon/bnpc_mossDragon.json
@@ -1,0 +1,130 @@
+{
+  "lootTable": "bnpc_mossDragon",
+  "pools": [
+    {
+      "name": "Pool #1 (Dragon Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 12571,
+          "name": "Dragon Skin",
+          "weight": 627,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 373,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Dragon Fang)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 12576,
+          "name": "Dragon Fang",
+          "weight": 627,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 373,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #3 (Dragon Blood)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 12630,
+          "name": "Dragon Blood",
+          "weight": 706,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 294,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #4 (Dragon Scale)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 12627,
+          "name": "Dragon Scale",
+          "weight": 569,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 431,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Drake/bnpc_mudBiast.json
+++ b/data/lootTables/bnpc/Drake/bnpc_mudBiast.json
@@ -1,0 +1,27 @@
+{
+  "lootTable": "bnpc_mudBiast",
+  "pools": [
+    {
+      "name": "Pool #1 (Gil)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 1,
+          "name": "Gil",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 14,
+            "max": 16
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Dullahan/bnpc_dullahan.json
+++ b/data/lootTables/bnpc/Dullahan/bnpc_dullahan.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_dullahan",
+  "pools": [
+    {
+      "name": "Pool #1 (Gil, Gil)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 2,
+        "max": 2
+      },
+      "items": [
+        {
+          "id": 1,
+          "name": "Gil",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 41,
+            "max": 58
+          }
+        },
+        {
+          "id": 1,
+          "name": "Gil",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 41,
+            "max": 58
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Eft/bnpc_barkEft.json
+++ b/data/lootTables/bnpc/Eft/bnpc_barkEft.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_barkEft",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5291,
+          "name": "Animal Skin",
+          "weight": 875,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 125,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Eft/bnpc_blackEft.json
+++ b/data/lootTables/bnpc/Eft/bnpc_blackEft.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_blackEft",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5291,
+          "name": "Animal Skin",
+          "weight": 395,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 3
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 605,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Eft/bnpc_mudpuppy.json
+++ b/data/lootTables/bnpc/Eft/bnpc_mudpuppy.json
@@ -1,0 +1,99 @@
+{
+  "lootTable": "bnpc_mudpuppy",
+  "pools": [
+    {
+      "name": "Pool #1 (Eft Tail)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4769,
+          "name": "Eft Tail",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Eft Tail)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4769,
+          "name": "Eft Tail",
+          "weight": 333,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 667,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #3 (Eft Tail)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4769,
+          "name": "Eft Tail",
+          "weight": 351,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 649,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Eft/bnpc_snowpuppy.json
+++ b/data/lootTables/bnpc/Eft/bnpc_snowpuppy.json
@@ -1,0 +1,27 @@
+{
+  "lootTable": "bnpc_snowpuppy",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5291,
+          "name": "Animal Skin",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Elder_Dragon/bnpc_fafnir.json
+++ b/data/lootTables/bnpc/Elder_Dragon/bnpc_fafnir.json
@@ -1,0 +1,16 @@
+{
+  "lootTable": "bnpc_fafnir",
+  "pools": [
+    {
+      "name": "Pool #1 (empty)",
+      "enabled": false,
+      "duplicates": false,
+      "pick": {
+        "min": 0,
+        "max": 0
+      },
+      "items": []
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Elder_Dragon/bnpc_faunehmEnemy.json
+++ b/data/lootTables/bnpc/Elder_Dragon/bnpc_faunehmEnemy.json
@@ -1,0 +1,16 @@
+{
+  "lootTable": "bnpc_faunehmEnemy",
+  "pools": [
+    {
+      "name": "Pool #1 (empty)",
+      "enabled": false,
+      "duplicates": false,
+      "pick": {
+        "min": 0,
+        "max": 0
+      },
+      "items": []
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Elder_Dragon/bnpc_tioman.json
+++ b/data/lootTables/bnpc/Elder_Dragon/bnpc_tioman.json
@@ -1,0 +1,16 @@
+{
+  "lootTable": "bnpc_tioman",
+  "pools": [
+    {
+      "name": "Pool #1 (empty)",
+      "enabled": false,
+      "duplicates": false,
+      "pick": {
+        "min": 0,
+        "max": 0
+      },
+      "items": []
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Elder_Wyvern/bnpc_elderWyvern.json
+++ b/data/lootTables/bnpc/Elder_Wyvern/bnpc_elderWyvern.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_elderWyvern",
+  "pools": [
+    {
+      "name": "Pool #1 (Wyvern Wing)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 12636,
+          "name": "Wyvern Wing",
+          "weight": 600,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 3
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 400,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Wyvern Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 12569,
+          "name": "Wyvern Skin",
+          "weight": 365,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 3
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 635,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Enemy_Humanoid/bnpc_3rdCohortHoplomachus.json
+++ b/data/lootTables/bnpc/Enemy_Humanoid/bnpc_3rdCohortHoplomachus.json
@@ -1,0 +1,99 @@
+{
+  "lootTable": "bnpc_3rdCohortHoplomachus",
+  "pools": [
+    {
+      "name": "Pool #1 (Legionary Visor)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 2931,
+          "name": "Legionary Visor",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Garlean Rubber)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5533,
+          "name": "Garlean Rubber",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #3 (Garlean Fiber)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5340,
+          "name": "Garlean Fiber",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Enemy_Humanoid/bnpc_3rdCohortLaquearius.json
+++ b/data/lootTables/bnpc/Enemy_Humanoid/bnpc_3rdCohortLaquearius.json
@@ -1,0 +1,99 @@
+{
+  "lootTable": "bnpc_3rdCohortLaquearius",
+  "pools": [
+    {
+      "name": "Pool #1 (Garlean Rubber)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5533,
+          "name": "Garlean Rubber",
+          "weight": 36,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 964,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Legionary Visor)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 2931,
+          "name": "Legionary Visor",
+          "weight": 71,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 929,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #3 (Garlean Fiber)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5340,
+          "name": "Garlean Fiber",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Enemy_Humanoid/bnpc_3rdCohortOptio.json
+++ b/data/lootTables/bnpc/Enemy_Humanoid/bnpc_3rdCohortOptio.json
@@ -1,0 +1,16 @@
+{
+  "lootTable": "bnpc_3rdCohortOptio",
+  "pools": [
+    {
+      "name": "Pool #1 (empty)",
+      "enabled": false,
+      "duplicates": false,
+      "pick": {
+        "min": 0,
+        "max": 0
+      },
+      "items": []
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Enemy_Humanoid/bnpc_3rdCohortSecutor.json
+++ b/data/lootTables/bnpc/Enemy_Humanoid/bnpc_3rdCohortSecutor.json
@@ -1,0 +1,99 @@
+{
+  "lootTable": "bnpc_3rdCohortSecutor",
+  "pools": [
+    {
+      "name": "Pool #1 (Garlean Fiber)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5340,
+          "name": "Garlean Fiber",
+          "weight": 73,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 927,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Garlean Rubber)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5533,
+          "name": "Garlean Rubber",
+          "weight": 18,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 982,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #3 (Legionary Visor)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 2931,
+          "name": "Legionary Visor",
+          "weight": 36,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 964,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Enemy_Humanoid/bnpc_3rdCohortSignifer.json
+++ b/data/lootTables/bnpc/Enemy_Humanoid/bnpc_3rdCohortSignifer.json
@@ -1,0 +1,99 @@
+{
+  "lootTable": "bnpc_3rdCohortSignifer",
+  "pools": [
+    {
+      "name": "Pool #1 (Garlean Fiber)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5340,
+          "name": "Garlean Fiber",
+          "weight": 20,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 980,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Legionary Visor)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 2931,
+          "name": "Legionary Visor",
+          "weight": 39,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 961,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #3 (Garlean Rubber)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5533,
+          "name": "Garlean Rubber",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Enemy_Humanoid/bnpc_5thCohortLaqueariusOverworld.json
+++ b/data/lootTables/bnpc/Enemy_Humanoid/bnpc_5thCohortLaqueariusOverworld.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_5thCohortLaqueariusOverworld",
+  "pools": [
+    {
+      "name": "Pool #1 (Garlean Fiber)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5340,
+          "name": "Garlean Fiber",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Garlean Rubber)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5533,
+          "name": "Garlean Rubber",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Enemy_Humanoid/bnpc_boarPoacher.json
+++ b/data/lootTables/bnpc/Enemy_Humanoid/bnpc_boarPoacher.json
@@ -1,0 +1,16 @@
+{
+  "lootTable": "bnpc_boarPoacher",
+  "pools": [
+    {
+      "name": "Pool #1 (empty)",
+      "enabled": false,
+      "duplicates": false,
+      "pick": {
+        "min": 0,
+        "max": 0
+      },
+      "items": []
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Enemy_Humanoid/bnpc_captainPetyrPigeontoe.json
+++ b/data/lootTables/bnpc/Enemy_Humanoid/bnpc_captainPetyrPigeontoe.json
@@ -1,0 +1,16 @@
+{
+  "lootTable": "bnpc_captainPetyrPigeontoe",
+  "pools": [
+    {
+      "name": "Pool #1 (empty)",
+      "enabled": false,
+      "duplicates": false,
+      "pick": {
+        "min": 0,
+        "max": 0
+      },
+      "items": []
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Enemy_Humanoid/bnpc_coeurlclawCutter.json
+++ b/data/lootTables/bnpc/Enemy_Humanoid/bnpc_coeurlclawCutter.json
@@ -1,0 +1,16 @@
+{
+  "lootTable": "bnpc_coeurlclawCutter",
+  "pools": [
+    {
+      "name": "Pool #1 (empty)",
+      "enabled": false,
+      "duplicates": false,
+      "pick": {
+        "min": 0,
+        "max": 0
+      },
+      "items": []
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Enemy_Humanoid/bnpc_coeurlclawHunter.json
+++ b/data/lootTables/bnpc/Enemy_Humanoid/bnpc_coeurlclawHunter.json
@@ -1,0 +1,16 @@
+{
+  "lootTable": "bnpc_coeurlclawHunter",
+  "pools": [
+    {
+      "name": "Pool #1 (empty)",
+      "enabled": false,
+      "duplicates": false,
+      "pick": {
+        "min": 0,
+        "max": 0
+      },
+      "items": []
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Enemy_Humanoid/bnpc_corpseBrigadeFootsoldier.json
+++ b/data/lootTables/bnpc/Enemy_Humanoid/bnpc_corpseBrigadeFootsoldier.json
@@ -1,0 +1,27 @@
+{
+  "lootTable": "bnpc_corpseBrigadeFootsoldier",
+  "pools": [
+    {
+      "name": "Pool #1 (Gil)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 1,
+          "name": "Gil",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Enemy_Humanoid/bnpc_galebornBuccaneer.json
+++ b/data/lootTables/bnpc/Enemy_Humanoid/bnpc_galebornBuccaneer.json
@@ -1,0 +1,27 @@
+{
+  "lootTable": "bnpc_galebornBuccaneer",
+  "pools": [
+    {
+      "name": "Pool #1 (Gil)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 1,
+          "name": "Gil",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Enemy_Humanoid/bnpc_groundedPirate.json
+++ b/data/lootTables/bnpc/Enemy_Humanoid/bnpc_groundedPirate.json
@@ -1,0 +1,16 @@
+{
+  "lootTable": "bnpc_groundedPirate",
+  "pools": [
+    {
+      "name": "Pool #1 (empty)",
+      "enabled": false,
+      "duplicates": false,
+      "pick": {
+        "min": 0,
+        "max": 0
+      },
+      "items": []
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Enemy_Humanoid/bnpc_groundedRaider.json
+++ b/data/lootTables/bnpc/Enemy_Humanoid/bnpc_groundedRaider.json
@@ -1,0 +1,16 @@
+{
+  "lootTable": "bnpc_groundedRaider",
+  "pools": [
+    {
+      "name": "Pool #1 (empty)",
+      "enabled": false,
+      "duplicates": false,
+      "pick": {
+        "min": 0,
+        "max": 0
+      },
+      "items": []
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Enemy_Humanoid/bnpc_hiredBow.json
+++ b/data/lootTables/bnpc/Enemy_Humanoid/bnpc_hiredBow.json
@@ -1,0 +1,16 @@
+{
+  "lootTable": "bnpc_hiredBow",
+  "pools": [
+    {
+      "name": "Pool #1 (empty)",
+      "enabled": false,
+      "duplicates": false,
+      "pick": {
+        "min": 0,
+        "max": 0
+      },
+      "items": []
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Enemy_Humanoid/bnpc_menacingMercenary.json
+++ b/data/lootTables/bnpc/Enemy_Humanoid/bnpc_menacingMercenary.json
@@ -1,0 +1,27 @@
+{
+  "lootTable": "bnpc_menacingMercenary",
+  "pools": [
+    {
+      "name": "Pool #1 (Gil)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 1,
+          "name": "Gil",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Enemy_Humanoid/bnpc_mindfulMercenary.json
+++ b/data/lootTables/bnpc/Enemy_Humanoid/bnpc_mindfulMercenary.json
@@ -1,0 +1,16 @@
+{
+  "lootTable": "bnpc_mindfulMercenary",
+  "pools": [
+    {
+      "name": "Pool #1 (empty)",
+      "enabled": false,
+      "duplicates": false,
+      "pick": {
+        "min": 0,
+        "max": 0
+      },
+      "items": []
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Enemy_Humanoid/bnpc_nobleWhoresonsPenman.json
+++ b/data/lootTables/bnpc/Enemy_Humanoid/bnpc_nobleWhoresonsPenman.json
@@ -1,0 +1,16 @@
+{
+  "lootTable": "bnpc_nobleWhoresonsPenman",
+  "pools": [
+    {
+      "name": "Pool #1 (empty)",
+      "enabled": false,
+      "duplicates": false,
+      "pick": {
+        "min": 0,
+        "max": 0
+      },
+      "items": []
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Enemy_Humanoid/bnpc_nobleWhoresonsRingleader.json
+++ b/data/lootTables/bnpc/Enemy_Humanoid/bnpc_nobleWhoresonsRingleader.json
@@ -1,0 +1,16 @@
+{
+  "lootTable": "bnpc_nobleWhoresonsRingleader",
+  "pools": [
+    {
+      "name": "Pool #1 (empty)",
+      "enabled": false,
+      "duplicates": false,
+      "pick": {
+        "min": 0,
+        "max": 0
+      },
+      "items": []
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Enemy_Humanoid/bnpc_nobleWhoresonsSmuggler.json
+++ b/data/lootTables/bnpc/Enemy_Humanoid/bnpc_nobleWhoresonsSmuggler.json
@@ -1,0 +1,16 @@
+{
+  "lootTable": "bnpc_nobleWhoresonsSmuggler",
+  "pools": [
+    {
+      "name": "Pool #1 (empty)",
+      "enabled": false,
+      "duplicates": false,
+      "pick": {
+        "min": 0,
+        "max": 0
+      },
+      "items": []
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Enemy_Humanoid/bnpc_quiveronGuard.json
+++ b/data/lootTables/bnpc/Enemy_Humanoid/bnpc_quiveronGuard.json
@@ -1,0 +1,16 @@
+{
+  "lootTable": "bnpc_quiveronGuard",
+  "pools": [
+    {
+      "name": "Pool #1 (empty)",
+      "enabled": false,
+      "duplicates": false,
+      "pick": {
+        "min": 0,
+        "max": 0
+      },
+      "items": []
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Enemy_Humanoid/bnpc_raptorPoacher.json
+++ b/data/lootTables/bnpc/Enemy_Humanoid/bnpc_raptorPoacher.json
@@ -1,0 +1,16 @@
+{
+  "lootTable": "bnpc_raptorPoacher",
+  "pools": [
+    {
+      "name": "Pool #1 (empty)",
+      "enabled": false,
+      "duplicates": false,
+      "pick": {
+        "min": 0,
+        "max": 0
+      },
+      "items": []
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Enemy_Humanoid/bnpc_reaverRightHand.json
+++ b/data/lootTables/bnpc/Enemy_Humanoid/bnpc_reaverRightHand.json
@@ -1,0 +1,16 @@
+{
+  "lootTable": "bnpc_reaverRightHand",
+  "pools": [
+    {
+      "name": "Pool #1 (empty)",
+      "enabled": false,
+      "duplicates": false,
+      "pick": {
+        "min": 0,
+        "max": 0
+      },
+      "items": []
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Enemy_Humanoid/bnpc_redbellyLarcener.json
+++ b/data/lootTables/bnpc/Enemy_Humanoid/bnpc_redbellyLarcener.json
@@ -1,0 +1,16 @@
+{
+  "lootTable": "bnpc_redbellyLarcener",
+  "pools": [
+    {
+      "name": "Pool #1 (empty)",
+      "enabled": false,
+      "duplicates": false,
+      "pick": {
+        "min": 0,
+        "max": 0
+      },
+      "items": []
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Enemy_Humanoid/bnpc_redbellyTombRaider.json
+++ b/data/lootTables/bnpc/Enemy_Humanoid/bnpc_redbellyTombRaider.json
@@ -1,0 +1,16 @@
+{
+  "lootTable": "bnpc_redbellyTombRaider",
+  "pools": [
+    {
+      "name": "Pool #1 (empty)",
+      "enabled": false,
+      "duplicates": false,
+      "pick": {
+        "min": 0,
+        "max": 0
+      },
+      "items": []
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Enemy_Humanoid/bnpc_rhotanoBuccaneer.json
+++ b/data/lootTables/bnpc/Enemy_Humanoid/bnpc_rhotanoBuccaneer.json
@@ -1,0 +1,16 @@
+{
+  "lootTable": "bnpc_rhotanoBuccaneer",
+  "pools": [
+    {
+      "name": "Pool #1 (empty)",
+      "enabled": false,
+      "duplicates": false,
+      "pick": {
+        "min": 0,
+        "max": 0
+      },
+      "items": []
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Enemy_Humanoid/bnpc_shelfclawReaver.json
+++ b/data/lootTables/bnpc/Enemy_Humanoid/bnpc_shelfclawReaver.json
@@ -1,0 +1,16 @@
+{
+  "lootTable": "bnpc_shelfclawReaver",
+  "pools": [
+    {
+      "name": "Pool #1 (empty)",
+      "enabled": false,
+      "duplicates": false,
+      "pick": {
+        "min": 0,
+        "max": 0
+      },
+      "items": []
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Enemy_Humanoid/bnpc_tarstainedBuccaneer.json
+++ b/data/lootTables/bnpc/Enemy_Humanoid/bnpc_tarstainedBuccaneer.json
@@ -1,0 +1,16 @@
+{
+  "lootTable": "bnpc_tarstainedBuccaneer",
+  "pools": [
+    {
+      "name": "Pool #1 (empty)",
+      "enabled": false,
+      "duplicates": false,
+      "pick": {
+        "min": 0,
+        "max": 0
+      },
+      "items": []
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Enemy_Humanoid/bnpc_wolfPoacher.json
+++ b/data/lootTables/bnpc/Enemy_Humanoid/bnpc_wolfPoacher.json
@@ -1,0 +1,16 @@
+{
+  "lootTable": "bnpc_wolfPoacher",
+  "pools": [
+    {
+      "name": "Pool #1 (empty)",
+      "enabled": false,
+      "duplicates": false,
+      "pick": {
+        "min": 0,
+        "max": 0
+      },
+      "items": []
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Enkidu/bnpc_enkiduMob.json
+++ b/data/lootTables/bnpc/Enkidu/bnpc_enkiduMob.json
@@ -1,0 +1,16 @@
+{
+  "lootTable": "bnpc_enkiduMob",
+  "pools": [
+    {
+      "name": "Pool #1 (empty)",
+      "enabled": false,
+      "duplicates": false,
+      "pick": {
+        "min": 0,
+        "max": 0
+      },
+      "items": []
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Flan/bnpc_gelato.json
+++ b/data/lootTables/bnpc/Flan/bnpc_gelato.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_gelato",
+  "pools": [
+    {
+      "name": "Pool #1 (Gelato Flesh)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 12635,
+          "name": "Gelato Flesh",
+          "weight": 369,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 3
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 631,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Flan/bnpc_sorbet.json
+++ b/data/lootTables/bnpc/Flan/bnpc_sorbet.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_sorbet",
+  "pools": [
+    {
+      "name": "Pool #1 (Gelato Flesh)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 12635,
+          "name": "Gelato Flesh",
+          "weight": 362,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 3
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 638,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Funguar/bnpc_forestFunguar.json
+++ b/data/lootTables/bnpc/Funguar/bnpc_forestFunguar.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_forestFunguar",
+  "pools": [
+    {
+      "name": "Pool #1 (Shriekshroom)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4794,
+          "name": "Shriekshroom",
+          "weight": 296,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 704,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Funguar/bnpc_sylphBonnet.json
+++ b/data/lootTables/bnpc/Funguar/bnpc_sylphBonnet.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_sylphBonnet",
+  "pools": [
+    {
+      "name": "Pool #1 (Shriekshroom)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4794,
+          "name": "Shriekshroom",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Shriekshroom)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4794,
+          "name": "Shriekshroom",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Gigantoad/bnpc_boneNix.json
+++ b/data/lootTables/bnpc/Gigantoad/bnpc_boneNix.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_boneNix",
+  "pools": [
+    {
+      "name": "Pool #1 (Gigantoad Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5300,
+          "name": "Gigantoad Skin",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Gigantoad/bnpc_dreamtoad.json
+++ b/data/lootTables/bnpc/Gigantoad/bnpc_dreamtoad.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_dreamtoad",
+  "pools": [
+    {
+      "name": "Pool #1 (Gigantoad Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5300,
+          "name": "Gigantoad Skin",
+          "weight": 889,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 5
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 111,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Gigantoad Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5300,
+          "name": "Gigantoad Skin",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Gigantoad/bnpc_gigantoad.json
+++ b/data/lootTables/bnpc/Gigantoad/bnpc_gigantoad.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_gigantoad",
+  "pools": [
+    {
+      "name": "Pool #1 (Gigantoad Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5300,
+          "name": "Gigantoad Skin",
+          "weight": 576,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 7
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 424,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Gigantoad/bnpc_gigglingGigantoad.json
+++ b/data/lootTables/bnpc/Gigantoad/bnpc_gigglingGigantoad.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_gigglingGigantoad",
+  "pools": [
+    {
+      "name": "Pool #1 (Gigantoad Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5300,
+          "name": "Gigantoad Skin",
+          "weight": 787,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 5
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 213,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Gigantoad/bnpc_inflatedNix.json
+++ b/data/lootTables/bnpc/Gigantoad/bnpc_inflatedNix.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_inflatedNix",
+  "pools": [
+    {
+      "name": "Pool #1 (Gigantoad Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5300,
+          "name": "Gigantoad Skin",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Gigantoad/bnpc_laughingToad.json
+++ b/data/lootTables/bnpc/Gigantoad/bnpc_laughingToad.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_laughingToad",
+  "pools": [
+    {
+      "name": "Pool #1 (Gigantoad Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5300,
+          "name": "Gigantoad Skin",
+          "weight": 750,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 5
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 250,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Gigantoad/bnpc_lumberToad.json
+++ b/data/lootTables/bnpc/Gigantoad/bnpc_lumberToad.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_lumberToad",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5291,
+          "name": "Animal Skin",
+          "weight": 333,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 667,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Gigantoad/bnpc_sandtoad.json
+++ b/data/lootTables/bnpc/Gigantoad/bnpc_sandtoad.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_sandtoad",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5291,
+          "name": "Animal Skin",
+          "weight": 640,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 360,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Goblin/bnpc_illuminatiFootman.json
+++ b/data/lootTables/bnpc/Goblin/bnpc_illuminatiFootman.json
@@ -1,0 +1,27 @@
+{
+  "lootTable": "bnpc_illuminatiFootman",
+  "pools": [
+    {
+      "name": "Pool #1 (Gil)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 1,
+          "name": "Gil",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 240,
+            "max": 320
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Goblin/bnpc_illuminatiMarksman.json
+++ b/data/lootTables/bnpc/Goblin/bnpc_illuminatiMarksman.json
@@ -1,0 +1,27 @@
+{
+  "lootTable": "bnpc_illuminatiMarksman",
+  "pools": [
+    {
+      "name": "Pool #1 (Gil)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 1,
+          "name": "Gil",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 240,
+            "max": 320
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Goblin/bnpc_illuminatiSoldier.json
+++ b/data/lootTables/bnpc/Goblin/bnpc_illuminatiSoldier.json
@@ -1,0 +1,27 @@
+{
+  "lootTable": "bnpc_illuminatiSoldier",
+  "pools": [
+    {
+      "name": "Pool #1 (Gil)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 1,
+          "name": "Gil",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 240,
+            "max": 320
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Golem/bnpc_chertGolem.json
+++ b/data/lootTables/bnpc/Golem/bnpc_chertGolem.json
@@ -1,0 +1,27 @@
+{
+  "lootTable": "bnpc_chertGolem",
+  "pools": [
+    {
+      "name": "Pool #1 (Mudstone)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5229,
+          "name": "Mudstone",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Golem/bnpc_marbleMarionette.json
+++ b/data/lootTables/bnpc/Golem/bnpc_marbleMarionette.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_marbleMarionette",
+  "pools": [
+    {
+      "name": "Pool #1 (Mudstone)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5229,
+          "name": "Mudstone",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Goobbue/bnpc_mildewedGoobbue.json
+++ b/data/lootTables/bnpc/Goobbue/bnpc_mildewedGoobbue.json
@@ -1,0 +1,27 @@
+{
+  "lootTable": "bnpc_mildewedGoobbue",
+  "pools": [
+    {
+      "name": "Pool #1 (Goobbue Fang)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5446,
+          "name": "Goobbue Fang",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Goobbue/bnpc_mosslessGoobbue.json
+++ b/data/lootTables/bnpc/Goobbue/bnpc_mosslessGoobbue.json
@@ -1,0 +1,130 @@
+{
+  "lootTable": "bnpc_mosslessGoobbue",
+  "pools": [
+    {
+      "name": "Pool #1 (Goobbue Fang)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5446,
+          "name": "Goobbue Fang",
+          "weight": 444,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 556,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Goobbue Fang)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5446,
+          "name": "Goobbue Fang",
+          "weight": 444,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 556,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #3 (Goobbue Fang)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5446,
+          "name": "Goobbue Fang",
+          "weight": 333,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 667,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #4 (Goobbue Fang)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5446,
+          "name": "Goobbue Fang",
+          "weight": 333,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 667,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Goobbue/bnpc_sweetToothGoobbue.json
+++ b/data/lootTables/bnpc/Goobbue/bnpc_sweetToothGoobbue.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_sweetToothGoobbue",
+  "pools": [
+    {
+      "name": "Pool #1 (Goobbue Fang)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5446,
+          "name": "Goobbue Fang",
+          "weight": 455,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 545,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Great_Dragon/bnpc_vishap.json
+++ b/data/lootTables/bnpc/Great_Dragon/bnpc_vishap.json
@@ -1,0 +1,16 @@
+{
+  "lootTable": "bnpc_vishap",
+  "pools": [
+    {
+      "name": "Pool #1 (empty)",
+      "enabled": false,
+      "duplicates": false,
+      "pick": {
+        "min": 0,
+        "max": 0
+      },
+      "items": []
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Griffin/bnpc_akhekhu.json
+++ b/data/lootTables/bnpc/Griffin/bnpc_akhekhu.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_akhekhu",
+  "pools": [
+    {
+      "name": "Pool #1 (Griffin Hide, Griffin Hide)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 2,
+        "max": 2
+      },
+      "items": [
+        {
+          "id": 12573,
+          "name": "Griffin Hide",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 12573,
+          "name": "Griffin Hide",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Griffin Talon)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 12577,
+          "name": "Griffin Talon",
+          "weight": 333,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 667,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Hippogryph/bnpc_gwyllgi.json
+++ b/data/lootTables/bnpc/Hippogryph/bnpc_gwyllgi.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_gwyllgi",
+  "pools": [
+    {
+      "name": "Pool #1 (Hippogryph Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5316,
+          "name": "Hippogryph Skin",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Hippogryph Sinew)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5321,
+          "name": "Hippogryph Sinew",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Hippogryph/bnpc_hippocerf.json
+++ b/data/lootTables/bnpc/Hippogryph/bnpc_hippocerf.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_hippocerf",
+  "pools": [
+    {
+      "name": "Pool #1 (Hippogryph Sinew)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5321,
+          "name": "Hippogryph Sinew",
+          "weight": 632,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 368,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Hippogryph/bnpc_wingedScavenger.json
+++ b/data/lootTables/bnpc/Hippogryph/bnpc_wingedScavenger.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_wingedScavenger",
+  "pools": [
+    {
+      "name": "Pool #1 (Hippogryph Skin, Hippogryph Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 2,
+        "max": 2
+      },
+      "items": [
+        {
+          "id": 5316,
+          "name": "Hippogryph Skin",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 3
+          }
+        },
+        {
+          "id": 5316,
+          "name": "Hippogryph Skin",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 3
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Imp/bnpc_deepvoidScamp.json
+++ b/data/lootTables/bnpc/Imp/bnpc_deepvoidScamp.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_deepvoidScamp",
+  "pools": [
+    {
+      "name": "Pool #1 (Imp Wing)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5552,
+          "name": "Imp Wing",
+          "weight": 333,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 667,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Imp/bnpc_hecklerImp.json
+++ b/data/lootTables/bnpc/Imp/bnpc_hecklerImp.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_hecklerImp",
+  "pools": [
+    {
+      "name": "Pool #1 (Imp Wing)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5552,
+          "name": "Imp Wing",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Imp/bnpc_mischiefmakerImp.json
+++ b/data/lootTables/bnpc/Imp/bnpc_mischiefmakerImp.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_mischiefmakerImp",
+  "pools": [
+    {
+      "name": "Pool #1 (Imp Wing)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5552,
+          "name": "Imp Wing",
+          "weight": 333,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 667,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Imp/bnpc_mormosMissionary.json
+++ b/data/lootTables/bnpc/Imp/bnpc_mormosMissionary.json
@@ -1,0 +1,27 @@
+{
+  "lootTable": "bnpc_mormosMissionary",
+  "pools": [
+    {
+      "name": "Pool #1 (Imp Wing)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5552,
+          "name": "Imp Wing",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Imp/bnpc_vandalousImp.json
+++ b/data/lootTables/bnpc/Imp/bnpc_vandalousImp.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_vandalousImp",
+  "pools": [
+    {
+      "name": "Pool #1 (Imp Wing)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5552,
+          "name": "Imp Wing",
+          "weight": 300,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 700,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Jellyfish/bnpc_aetherboundAurelia.json
+++ b/data/lootTables/bnpc/Jellyfish/bnpc_aetherboundAurelia.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_aetherboundAurelia",
+  "pools": [
+    {
+      "name": "Pool #1 (Jellyfish Umbrella)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5557,
+          "name": "Jellyfish Umbrella",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Jellyfish/bnpc_bloodshoreBell.json
+++ b/data/lootTables/bnpc/Jellyfish/bnpc_bloodshoreBell.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_bloodshoreBell",
+  "pools": [
+    {
+      "name": "Pool #1 (Jellyfish Cnida)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5556,
+          "name": "Jellyfish Cnida",
+          "weight": 235,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 765,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Jellyfish Umbrella)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5557,
+          "name": "Jellyfish Umbrella",
+          "weight": 382,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 618,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Jellyfish/bnpc_darkMatterAurelia.json
+++ b/data/lootTables/bnpc/Jellyfish/bnpc_darkMatterAurelia.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_darkMatterAurelia",
+  "pools": [
+    {
+      "name": "Pool #1 (Jellyfish Umbrella)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5557,
+          "name": "Jellyfish Umbrella",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Jellyfish Cnida)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5556,
+          "name": "Jellyfish Cnida",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Jellyfish/bnpc_territorialSeaWasp.json
+++ b/data/lootTables/bnpc/Jellyfish/bnpc_territorialSeaWasp.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_territorialSeaWasp",
+  "pools": [
+    {
+      "name": "Pool #1 (Jellyfish Umbrella)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5557,
+          "name": "Jellyfish Umbrella",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Jellyfish Cnida)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5556,
+          "name": "Jellyfish Cnida",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/King_Thordan/bnpc_kingThordanPrimal.json
+++ b/data/lootTables/bnpc/King_Thordan/bnpc_kingThordanPrimal.json
@@ -1,0 +1,16 @@
+{
+  "lootTable": "bnpc_kingThordanPrimal",
+  "pools": [
+    {
+      "name": "Pool #1 (empty)",
+      "enabled": false,
+      "duplicates": false,
+      "pick": {
+        "min": 0,
+        "max": 0
+      },
+      "items": []
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Landtrap/bnpc_kedtrap.json
+++ b/data/lootTables/bnpc/Landtrap/bnpc_kedtrap.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_kedtrap",
+  "pools": [
+    {
+      "name": "Pool #1 (Blue Landtrap Leaf)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5549,
+          "name": "Blue Landtrap Leaf",
+          "weight": 279,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 721,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Blue Landtrap Leaf)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5549,
+          "name": "Blue Landtrap Leaf",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Landtrap/bnpc_milkrootSapling.json
+++ b/data/lootTables/bnpc/Landtrap/bnpc_milkrootSapling.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_milkrootSapling",
+  "pools": [
+    {
+      "name": "Pool #1 (Blue Landtrap Leaf)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5549,
+          "name": "Blue Landtrap Leaf",
+          "weight": 385,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 615,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Blue Landtrap Leaf)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5549,
+          "name": "Blue Landtrap Leaf",
+          "weight": 400,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 600,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Landtrap/bnpc_poisonousFlytrap.json
+++ b/data/lootTables/bnpc/Landtrap/bnpc_poisonousFlytrap.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_poisonousFlytrap",
+  "pools": [
+    {
+      "name": "Pool #1 (Blue Landtrap Leaf)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5549,
+          "name": "Blue Landtrap Leaf",
+          "weight": 333,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 667,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Landtrap/bnpc_roselet.json
+++ b/data/lootTables/bnpc/Landtrap/bnpc_roselet.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_roselet",
+  "pools": [
+    {
+      "name": "Pool #1 (Red Landtrap Leaf)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5548,
+          "name": "Red Landtrap Leaf",
+          "weight": 283,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 717,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Landtrap/bnpc_roseling.json
+++ b/data/lootTables/bnpc/Landtrap/bnpc_roseling.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_roseling",
+  "pools": [
+    {
+      "name": "Pool #1 (Red Landtrap Leaf)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5548,
+          "name": "Red Landtrap Leaf",
+          "weight": 364,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 636,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Landtrap/bnpc_sweetTrap.json
+++ b/data/lootTables/bnpc/Landtrap/bnpc_sweetTrap.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_sweetTrap",
+  "pools": [
+    {
+      "name": "Pool #1 (Red Landtrap Leaf)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5548,
+          "name": "Red Landtrap Leaf",
+          "weight": 250,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 750,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Megalocrab/bnpc_bigClaw.json
+++ b/data/lootTables/bnpc/Megalocrab/bnpc_bigClaw.json
@@ -1,0 +1,47 @@
+{
+  "lootTable": "bnpc_bigClaw",
+  "pools": [
+    {
+      "name": "Pool #1 (Green Megalocrab Shell, Green Megalocrab Shell, Green Megalocrab Shell)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 3,
+        "max": 3
+      },
+      "items": [
+        {
+          "id": 5456,
+          "name": "Green Megalocrab Shell",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 5456,
+          "name": "Green Megalocrab Shell",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 5456,
+          "name": "Green Megalocrab Shell",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Megalocrab/bnpc_moltingMegalocrab.json
+++ b/data/lootTables/bnpc/Megalocrab/bnpc_moltingMegalocrab.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_moltingMegalocrab",
+  "pools": [
+    {
+      "name": "Pool #1 (Green Megalocrab Shell)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5456,
+          "name": "Green Megalocrab Shell",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Megalocrab/bnpc_spawningMegalocrab.json
+++ b/data/lootTables/bnpc/Megalocrab/bnpc_spawningMegalocrab.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_spawningMegalocrab",
+  "pools": [
+    {
+      "name": "Pool #1 (Megalocrab Leg)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4771,
+          "name": "Megalocrab Leg",
+          "weight": 267,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 733,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Green Megalocrab Shell)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5456,
+          "name": "Green Megalocrab Shell",
+          "weight": 400,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 600,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Megalocrab/bnpc_territorialSnipper.json
+++ b/data/lootTables/bnpc/Megalocrab/bnpc_territorialSnipper.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_territorialSnipper",
+  "pools": [
+    {
+      "name": "Pool #1 (Green Megalocrab Shell)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5456,
+          "name": "Green Megalocrab Shell",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Mole/bnpc_dryboneTucotuco.json
+++ b/data/lootTables/bnpc/Mole/bnpc_dryboneTucotuco.json
@@ -1,0 +1,190 @@
+{
+  "lootTable": "bnpc_dryboneTucotuco",
+  "pools": [
+    {
+      "name": "Pool #1 (Mole Meat, Mole Meat, Mole Meat, Mole Meat, Mole Meat, Mole Meat, Mole Meat, Mole Meat)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 8,
+        "max": 8
+      },
+      "items": [
+        {
+          "id": 4761,
+          "name": "Mole Meat",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 4761,
+          "name": "Mole Meat",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 4761,
+          "name": "Mole Meat",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 4761,
+          "name": "Mole Meat",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 4761,
+          "name": "Mole Meat",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 4761,
+          "name": "Mole Meat",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 4761,
+          "name": "Mole Meat",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 4761,
+          "name": "Mole Meat",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Animal Sinew)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5318,
+          "name": "Animal Sinew",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #3 (Mole Meat)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4761,
+          "name": "Mole Meat",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #4 (Mole Meat)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4761,
+          "name": "Mole Meat",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Mole/bnpc_ironquillTucotuco.json
+++ b/data/lootTables/bnpc/Mole/bnpc_ironquillTucotuco.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_ironquillTucotuco",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Sinew)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5318,
+          "name": "Animal Sinew",
+          "weight": 250,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 750,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Mole Meat)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4761,
+          "name": "Mole Meat",
+          "weight": 750,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 250,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Morbol/bnpc_capriciousCassie.json
+++ b/data/lootTables/bnpc/Morbol/bnpc_capriciousCassie.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_capriciousCassie",
+  "pools": [
+    {
+      "name": "Pool #1 (Morbol Vine)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5554,
+          "name": "Morbol Vine",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Morbol/bnpc_stroper.json
+++ b/data/lootTables/bnpc/Morbol/bnpc_stroper.json
@@ -1,0 +1,99 @@
+{
+  "lootTable": "bnpc_stroper",
+  "pools": [
+    {
+      "name": "Pool #1 (Morbol Vine)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5554,
+          "name": "Morbol Vine",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Morbol Vine)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5554,
+          "name": "Morbol Vine",
+          "weight": 262,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 738,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #3 (Morbol Vine)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5554,
+          "name": "Morbol Vine",
+          "weight": 220,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 780,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Opoopo/bnpc_galago.json
+++ b/data/lootTables/bnpc/Opoopo/bnpc_galago.json
@@ -1,0 +1,99 @@
+{
+  "lootTable": "bnpc_galago",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5291,
+          "name": "Animal Skin",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Animal Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5291,
+          "name": "Animal Skin",
+          "weight": 529,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 471,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #3 (Galago Mint)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4834,
+          "name": "Galago Mint",
+          "weight": 471,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 529,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Opoopo/bnpc_leapingRingtail.json
+++ b/data/lootTables/bnpc/Opoopo/bnpc_leapingRingtail.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_leapingRingtail",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Hide)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5292,
+          "name": "Animal Hide",
+          "weight": 800,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 200,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Opoopo/bnpc_lemur.json
+++ b/data/lootTables/bnpc/Opoopo/bnpc_lemur.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_lemur",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Hide)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5292,
+          "name": "Animal Hide",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Animal Hide)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5292,
+          "name": "Animal Hide",
+          "weight": 429,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 571,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Opoopo/bnpc_longwindedLemur.json
+++ b/data/lootTables/bnpc/Opoopo/bnpc_longwindedLemur.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_longwindedLemur",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Hide)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5292,
+          "name": "Animal Hide",
+          "weight": 333,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 667,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Opoopo/bnpc_northShroudLemur.json
+++ b/data/lootTables/bnpc/Opoopo/bnpc_northShroudLemur.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_northShroudLemur",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Hide)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5292,
+          "name": "Animal Hide",
+          "weight": 333,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 667,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Opoopo/bnpc_opoopo.json
+++ b/data/lootTables/bnpc/Opoopo/bnpc_opoopo.json
@@ -1,0 +1,223 @@
+{
+  "lootTable": "bnpc_opoopo",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5291,
+          "name": "Animal Skin",
+          "weight": 917,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 3
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 83,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Animal Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5291,
+          "name": "Animal Skin",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #3 (Animal Hide)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5292,
+          "name": "Animal Hide",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #4 (Galago Mint)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4834,
+          "name": "Galago Mint",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #5 (Animal Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5291,
+          "name": "Animal Skin",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #6 (Animal Hide)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5292,
+          "name": "Animal Hide",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #7 (Galago Mint)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4834,
+          "name": "Galago Mint",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Opoopo/bnpc_ringtail.json
+++ b/data/lootTables/bnpc/Opoopo/bnpc_ringtail.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_ringtail",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Hide)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5292,
+          "name": "Animal Hide",
+          "weight": 100,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 900,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Orobon/bnpc_alpgrotOrobon.json
+++ b/data/lootTables/bnpc/Orobon/bnpc_alpgrotOrobon.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_alpgrotOrobon",
+  "pools": [
+    {
+      "name": "Pool #1 (Orobon Liver)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4770,
+          "name": "Orobon Liver",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Orobon/bnpc_angler.json
+++ b/data/lootTables/bnpc/Orobon/bnpc_angler.json
@@ -1,0 +1,99 @@
+{
+  "lootTable": "bnpc_angler",
+  "pools": [
+    {
+      "name": "Pool #1 (Orobon Liver)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4770,
+          "name": "Orobon Liver",
+          "weight": 308,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 692,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Orobon Liver)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4770,
+          "name": "Orobon Liver",
+          "weight": 308,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 692,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #3 (Orobon Liver)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4770,
+          "name": "Orobon Liver",
+          "weight": 200,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 800,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Orobon/bnpc_bigmouthOrobon.json
+++ b/data/lootTables/bnpc/Orobon/bnpc_bigmouthOrobon.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_bigmouthOrobon",
+  "pools": [
+    {
+      "name": "Pool #1 (Orobon Liver)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4770,
+          "name": "Orobon Liver",
+          "weight": 400,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 600,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Peiste/bnpc_fellbitePeiste.json
+++ b/data/lootTables/bnpc/Peiste/bnpc_fellbitePeiste.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_fellbitePeiste",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Hide)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5292,
+          "name": "Animal Hide",
+          "weight": 800,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 200,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Peiste Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5306,
+          "name": "Peiste Skin",
+          "weight": 800,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 200,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Peiste/bnpc_quicksandBasilisk.json
+++ b/data/lootTables/bnpc/Peiste/bnpc_quicksandBasilisk.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_quicksandBasilisk",
+  "pools": [
+    {
+      "name": "Pool #1 (Peiste Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5306,
+          "name": "Peiste Skin",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Basilisk Egg)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5263,
+          "name": "Basilisk Egg",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Peiste/bnpc_sandskinPeiste.json
+++ b/data/lootTables/bnpc/Peiste/bnpc_sandskinPeiste.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_sandskinPeiste",
+  "pools": [
+    {
+      "name": "Pool #1 (Peiste Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5306,
+          "name": "Peiste Skin",
+          "weight": 680,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 5
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 320,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Phoenix/bnpc_phoenix.json
+++ b/data/lootTables/bnpc/Phoenix/bnpc_phoenix.json
@@ -1,0 +1,16 @@
+{
+  "lootTable": "bnpc_phoenix",
+  "pools": [
+    {
+      "name": "Pool #1 (empty)",
+      "enabled": false,
+      "duplicates": false,
+      "pick": {
+        "min": 0,
+        "max": 0
+      },
+      "items": []
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Plasmoid/bnpc_houndLight.json
+++ b/data/lootTables/bnpc/Plasmoid/bnpc_houndLight.json
@@ -1,0 +1,27 @@
+{
+  "lootTable": "bnpc_houndLight",
+  "pools": [
+    {
+      "name": "Pool #1 (Gil)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 1,
+          "name": "Gil",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 47,
+            "max": 57
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Puk/bnpc_pteroc.json
+++ b/data/lootTables/bnpc/Puk/bnpc_pteroc.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_pteroc",
+  "pools": [
+    {
+      "name": "Pool #1 (Puk Egg)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4774,
+          "name": "Puk Egg",
+          "weight": 278,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 722,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Puk Wing)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5550,
+          "name": "Puk Wing",
+          "weight": 287,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 713,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Puk/bnpc_pterocMatron.json
+++ b/data/lootTables/bnpc/Puk/bnpc_pterocMatron.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_pterocMatron",
+  "pools": [
+    {
+      "name": "Pool #1 (Puk Wing)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5550,
+          "name": "Puk Wing",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Puk/bnpc_pukHatchling.json
+++ b/data/lootTables/bnpc/Puk/bnpc_pukHatchling.json
@@ -1,0 +1,99 @@
+{
+  "lootTable": "bnpc_pukHatchling",
+  "pools": [
+    {
+      "name": "Pool #1 (Puk Wing)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5550,
+          "name": "Puk Wing",
+          "weight": 222,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 778,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Puk Wing)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5550,
+          "name": "Puk Wing",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #3 (Puk Wing)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5550,
+          "name": "Puk Wing",
+          "weight": 240,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 760,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Raptor/bnpc_anole.json
+++ b/data/lootTables/bnpc/Raptor/bnpc_anole.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_anole",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Hide)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5292,
+          "name": "Animal Hide",
+          "weight": 454,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 3
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 546,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Raptor/bnpc_grassRaptor.json
+++ b/data/lootTables/bnpc/Raptor/bnpc_grassRaptor.json
@@ -1,0 +1,378 @@
+{
+  "lootTable": "bnpc_grassRaptor",
+  "pools": [
+    {
+      "name": "Pool #1 (Raptor Sinew)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5322,
+          "name": "Raptor Sinew",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Raptor Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5310,
+          "name": "Raptor Skin",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #3 (Raptor Shank)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4767,
+          "name": "Raptor Shank",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #4 (Raptor Sinew)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5322,
+          "name": "Raptor Sinew",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #5 (Raptor Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5310,
+          "name": "Raptor Skin",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #6 (Raptor Shank)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4767,
+          "name": "Raptor Shank",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #7 (Raptor Sinew)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5322,
+          "name": "Raptor Sinew",
+          "weight": 343,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 657,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #8 (Raptor Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5310,
+          "name": "Raptor Skin",
+          "weight": 608,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 392,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #9 (Raptor Shank)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4767,
+          "name": "Raptor Shank",
+          "weight": 304,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 696,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #10 (Raptor Sinew)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5322,
+          "name": "Raptor Sinew",
+          "weight": 394,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 606,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #11 (Raptor Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5310,
+          "name": "Raptor Skin",
+          "weight": 617,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 383,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #12 (Raptor Shank)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4767,
+          "name": "Raptor Shank",
+          "weight": 350,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 650,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Raptor/bnpc_lindwurm.json
+++ b/data/lootTables/bnpc/Raptor/bnpc_lindwurm.json
@@ -1,0 +1,223 @@
+{
+  "lootTable": "bnpc_lindwurm",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Hide)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5292,
+          "name": "Animal Hide",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Raptor Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5310,
+          "name": "Raptor Skin",
+          "weight": 691,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 309,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #3 (Raptor Sinew)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5322,
+          "name": "Raptor Sinew",
+          "weight": 209,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 791,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #4 (Raptor Shank)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4767,
+          "name": "Raptor Shank",
+          "weight": 218,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 782,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #5 (Raptor Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5310,
+          "name": "Raptor Skin",
+          "weight": 504,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 496,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #6 (Raptor Sinew)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5322,
+          "name": "Raptor Sinew",
+          "weight": 265,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 735,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #7 (Raptor Shank)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4767,
+          "name": "Raptor Shank",
+          "weight": 336,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 664,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Raptor/bnpc_plainstrider.json
+++ b/data/lootTables/bnpc/Raptor/bnpc_plainstrider.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_plainstrider",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Hide)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5292,
+          "name": "Animal Hide",
+          "weight": 400,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 600,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Animal Hide)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5292,
+          "name": "Animal Hide",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Raptor/bnpc_restlessRaptor.json
+++ b/data/lootTables/bnpc/Raptor/bnpc_restlessRaptor.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_restlessRaptor",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Hide)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5292,
+          "name": "Animal Hide",
+          "weight": 833,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 167,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Raptor/bnpc_territorialRaptor.json
+++ b/data/lootTables/bnpc/Raptor/bnpc_territorialRaptor.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_territorialRaptor",
+  "pools": [
+    {
+      "name": "Pool #1 (Raptor Sinew, Raptor Sinew)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 2,
+        "max": 2
+      },
+      "items": [
+        {
+          "id": 5322,
+          "name": "Raptor Sinew",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 5322,
+          "name": "Raptor Sinew",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Raptor Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5310,
+          "name": "Raptor Skin",
+          "weight": 333,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 667,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Raptor/bnpc_velociraptor.json
+++ b/data/lootTables/bnpc/Raptor/bnpc_velociraptor.json
@@ -1,0 +1,99 @@
+{
+  "lootTable": "bnpc_velociraptor",
+  "pools": [
+    {
+      "name": "Pool #1 (Raptor Shank)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4767,
+          "name": "Raptor Shank",
+          "weight": 333,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 667,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Raptor Sinew)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5322,
+          "name": "Raptor Sinew",
+          "weight": 333,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 667,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #3 (Raptor Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5310,
+          "name": "Raptor Skin",
+          "weight": 736,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 3
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 264,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Rodent/bnpc_groundSquirrel.json
+++ b/data/lootTables/bnpc/Rodent/bnpc_groundSquirrel.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_groundSquirrel",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5291,
+          "name": "Animal Skin",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Animal Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5291,
+          "name": "Animal Skin",
+          "weight": 434,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 3
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 566,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Rodent/bnpc_nutmuncherMarmot.json
+++ b/data/lootTables/bnpc/Rodent/bnpc_nutmuncherMarmot.json
@@ -1,0 +1,130 @@
+{
+  "lootTable": "bnpc_nutmuncherMarmot",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5291,
+          "name": "Animal Skin",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Animal Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5291,
+          "name": "Animal Skin",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #3 (Animal Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5291,
+          "name": "Animal Skin",
+          "weight": 250,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 750,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #4 (Animal Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5291,
+          "name": "Animal Skin",
+          "weight": 400,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 600,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Sheep/bnpc_lostLambMob.json
+++ b/data/lootTables/bnpc/Sheep/bnpc_lostLambMob.json
@@ -1,0 +1,99 @@
+{
+  "lootTable": "bnpc_lostLambMob",
+  "pools": [
+    {
+      "name": "Pool #1 (Mutton Loin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4759,
+          "name": "Mutton Loin",
+          "weight": 276,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 724,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Ram Horn)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5434,
+          "name": "Ram Horn",
+          "weight": 259,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 741,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #3 (Mutton Loin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4759,
+          "name": "Mutton Loin",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Sheep/bnpc_orneryKarakul.json
+++ b/data/lootTables/bnpc/Sheep/bnpc_orneryKarakul.json
@@ -1,0 +1,192 @@
+{
+  "lootTable": "bnpc_orneryKarakul",
+  "pools": [
+    {
+      "name": "Pool #1 (Karakul Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5308,
+          "name": "Karakul Skin",
+          "weight": 307,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 693,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Fleece)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5347,
+          "name": "Fleece",
+          "weight": 616,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 9
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 384,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #3 (Karakul Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5308,
+          "name": "Karakul Skin",
+          "weight": 266,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 734,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #4 (Fleece)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5347,
+          "name": "Fleece",
+          "weight": 408,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 9
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 592,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #5 (Karakul Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5308,
+          "name": "Karakul Skin",
+          "weight": 277,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 723,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #6 (Fleece)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5347,
+          "name": "Fleece",
+          "weight": 528,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 9
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 472,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Slug/bnpc_gearGrease.json
+++ b/data/lootTables/bnpc/Slug/bnpc_gearGrease.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_gearGrease",
+  "pools": [
+    {
+      "name": "Pool #1 (Viscous Secretions)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5495,
+          "name": "Viscous Secretions",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Slug/bnpc_leefbleedHare.json
+++ b/data/lootTables/bnpc/Slug/bnpc_leefbleedHare.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_leefbleedHare",
+  "pools": [
+    {
+      "name": "Pool #1 (Acidic Secretions)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5496,
+          "name": "Acidic Secretions",
+          "weight": 125,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 875,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Slug/bnpc_treeSlug.json
+++ b/data/lootTables/bnpc/Slug/bnpc_treeSlug.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_treeSlug",
+  "pools": [
+    {
+      "name": "Pool #1 (Viscous Secretions)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5495,
+          "name": "Viscous Secretions",
+          "weight": 133,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 867,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Viscous Secretions)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5495,
+          "name": "Viscous Secretions",
+          "weight": 258,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 742,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Starkshadow_Wyvern/bnpc_starkshadowWyvern.json
+++ b/data/lootTables/bnpc/Starkshadow_Wyvern/bnpc_starkshadowWyvern.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_starkshadowWyvern",
+  "pools": [
+    {
+      "name": "Pool #1 (Wyvern Wing)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 12636,
+          "name": "Wyvern Wing",
+          "weight": 600,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 3
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 400,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Wyvern Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 12569,
+          "name": "Wyvern Skin",
+          "weight": 365,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 3
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 635,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Swarm/bnpc_agaricFlySwarm.json
+++ b/data/lootTables/bnpc/Swarm/bnpc_agaricFlySwarm.json
@@ -1,0 +1,27 @@
+{
+  "lootTable": "bnpc_agaricFlySwarm",
+  "pools": [
+    {
+      "name": "Pool #1 (Beastkin Blood)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5492,
+          "name": "Beastkin Blood",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Swarm/bnpc_beeCloud.json
+++ b/data/lootTables/bnpc/Swarm/bnpc_beeCloud.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_beeCloud",
+  "pools": [
+    {
+      "name": "Pool #1 (Honey)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4850,
+          "name": "Honey",
+          "weight": 111,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 889,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Swarm/bnpc_blowflySwarm.json
+++ b/data/lootTables/bnpc/Swarm/bnpc_blowflySwarm.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_blowflySwarm",
+  "pools": [
+    {
+      "name": "Pool #1 (Beastkin Blood)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5492,
+          "name": "Beastkin Blood",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Swarm/bnpc_dungMidgeSwarm.json
+++ b/data/lootTables/bnpc/Swarm/bnpc_dungMidgeSwarm.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_dungMidgeSwarm",
+  "pools": [
+    {
+      "name": "Pool #1 (Beastkin Blood)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5492,
+          "name": "Beastkin Blood",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Beastkin Blood)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5492,
+          "name": "Beastkin Blood",
+          "weight": 200,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 800,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Swarm/bnpc_honeybeeCloud.json
+++ b/data/lootTables/bnpc/Swarm/bnpc_honeybeeCloud.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_honeybeeCloud",
+  "pools": [
+    {
+      "name": "Pool #1 (Honey)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4850,
+          "name": "Honey",
+          "weight": 250,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 750,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Swarm/bnpc_hornetCloud.json
+++ b/data/lootTables/bnpc/Swarm/bnpc_hornetCloud.json
@@ -1,0 +1,27 @@
+{
+  "lootTable": "bnpc_hornetCloud",
+  "pools": [
+    {
+      "name": "Pool #1 (Honey)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4850,
+          "name": "Honey",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Swarm/bnpc_hornetSwarm.json
+++ b/data/lootTables/bnpc/Swarm/bnpc_hornetSwarm.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_hornetSwarm",
+  "pools": [
+    {
+      "name": "Pool #1 (Honey)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4850,
+          "name": "Honey",
+          "weight": 308,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 692,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Honey)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4850,
+          "name": "Honey",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Swarm/bnpc_hoverflySwarm.json
+++ b/data/lootTables/bnpc/Swarm/bnpc_hoverflySwarm.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_hoverflySwarm",
+  "pools": [
+    {
+      "name": "Pool #1 (Beastkin Blood)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5492,
+          "name": "Beastkin Blood",
+          "weight": 100,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 900,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Swarm/bnpc_midgeSwarm.json
+++ b/data/lootTables/bnpc/Swarm/bnpc_midgeSwarm.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_midgeSwarm",
+  "pools": [
+    {
+      "name": "Pool #1 (Beastkin Blood)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5492,
+          "name": "Beastkin Blood",
+          "weight": 273,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 727,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Beastkin Blood)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5492,
+          "name": "Beastkin Blood",
+          "weight": 312,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 688,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Swarm/bnpc_potterWaspSwarm.json
+++ b/data/lootTables/bnpc/Swarm/bnpc_potterWaspSwarm.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_potterWaspSwarm",
+  "pools": [
+    {
+      "name": "Pool #1 (Honey)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4850,
+          "name": "Honey",
+          "weight": 400,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 600,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Swarm/bnpc_sandstorm.json
+++ b/data/lootTables/bnpc/Swarm/bnpc_sandstorm.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_sandstorm",
+  "pools": [
+    {
+      "name": "Pool #1 (Honey)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4850,
+          "name": "Honey",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Swarm/bnpc_sunMidgeCloud.json
+++ b/data/lootTables/bnpc/Swarm/bnpc_sunMidgeCloud.json
@@ -1,0 +1,27 @@
+{
+  "lootTable": "bnpc_sunMidgeCloud",
+  "pools": [
+    {
+      "name": "Pool #1 (Beastkin Blood)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5492,
+          "name": "Beastkin Blood",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Swarm/bnpc_sunMidgeSwarm.json
+++ b/data/lootTables/bnpc/Swarm/bnpc_sunMidgeSwarm.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_sunMidgeSwarm",
+  "pools": [
+    {
+      "name": "Pool #1 (Beastkin Blood)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5492,
+          "name": "Beastkin Blood",
+          "weight": 143,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 857,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Swarm/bnpc_syrphidCloud.json
+++ b/data/lootTables/bnpc/Swarm/bnpc_syrphidCloud.json
@@ -1,0 +1,130 @@
+{
+  "lootTable": "bnpc_syrphidCloud",
+  "pools": [
+    {
+      "name": "Pool #1 (Beastkin Blood)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5492,
+          "name": "Beastkin Blood",
+          "weight": 379,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 621,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Beastkin Blood)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5492,
+          "name": "Beastkin Blood",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #3 (Honey)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4850,
+          "name": "Honey",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #4 (Beastkin Blood)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5492,
+          "name": "Beastkin Blood",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Swarm/bnpc_syrphidSwarm.json
+++ b/data/lootTables/bnpc/Swarm/bnpc_syrphidSwarm.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_syrphidSwarm",
+  "pools": [
+    {
+      "name": "Pool #1 (Beastkin Blood)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5492,
+          "name": "Beastkin Blood",
+          "weight": 288,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 712,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Tamamo_Gozen/bnpc_tamamoGozen.json
+++ b/data/lootTables/bnpc/Tamamo_Gozen/bnpc_tamamoGozen.json
@@ -1,0 +1,16 @@
+{
+  "lootTable": "bnpc_tamamoGozen",
+  "pools": [
+    {
+      "name": "Pool #1 (empty)",
+      "enabled": false,
+      "duplicates": false,
+      "pick": {
+        "min": 0,
+        "max": 0
+      },
+      "items": []
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Taurus/bnpc_brontotaur.json
+++ b/data/lootTables/bnpc/Taurus/bnpc_brontotaur.json
@@ -1,0 +1,27 @@
+{
+  "lootTable": "bnpc_brontotaur",
+  "pools": [
+    {
+      "name": "Pool #1 (Gil)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 1,
+          "name": "Gil",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 40,
+            "max": 59
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Treant/bnpc_angeredElm.json
+++ b/data/lootTables/bnpc/Treant/bnpc_angeredElm.json
@@ -1,0 +1,27 @@
+{
+  "lootTable": "bnpc_angeredElm",
+  "pools": [
+    {
+      "name": "Pool #1 (Treant Sap)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5499,
+          "name": "Treant Sap",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Treant/bnpc_diseasedTreant.json
+++ b/data/lootTables/bnpc/Treant/bnpc_diseasedTreant.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_diseasedTreant",
+  "pools": [
+    {
+      "name": "Pool #1 (Treant Sap)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5499,
+          "name": "Treant Sap",
+          "weight": 242,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 758,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Treant/bnpc_dryad.json
+++ b/data/lootTables/bnpc/Treant/bnpc_dryad.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_dryad",
+  "pools": [
+    {
+      "name": "Pool #1 (Treant Sap)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5499,
+          "name": "Treant Sap",
+          "weight": 270,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 730,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_aetherboundKern.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_aetherboundKern.json
@@ -1,0 +1,16 @@
+{
+  "lootTable": "bnpc_aetherboundKern",
+  "pools": [
+    {
+      "name": "Pool #1 (empty)",
+      "enabled": false,
+      "duplicates": false,
+      "pick": {
+        "min": 0,
+        "max": 0
+      },
+      "items": []
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_allaganChimera.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_allaganChimera.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_allaganChimera",
+  "pools": [
+    {
+      "name": "Pool #1 (Chimera Mane)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 12599,
+          "name": "Chimera Mane",
+          "weight": 340,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 3
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 660,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_antelopeStag.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_antelopeStag.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_antelopeStag",
+  "pools": [
+    {
+      "name": "Pool #1 (Antelope Horn)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5435,
+          "name": "Antelope Horn",
+          "weight": 326,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 674,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Beast Sinew)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5319,
+          "name": "Beast Sinew",
+          "weight": 289,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 711,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_antlingSoldier.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_antlingSoldier.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_antlingSoldier",
+  "pools": [
+    {
+      "name": "Pool #1 (Formic Acid)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5497,
+          "name": "Formic Acid",
+          "weight": 235,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 765,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_arkoseGolem.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_arkoseGolem.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_arkoseGolem",
+  "pools": [
+    {
+      "name": "Pool #1 (Mudstone)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5229,
+          "name": "Mudstone",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_ashdrake.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_ashdrake.json
@@ -1,0 +1,27 @@
+{
+  "lootTable": "bnpc_ashdrake",
+  "pools": [
+    {
+      "name": "Pool #1 (Gil)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 1,
+          "name": "Gil",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 14,
+            "max": 16
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_bloodshotDeepeye.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_bloodshotDeepeye.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_bloodshotDeepeye",
+  "pools": [
+    {
+      "name": "Pool #1 (Deepeye Tears)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 12628,
+          "name": "Deepeye Tears",
+          "weight": 218,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 3
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 782,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_bolthorn.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_bolthorn.json
@@ -1,0 +1,27 @@
+{
+  "lootTable": "bnpc_bolthorn",
+  "pools": [
+    {
+      "name": "Pool #1 (Ogre Horn)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5439,
+          "name": "Ogre Horn",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_cleverHedgemole.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_cleverHedgemole.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_cleverHedgemole",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Sinew)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5318,
+          "name": "Animal Sinew",
+          "weight": 167,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 833,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Mole Meat)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4761,
+          "name": "Mole Meat",
+          "weight": 333,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 667,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_cockatrice.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_cockatrice.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_cockatrice",
+  "pools": [
+    {
+      "name": "Pool #1 (Cockatrice Thigh)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 12876,
+          "name": "Cockatrice Thigh",
+          "weight": 286,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 3
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 714,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_coeurlclawPoacherEnemy.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_coeurlclawPoacherEnemy.json
@@ -1,0 +1,16 @@
+{
+  "lootTable": "bnpc_coeurlclawPoacherEnemy",
+  "pools": [
+    {
+      "name": "Pool #1 (empty)",
+      "enabled": false,
+      "duplicates": false,
+      "pick": {
+        "min": 0,
+        "max": 0
+      },
+      "items": []
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_cogOil.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_cogOil.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_cogOil",
+  "pools": [
+    {
+      "name": "Pool #1 (Viscous Secretions)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5495,
+          "name": "Viscous Secretions",
+          "weight": 200,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 800,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_cometChaser.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_cometChaser.json
@@ -1,0 +1,27 @@
+{
+  "lootTable": "bnpc_cometChaser",
+  "pools": [
+    {
+      "name": "Pool #1 (Gil)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 1,
+          "name": "Gil",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 14,
+            "max": 16
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_darkMatterGolem.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_darkMatterGolem.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_darkMatterGolem",
+  "pools": [
+    {
+      "name": "Pool #1 (Mudstone)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5229,
+          "name": "Mudstone",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Mudstone)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5229,
+          "name": "Mudstone",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_darkMatterPelican.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_darkMatterPelican.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_darkMatterPelican",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Hide)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5292,
+          "name": "Animal Hide",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_darkMatterPteroc.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_darkMatterPteroc.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_darkMatterPteroc",
+  "pools": [
+    {
+      "name": "Pool #1 (Puk Egg)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4774,
+          "name": "Puk Egg",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Puk Wing)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5550,
+          "name": "Puk Wing",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_darkMatterSlug.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_darkMatterSlug.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_darkMatterSlug",
+  "pools": [
+    {
+      "name": "Pool #1 (Acidic Secretions)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5496,
+          "name": "Acidic Secretions",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_decoyCrab.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_decoyCrab.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_decoyCrab",
+  "pools": [
+    {
+      "name": "Pool #1 (Green Megalocrab Shell)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5456,
+          "name": "Green Megalocrab Shell",
+          "weight": 250,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 750,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Megalocrab Leg)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4771,
+          "name": "Megalocrab Leg",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_deepJungleCoeurl.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_deepJungleCoeurl.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_deepJungleCoeurl",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Hide)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5292,
+          "name": "Animal Hide",
+          "weight": 200,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 3
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 800,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Coeurl Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5317,
+          "name": "Coeurl Skin",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_deepeye.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_deepeye.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_deepeye",
+  "pools": [
+    {
+      "name": "Pool #1 (Deepeye Tears)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 12628,
+          "name": "Deepeye Tears",
+          "weight": 234,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 3
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 766,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_deepstainedSpriteLightning.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_deepstainedSpriteLightning.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_deepstainedSpriteLightning",
+  "pools": [
+    {
+      "name": "Pool #1 (Lightning Crystal)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 12,
+          "name": "Lightning Crystal",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_deepstainedSpriteWind.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_deepstainedSpriteWind.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_deepstainedSpriteWind",
+  "pools": [
+    {
+      "name": "Pool #1 (Wind Crystal)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 10,
+          "name": "Wind Crystal",
+          "weight": 667,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 333,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_dungWespe.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_dungWespe.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_dungWespe",
+  "pools": [
+    {
+      "name": "Pool #1 (Honey)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4850,
+          "name": "Honey",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_eoraptor.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_eoraptor.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_eoraptor",
+  "pools": [
+    {
+      "name": "Pool #1 (Raptor Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5310,
+          "name": "Raptor Skin",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Raptor Sinew)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5322,
+          "name": "Raptor Sinew",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_faerieFunguar.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_faerieFunguar.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_faerieFunguar",
+  "pools": [
+    {
+      "name": "Pool #1 (Shriekshroom)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4794,
+          "name": "Shriekshroom",
+          "weight": 400,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 600,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_fallenPikeman.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_fallenPikeman.json
@@ -1,0 +1,16 @@
+{
+  "lootTable": "bnpc_fallenPikeman",
+  "pools": [
+    {
+      "name": "Pool #1 (empty)",
+      "enabled": false,
+      "duplicates": false,
+      "pick": {
+        "min": 0,
+        "max": 0
+      },
+      "items": []
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_fallenWizard.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_fallenWizard.json
@@ -1,0 +1,16 @@
+{
+  "lootTable": "bnpc_fallenWizard",
+  "pools": [
+    {
+      "name": "Pool #1 (empty)",
+      "enabled": false,
+      "duplicates": false,
+      "pick": {
+        "min": 0,
+        "max": 0
+      },
+      "items": []
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_fatDodo.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_fatDodo.json
@@ -1,0 +1,130 @@
+{
+  "lootTable": "bnpc_fatDodo",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Hide)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5292,
+          "name": "Animal Hide",
+          "weight": 700,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 300,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Dodo Egg)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4773,
+          "name": "Dodo Egg",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #3 (Dodo Feather)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5355,
+          "name": "Dodo Feather",
+          "weight": 229,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 771,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #4 (Dodo Tenderloin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4760,
+          "name": "Dodo Tenderloin",
+          "weight": 286,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 714,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_frozenBavarois.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_frozenBavarois.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_frozenBavarois",
+  "pools": [
+    {
+      "name": "Pool #1 (Pudding Flesh)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5558,
+          "name": "Pudding Flesh",
+          "weight": 474,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 526,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Pudding Flesh)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5558,
+          "name": "Pudding Flesh",
+          "weight": 600,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 400,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_gobbieBeak.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_gobbieBeak.json
@@ -1,0 +1,27 @@
+{
+  "lootTable": "bnpc_gobbieBeak",
+  "pools": [
+    {
+      "name": "Pool #1 (Gil)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 1,
+          "name": "Gil",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 240,
+            "max": 320
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_gullyGalago.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_gullyGalago.json
@@ -1,0 +1,119 @@
+{
+  "lootTable": "bnpc_gullyGalago",
+  "pools": [
+    {
+      "name": "Pool #1 (Gil, Gil, Gil, Gil)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 4,
+        "max": 4
+      },
+      "items": [
+        {
+          "id": 1,
+          "name": "Gil",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 240,
+            "max": 320
+          }
+        },
+        {
+          "id": 1,
+          "name": "Gil",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 240,
+            "max": 320
+          }
+        },
+        {
+          "id": 1,
+          "name": "Gil",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 240,
+            "max": 320
+          }
+        },
+        {
+          "id": 1,
+          "name": "Gil",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 240,
+            "max": 320
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Galago Mint)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4834,
+          "name": "Galago Mint",
+          "weight": 200,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 800,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #3 (Animal Hide)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5292,
+          "name": "Animal Hide",
+          "weight": 200,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 2
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 800,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_hapalit.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_hapalit.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_hapalit",
+  "pools": [
+    {
+      "name": "Pool #1 (Ogre Horn)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5439,
+          "name": "Ogre Horn",
+          "weight": 308,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 692,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_hedgemole.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_hedgemole.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_hedgemole",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Sinew)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5318,
+          "name": "Animal Sinew",
+          "weight": 286,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 714,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Mole Meat)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4761,
+          "name": "Mole Meat",
+          "weight": 333,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 667,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_hippogryph.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_hippogryph.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_hippogryph",
+  "pools": [
+    {
+      "name": "Pool #1 (Hippogryph Sinew)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5321,
+          "name": "Hippogryph Sinew",
+          "weight": 397,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 603,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Hippogryph Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5316,
+          "name": "Hippogryph Skin",
+          "weight": 759,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 3
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 241,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_hugeHornet.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_hugeHornet.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_hugeHornet",
+  "pools": [
+    {
+      "name": "Pool #1 (Honey)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4850,
+          "name": "Honey",
+          "weight": 400,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 600,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_icetrap.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_icetrap.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_icetrap",
+  "pools": [
+    {
+      "name": "Pool #1 (Icetrap Leaf)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 12637,
+          "name": "Icetrap Leaf",
+          "weight": 370,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 3
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 630,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_illuminatiGlider.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_illuminatiGlider.json
@@ -1,0 +1,27 @@
+{
+  "lootTable": "bnpc_illuminatiGlider",
+  "pools": [
+    {
+      "name": "Pool #1 (Gil)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 1,
+          "name": "Gil",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 240,
+            "max": 320
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_imperialWarHound.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_imperialWarHound.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_imperialWarHound",
+  "pools": [
+    {
+      "name": "Pool #1 (Wolf Fang)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5444,
+          "name": "Wolf Fang",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Wolf Fang)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5444,
+          "name": "Wolf Fang",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_jungleCoeurl.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_jungleCoeurl.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_jungleCoeurl",
+  "pools": [
+    {
+      "name": "Pool #1 (Coeurl Meat)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 6150,
+          "name": "Coeurl Meat",
+          "weight": 333,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 667,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Coeurl Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5317,
+          "name": "Coeurl Skin",
+          "weight": 333,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 3
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 667,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_largeBuffalo.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_largeBuffalo.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_largeBuffalo",
+  "pools": [
+    {
+      "name": "Pool #1 (Buffalo Sirloin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4768,
+          "name": "Buffalo Sirloin",
+          "weight": 312,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 688,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Night Milk)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 6149,
+          "name": "Night Milk",
+          "weight": 312,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 688,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_lunaticFollowerLancer.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_lunaticFollowerLancer.json
@@ -1,0 +1,16 @@
+{
+  "lootTable": "bnpc_lunaticFollowerLancer",
+  "pools": [
+    {
+      "name": "Pool #1 (empty)",
+      "enabled": false,
+      "duplicates": false,
+      "pick": {
+        "min": 0,
+        "max": 0
+      },
+      "items": []
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_lunaticFollowerMarauder.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_lunaticFollowerMarauder.json
@@ -1,0 +1,16 @@
+{
+  "lootTable": "bnpc_lunaticFollowerMarauder",
+  "pools": [
+    {
+      "name": "Pool #1 (empty)",
+      "enabled": false,
+      "duplicates": false,
+      "pick": {
+        "min": 0,
+        "max": 0
+      },
+      "items": []
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_lunaticFollowerPugilist.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_lunaticFollowerPugilist.json
@@ -1,0 +1,16 @@
+{
+  "lootTable": "bnpc_lunaticFollowerPugilist",
+  "pools": [
+    {
+      "name": "Pool #1 (empty)",
+      "enabled": false,
+      "duplicates": false,
+      "pick": {
+        "min": 0,
+        "max": 0
+      },
+      "items": []
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_lunaticFollowerThaumaturge.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_lunaticFollowerThaumaturge.json
@@ -1,0 +1,16 @@
+{
+  "lootTable": "bnpc_lunaticFollowerThaumaturge",
+  "pools": [
+    {
+      "name": "Pool #1 (empty)",
+      "enabled": false,
+      "duplicates": false,
+      "pick": {
+        "min": 0,
+        "max": 0
+      },
+      "items": []
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_megalithMarionette.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_megalithMarionette.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_megalithMarionette",
+  "pools": [
+    {
+      "name": "Pool #1 (Mudstone)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5229,
+          "name": "Mudstone",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_megalocrab.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_megalocrab.json
@@ -1,0 +1,130 @@
+{
+  "lootTable": "bnpc_megalocrab",
+  "pools": [
+    {
+      "name": "Pool #1 (Green Megalocrab Shell)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5456,
+          "name": "Green Megalocrab Shell",
+          "weight": 302,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 698,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Megalocrab Leg)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4771,
+          "name": "Megalocrab Leg",
+          "weight": 250,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 750,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #3 (Green Megalocrab Shell)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5456,
+          "name": "Green Megalocrab Shell",
+          "weight": 322,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 678,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #4 (Megalocrab Leg)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4771,
+          "name": "Megalocrab Leg",
+          "weight": 325,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 675,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_morabyMole.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_morabyMole.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_morabyMole",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Sinew)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5318,
+          "name": "Animal Sinew",
+          "weight": 317,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 683,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Mole Meat)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4761,
+          "name": "Mole Meat",
+          "weight": 346,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 654,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_myrmidonGuard.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_myrmidonGuard.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_myrmidonGuard",
+  "pools": [
+    {
+      "name": "Pool #1 (Formic Acid)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5497,
+          "name": "Formic Acid",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_myrmidonMarshal.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_myrmidonMarshal.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_myrmidonMarshal",
+  "pools": [
+    {
+      "name": "Pool #1 (Formic Acid)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5497,
+          "name": "Formic Acid",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_myrmidonSentry.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_myrmidonSentry.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_myrmidonSentry",
+  "pools": [
+    {
+      "name": "Pool #1 (Formic Acid)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5497,
+          "name": "Formic Acid",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_myrmidonSoldier.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_myrmidonSoldier.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_myrmidonSoldier",
+  "pools": [
+    {
+      "name": "Pool #1 (Formic Acid)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5497,
+          "name": "Formic Acid",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_ochu.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_ochu.json
@@ -1,0 +1,99 @@
+{
+  "lootTable": "bnpc_ochu",
+  "pools": [
+    {
+      "name": "Pool #1 (Ochu Vine)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5555,
+          "name": "Ochu Vine",
+          "weight": 435,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 565,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Ochu Vine)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5555,
+          "name": "Ochu Vine",
+          "weight": 294,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 706,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #3 (Ochu Vine)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5555,
+          "name": "Ochu Vine",
+          "weight": 198,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 802,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_oldSixarms.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_oldSixarms.json
@@ -1,0 +1,27 @@
+{
+  "lootTable": "bnpc_oldSixarms",
+  "pools": [
+    {
+      "name": "Pool #1 (Green Megalocrab Shell)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5456,
+          "name": "Green Megalocrab Shell",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_paintedColibri.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_paintedColibri.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_paintedColibri",
+  "pools": [
+    {
+      "name": "Pool #1 (Gil, Gil)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 2,
+        "max": 2
+      },
+      "items": [
+        {
+          "id": 1,
+          "name": "Gil",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 240,
+            "max": 320
+          }
+        },
+        {
+          "id": 1,
+          "name": "Gil",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 240,
+            "max": 320
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_raggedyJackal.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_raggedyJackal.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_raggedyJackal",
+  "pools": [
+    {
+      "name": "Pool #1 (Wolf Fang)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5444,
+          "name": "Wolf Fang",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_raveledRaincatcher.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_raveledRaincatcher.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_raveledRaincatcher",
+  "pools": [
+    {
+      "name": "Pool #1 (Gil, Gil)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 2,
+        "max": 2
+      },
+      "items": [
+        {
+          "id": 1,
+          "name": "Gil",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 240,
+            "max": 320
+          }
+        },
+        {
+          "id": 1,
+          "name": "Gil",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 240,
+            "max": 320
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_recluseHippogryph.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_recluseHippogryph.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_recluseHippogryph",
+  "pools": [
+    {
+      "name": "Pool #1 (Hippogryph Sinew)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5321,
+          "name": "Hippogryph Sinew",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_recluseHippogryphBlack.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_recluseHippogryphBlack.json
@@ -1,0 +1,109 @@
+{
+  "lootTable": "bnpc_recluseHippogryphBlack",
+  "pools": [
+    {
+      "name": "Pool #1 (Gil, Gil, Gil)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 3,
+        "max": 3
+      },
+      "items": [
+        {
+          "id": 1,
+          "name": "Gil",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 40,
+            "max": 55
+          }
+        },
+        {
+          "id": 1,
+          "name": "Gil",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 40,
+            "max": 55
+          }
+        },
+        {
+          "id": 1,
+          "name": "Gil",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 40,
+            "max": 55
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Hippogryph Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5316,
+          "name": "Hippogryph Skin",
+          "weight": 200,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 3
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 800,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #3 (Hippogryph Sinew)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5321,
+          "name": "Hippogryph Sinew",
+          "weight": 200,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 800,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_ropeburnedBuccaneer.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_ropeburnedBuccaneer.json
@@ -1,0 +1,16 @@
+{
+  "lootTable": "bnpc_ropeburnedBuccaneer",
+  "pools": [
+    {
+      "name": "Pool #1 (empty)",
+      "enabled": false,
+      "duplicates": false,
+      "pick": {
+        "min": 0,
+        "max": 0
+      },
+      "items": []
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_rottingCorpse.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_rottingCorpse.json
@@ -1,0 +1,16 @@
+{
+  "lootTable": "bnpc_rottingCorpse",
+  "pools": [
+    {
+      "name": "Pool #1 (empty)",
+      "enabled": false,
+      "duplicates": false,
+      "pick": {
+        "min": 0,
+        "max": 0
+      },
+      "items": []
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_rottingNoble.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_rottingNoble.json
@@ -1,0 +1,16 @@
+{
+  "lootTable": "bnpc_rottingNoble",
+  "pools": [
+    {
+      "name": "Pool #1 (empty)",
+      "enabled": false,
+      "duplicates": false,
+      "pick": {
+        "min": 0,
+        "max": 0
+      },
+      "items": []
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_sabotender.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_sabotender.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_sabotender",
+  "pools": [
+    {
+      "name": "Pool #1 (Cactuar Needle)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5468,
+          "name": "Cactuar Needle",
+          "weight": 273,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 727,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_sandworm.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_sandworm.json
@@ -1,0 +1,99 @@
+{
+  "lootTable": "bnpc_sandworm",
+  "pools": [
+    {
+      "name": "Pool #1 (Sandworm Fang)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5447,
+          "name": "Sandworm Fang",
+          "weight": 300,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 700,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Sandworm Fang)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5447,
+          "name": "Sandworm Fang",
+          "weight": 300,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 700,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #3 (Sandworm Fang)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5447,
+          "name": "Sandworm Fang",
+          "weight": 300,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 700,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_sewerMole.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_sewerMole.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_sewerMole",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Sinew)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5318,
+          "name": "Animal Sinew",
+          "weight": 375,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 625,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Mole Meat)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4761,
+          "name": "Mole Meat",
+          "weight": 250,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 750,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_shroudHare.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_shroudHare.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_shroudHare",
+  "pools": [
+    {
+      "name": "Pool #1 (Acidic Secretions)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5496,
+          "name": "Acidic Secretions",
+          "weight": 238,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 762,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Acidic Secretions)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5496,
+          "name": "Acidic Secretions",
+          "weight": 154,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 846,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_smolenkos.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_smolenkos.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_smolenkos",
+  "pools": [
+    {
+      "name": "Pool #1 (Gil, Gil)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 2,
+        "max": 2
+      },
+      "items": [
+        {
+          "id": 1,
+          "name": "Gil",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 45,
+            "max": 57
+          }
+        },
+        {
+          "id": 1,
+          "name": "Gil",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 45,
+            "max": 57
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Ahriman Wing)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5553,
+          "name": "Ahriman Wing",
+          "weight": 333,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 667,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_snipper.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_snipper.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_snipper",
+  "pools": [
+    {
+      "name": "Pool #1 (Red Megalocrab Shell)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5457,
+          "name": "Red Megalocrab Shell",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Red Megalocrab Shell)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5457,
+          "name": "Red Megalocrab Shell",
+          "weight": 400,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 600,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_snowWolfPup.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_snowWolfPup.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_snowWolfPup",
+  "pools": [
+    {
+      "name": "Pool #1 (Wolf Fang)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5444,
+          "name": "Wolf Fang",
+          "weight": 525,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 475,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Wolf Fang)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5444,
+          "name": "Wolf Fang",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_starMarmot.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_starMarmot.json
@@ -1,0 +1,130 @@
+{
+  "lootTable": "bnpc_starMarmot",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5291,
+          "name": "Animal Skin",
+          "weight": 688,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 312,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Marmot Meat)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4758,
+          "name": "Marmot Meat",
+          "weight": 292,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 708,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #3 (Animal Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5291,
+          "name": "Animal Skin",
+          "weight": 719,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 281,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #4 (Marmot Meat)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4758,
+          "name": "Marmot Meat",
+          "weight": 344,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 656,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_stoneMarionette.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_stoneMarionette.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_stoneMarionette",
+  "pools": [
+    {
+      "name": "Pool #1 (Mudstone)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5229,
+          "name": "Mudstone",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_stormSprite.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_stormSprite.json
@@ -1,0 +1,27 @@
+{
+  "lootTable": "bnpc_stormSprite",
+  "pools": [
+    {
+      "name": "Pool #1 (Wind Crystal)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 10,
+          "name": "Wind Crystal",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 2,
+            "max": 2
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_succubus.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_succubus.json
@@ -1,0 +1,27 @@
+{
+  "lootTable": "bnpc_succubus",
+  "pools": [
+    {
+      "name": "Pool #1 (Gil)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 1,
+          "name": "Gil",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 46,
+            "max": 57
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_swampPugil.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_swampPugil.json
@@ -1,0 +1,27 @@
+{
+  "lootTable": "bnpc_swampPugil",
+  "pools": [
+    {
+      "name": "Pool #1 (Gil)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 1,
+          "name": "Gil",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 14,
+            "max": 16
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_templeBat.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_templeBat.json
@@ -1,0 +1,99 @@
+{
+  "lootTable": "bnpc_templeBat",
+  "pools": [
+    {
+      "name": "Pool #1 (Bat Fang)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5442,
+          "name": "Bat Fang",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Bat Wing)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5551,
+          "name": "Bat Wing",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #3 (Beastkin Blood)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5492,
+          "name": "Beastkin Blood",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_templeGuardian.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_templeGuardian.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_templeGuardian",
+  "pools": [
+    {
+      "name": "Pool #1 (Mudstone)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5229,
+          "name": "Mudstone",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_tucotuco.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_tucotuco.json
@@ -1,0 +1,130 @@
+{
+  "lootTable": "bnpc_tucotuco",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Sinew)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5318,
+          "name": "Animal Sinew",
+          "weight": 310,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 690,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Mole Meat)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4761,
+          "name": "Mole Meat",
+          "weight": 207,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 793,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #3 (Animal Sinew)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5318,
+          "name": "Animal Sinew",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #4 (Mole Meat)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4761,
+          "name": "Mole Meat",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_untamedShrew.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_untamedShrew.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_untamedShrew",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Sinew)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5318,
+          "name": "Animal Sinew",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Mole Meat)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4761,
+          "name": "Mole Meat",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_vodorigaSleeper.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_vodorigaSleeper.json
@@ -1,0 +1,27 @@
+{
+  "lootTable": "bnpc_vodorigaSleeper",
+  "pools": [
+    {
+      "name": "Pool #1 (Gil)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 1,
+          "name": "Gil",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 41,
+            "max": 59
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_watchwolf.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_watchwolf.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_watchwolf",
+  "pools": [
+    {
+      "name": "Pool #1 (Wolf Fang)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5444,
+          "name": "Wolf Fang",
+          "weight": 333,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 667,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_waterSprite.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_waterSprite.json
@@ -1,0 +1,440 @@
+{
+  "lootTable": "bnpc_waterSprite",
+  "pools": [
+    {
+      "name": "Pool #1 (Water Shard)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 7,
+          "name": "Water Shard",
+          "weight": 355,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 5
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 645,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Water Shard)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 7,
+          "name": "Water Shard",
+          "weight": 355,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 5
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 645,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #3 (Water Shard)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 7,
+          "name": "Water Shard",
+          "weight": 556,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 444,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #4 (Water Crystal)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 13,
+          "name": "Water Crystal",
+          "weight": 200,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 800,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #5 (Water Shard)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 7,
+          "name": "Water Shard",
+          "weight": 100,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 900,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #6 (Water Crystal)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 13,
+          "name": "Water Crystal",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 2
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #7 (Water Crystal)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 13,
+          "name": "Water Crystal",
+          "weight": 200,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 800,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #8 (Water Crystal)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 13,
+          "name": "Water Crystal",
+          "weight": 300,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 3
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 700,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #9 (Water Crystal)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 13,
+          "name": "Water Crystal",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #10 (Water Crystal)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 13,
+          "name": "Water Crystal",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #11 (Water Crystal)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 13,
+          "name": "Water Crystal",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #12 (Water Crystal)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 13,
+          "name": "Water Crystal",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #13 (Water Crystal)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 13,
+          "name": "Water Crystal",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #14 (Water Crystal)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 13,
+          "name": "Water Crystal",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_wharfRat.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_wharfRat.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_wharfRat",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5291,
+          "name": "Animal Skin",
+          "weight": 868,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 132,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Animal Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5291,
+          "name": "Animal Skin",
+          "weight": 556,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 444,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_whiteDeath.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_whiteDeath.json
@@ -1,0 +1,27 @@
+{
+  "lootTable": "bnpc_whiteDeath",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5291,
+          "name": "Animal Skin",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_wildDodo.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_wildDodo.json
@@ -1,0 +1,440 @@
+{
+  "lootTable": "bnpc_wildDodo",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Hide)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5292,
+          "name": "Animal Hide",
+          "weight": 677,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 323,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Dodo Feather)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5355,
+          "name": "Dodo Feather",
+          "weight": 194,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 806,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #3 (Dodo Tenderloin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4760,
+          "name": "Dodo Tenderloin",
+          "weight": 290,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 710,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #4 (Animal Hide)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5292,
+          "name": "Animal Hide",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #5 (Animal Hide)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5292,
+          "name": "Animal Hide",
+          "weight": 367,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 633,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #6 (Dodo Egg)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4773,
+          "name": "Dodo Egg",
+          "weight": 321,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 679,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #7 (Dodo Feather)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5355,
+          "name": "Dodo Feather",
+          "weight": 248,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 752,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #8 (Dodo Tenderloin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4760,
+          "name": "Dodo Tenderloin",
+          "weight": 284,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 716,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #9 (Animal Hide)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5292,
+          "name": "Animal Hide",
+          "weight": 579,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 421,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #10 (Dodo Egg)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4773,
+          "name": "Dodo Egg",
+          "weight": 105,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 895,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #11 (Dodo Feather)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5355,
+          "name": "Dodo Feather",
+          "weight": 368,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 632,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #12 (Dodo Tenderloin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4760,
+          "name": "Dodo Tenderloin",
+          "weight": 316,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 684,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #13 (Dodo Egg)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 4773,
+          "name": "Dodo Egg",
+          "weight": 333,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 667,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #14 (Dodo Feather)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5355,
+          "name": "Dodo Feather",
+          "weight": 333,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 667,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_wildWolf.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_wildWolf.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_wildWolf",
+  "pools": [
+    {
+      "name": "Pool #1 (Wolf Fang)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5444,
+          "name": "Wolf Fang",
+          "weight": 323,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 677,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_wyrmhound.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_wyrmhound.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_wyrmhound",
+  "pools": [
+    {
+      "name": "Pool #1 (Peiste Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5306,
+          "name": "Peiste Skin",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_yarzonScavenger.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_yarzonScavenger.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_yarzonScavenger",
+  "pools": [
+    {
+      "name": "Pool #1 (Yellow Yarzon Leg)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5454,
+          "name": "Yellow Yarzon Leg",
+          "weight": 333,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 667,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Yellow Yarzon Leg)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5454,
+          "name": "Yellow Yarzon Leg",
+          "weight": 312,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 688,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_youngCoeurl.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_youngCoeurl.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_youngCoeurl",
+  "pools": [
+    {
+      "name": "Pool #1 (Coeurl Meat)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 6150,
+          "name": "Coeurl Meat",
+          "weight": 316,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 684,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Coeurl Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5317,
+          "name": "Coeurl Skin",
+          "weight": 684,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 3
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 316,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_zombieSoldier.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_zombieSoldier.json
@@ -1,0 +1,16 @@
+{
+  "lootTable": "bnpc_zombieSoldier",
+  "pools": [
+    {
+      "name": "Pool #1 (empty)",
+      "enabled": false,
+      "duplicates": false,
+      "pick": {
+        "min": 0,
+        "max": 0
+      },
+      "items": []
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/UnknownGenus/bnpc_zombieWizard.json
+++ b/data/lootTables/bnpc/UnknownGenus/bnpc_zombieWizard.json
@@ -1,0 +1,16 @@
+{
+  "lootTable": "bnpc_zombieWizard",
+  "pools": [
+    {
+      "name": "Pool #1 (empty)",
+      "enabled": false,
+      "duplicates": false,
+      "pick": {
+        "min": 0,
+        "max": 0
+      },
+      "items": []
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Vanguard/bnpc_2ndCohortVanguard.json
+++ b/data/lootTables/bnpc/Vanguard/bnpc_2ndCohortVanguard.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_2ndCohortVanguard",
+  "pools": [
+    {
+      "name": "Pool #1 (Garlean Steel Joint)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5104,
+          "name": "Garlean Steel Joint",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Garlean Steel Plate)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5105,
+          "name": "Garlean Steel Plate",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 500,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Vanguard/bnpc_magitekVanguard.json
+++ b/data/lootTables/bnpc/Vanguard/bnpc_magitekVanguard.json
@@ -1,0 +1,254 @@
+{
+  "lootTable": "bnpc_magitekVanguard",
+  "pools": [
+    {
+      "name": "Pool #1 (Garlean Steel Plate)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5105,
+          "name": "Garlean Steel Plate",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Garlean Steel Joint)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5104,
+          "name": "Garlean Steel Joint",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #3 (Garlean Steel Plate)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5105,
+          "name": "Garlean Steel Plate",
+          "weight": 61,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 939,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #4 (Garlean Steel Joint)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5104,
+          "name": "Garlean Steel Joint",
+          "weight": 61,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 939,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #5 (Garlean Steel Plate)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5105,
+          "name": "Garlean Steel Plate",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #6 (Garlean Steel Joint)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5104,
+          "name": "Garlean Steel Joint",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #7 (Garlean Steel Plate)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5105,
+          "name": "Garlean Steel Plate",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #8 (Garlean Steel Joint)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5104,
+          "name": "Garlean Steel Joint",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Wight/bnpc_hellsboundWarrior.json
+++ b/data/lootTables/bnpc/Wight/bnpc_hellsboundWarrior.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_hellsboundWarrior",
+  "pools": [
+    {
+      "name": "Pool #1 (Bone Chip)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5432,
+          "name": "Bone Chip",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Wight/bnpc_magickedBones.json
+++ b/data/lootTables/bnpc/Wight/bnpc_magickedBones.json
@@ -1,0 +1,109 @@
+{
+  "lootTable": "bnpc_magickedBones",
+  "pools": [
+    {
+      "name": "Pool #1 (Bone Chip, Bone Chip, Bone Chip)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 3,
+        "max": 3
+      },
+      "items": [
+        {
+          "id": 5432,
+          "name": "Bone Chip",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 5432,
+          "name": "Bone Chip",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 5432,
+          "name": "Bone Chip",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Bone Chip)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5432,
+          "name": "Bone Chip",
+          "weight": 227,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 773,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #3 (Bone Chip)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5432,
+          "name": "Bone Chip",
+          "weight": 167,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 833,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Wight/bnpc_manorFootman.json
+++ b/data/lootTables/bnpc/Wight/bnpc_manorFootman.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_manorFootman",
+  "pools": [
+    {
+      "name": "Pool #1 (Bone Chip)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5432,
+          "name": "Bone Chip",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Wight/bnpc_soldierOfNym.json
+++ b/data/lootTables/bnpc/Wight/bnpc_soldierOfNym.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_soldierOfNym",
+  "pools": [
+    {
+      "name": "Pool #1 (Bone Chip)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5432,
+          "name": "Bone Chip",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Wight/bnpc_theAccused.json
+++ b/data/lootTables/bnpc/Wight/bnpc_theAccused.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_theAccused",
+  "pools": [
+    {
+      "name": "Pool #1 (Bone Chip)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5432,
+          "name": "Bone Chip",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Worm/bnpc_giantSandworm.json
+++ b/data/lootTables/bnpc/Worm/bnpc_giantSandworm.json
@@ -1,0 +1,27 @@
+{
+  "lootTable": "bnpc_giantSandworm",
+  "pools": [
+    {
+      "name": "Pool #1 (Sandworm Fang)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5447,
+          "name": "Sandworm Fang",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Wyvern/bnpc_dravanianWyvern.json
+++ b/data/lootTables/bnpc/Wyvern/bnpc_dravanianWyvern.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_dravanianWyvern",
+  "pools": [
+    {
+      "name": "Pool #1 (Wyvern Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 12569,
+          "name": "Wyvern Skin",
+          "weight": 458,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 3
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 542,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Wyvern Wing)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 12636,
+          "name": "Wyvern Wing",
+          "weight": 507,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 3
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 493,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Yarzon/bnpc_forestYarzon.json
+++ b/data/lootTables/bnpc/Yarzon/bnpc_forestYarzon.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_forestYarzon",
+  "pools": [
+    {
+      "name": "Pool #1 (Blue Yarzon Leg)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5455,
+          "name": "Blue Yarzon Leg",
+          "weight": 300,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 700,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Yarzon/bnpc_riverYarzon.json
+++ b/data/lootTables/bnpc/Yarzon/bnpc_riverYarzon.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_riverYarzon",
+  "pools": [
+    {
+      "name": "Pool #1 (Blue Yarzon Leg)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5455,
+          "name": "Blue Yarzon Leg",
+          "weight": 250,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 750,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Yarzon/bnpc_russetYarzon.json
+++ b/data/lootTables/bnpc/Yarzon/bnpc_russetYarzon.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_russetYarzon",
+  "pools": [
+    {
+      "name": "Pool #1 (Yellow Yarzon Leg)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5454,
+          "name": "Yellow Yarzon Leg",
+          "weight": 333,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 667,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Yarzon/bnpc_wallCrawler.json
+++ b/data/lootTables/bnpc/Yarzon/bnpc_wallCrawler.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_wallCrawler",
+  "pools": [
+    {
+      "name": "Pool #1 (Yellow Yarzon Leg)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5454,
+          "name": "Yellow Yarzon Leg",
+          "weight": 0,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Ziz/bnpc_axeBeak.json
+++ b/data/lootTables/bnpc/Ziz/bnpc_axeBeak.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_axeBeak",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Hide)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5292,
+          "name": "Animal Hide",
+          "weight": 700,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 300,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Ziz/bnpc_broodZiz.json
+++ b/data/lootTables/bnpc/Ziz/bnpc_broodZiz.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_broodZiz",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Hide)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5292,
+          "name": "Animal Hide",
+          "weight": 91,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 909,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Ziz/bnpc_gauntBeak.json
+++ b/data/lootTables/bnpc/Ziz/bnpc_gauntBeak.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_gauntBeak",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Hide)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5292,
+          "name": "Animal Hide",
+          "weight": 750,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 250,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Ziz/bnpc_giantPelican.json
+++ b/data/lootTables/bnpc/Ziz/bnpc_giantPelican.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_giantPelican",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Hide)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5292,
+          "name": "Animal Hide",
+          "weight": 333,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 667,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Ziz/bnpc_hammerBeak.json
+++ b/data/lootTables/bnpc/Ziz/bnpc_hammerBeak.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_hammerBeak",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5291,
+          "name": "Animal Skin",
+          "weight": 667,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 333,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Animal Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5291,
+          "name": "Animal Skin",
+          "weight": 622,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 378,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Ziz/bnpc_rothlytPelican.json
+++ b/data/lootTables/bnpc/Ziz/bnpc_rothlytPelican.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_rothlytPelican",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Hide)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5292,
+          "name": "Animal Hide",
+          "weight": 333,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 2
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 667,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Ziz/bnpc_sableBack.json
+++ b/data/lootTables/bnpc/Ziz/bnpc_sableBack.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_sableBack",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Hide)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5292,
+          "name": "Animal Hide",
+          "weight": 333,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 2
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 667,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Ziz/bnpc_territorialPelican.json
+++ b/data/lootTables/bnpc/Ziz/bnpc_territorialPelican.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_territorialPelican",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Hide)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5292,
+          "name": "Animal Hide",
+          "weight": 667,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 333,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Ziz/bnpc_tomahawkBeak.json
+++ b/data/lootTables/bnpc/Ziz/bnpc_tomahawkBeak.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_tomahawkBeak",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5291,
+          "name": "Animal Skin",
+          "weight": 333,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 667,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Ziz/bnpc_violetBack.json
+++ b/data/lootTables/bnpc/Ziz/bnpc_violetBack.json
@@ -1,0 +1,109 @@
+{
+  "lootTable": "bnpc_violetBack",
+  "pools": [
+    {
+      "name": "Pool #1 (Gil, Gil, Gil)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 3,
+        "max": 3
+      },
+      "items": [
+        {
+          "id": 1,
+          "name": "Gil",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 14,
+            "max": 16
+          }
+        },
+        {
+          "id": 1,
+          "name": "Gil",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 14,
+            "max": 16
+          }
+        },
+        {
+          "id": 1,
+          "name": "Gil",
+          "weight": 1000,
+          "isHq": false,
+          "quantity": {
+            "min": 14,
+            "max": 16
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Animal Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5291,
+          "name": "Animal Skin",
+          "weight": 200,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 2
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 800,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #3 (Animal Skin)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5291,
+          "name": "Animal Skin",
+          "weight": 250,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 2
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 750,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Ziz/bnpc_ziz.json
+++ b/data/lootTables/bnpc/Ziz/bnpc_ziz.json
@@ -1,0 +1,68 @@
+{
+  "lootTable": "bnpc_ziz",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Hide)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5292,
+          "name": "Animal Hide",
+          "weight": 139,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 2
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 861,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Pool #2 (Animal Hide)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5292,
+          "name": "Animal Hide",
+          "weight": 800,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 200,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Ziz/bnpc_zizGorlin.json
+++ b/data/lootTables/bnpc/Ziz/bnpc_zizGorlin.json
@@ -1,0 +1,37 @@
+{
+  "lootTable": "bnpc_zizGorlin",
+  "pools": [
+    {
+      "name": "Pool #1 (Animal Hide)",
+      "enabled": true,
+      "duplicates": false,
+      "pick": {
+        "min": 1,
+        "max": 1
+      },
+      "items": [
+        {
+          "id": 5292,
+          "name": "Animal Hide",
+          "weight": 846,
+          "isHq": false,
+          "quantity": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        {
+          "id": 0,
+          "name": "<none>",
+          "weight": 154,
+          "isHq": false,
+          "quantity": {
+            "min": 0,
+            "max": 0
+          }
+        }
+      ]
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/bnpc/Zurvan/bnpc_zurvan.json
+++ b/data/lootTables/bnpc/Zurvan/bnpc_zurvan.json
@@ -1,0 +1,16 @@
+{
+  "lootTable": "bnpc_zurvan",
+  "pools": [
+    {
+      "name": "Pool #1 (empty)",
+      "enabled": false,
+      "duplicates": false,
+      "pick": {
+        "min": 0,
+        "max": 0
+      },
+      "items": []
+    }
+  ],
+  "type": "bNPC"
+}

--- a/data/lootTables/debug/testTable.json
+++ b/data/lootTables/debug/testTable.json
@@ -8,17 +8,18 @@
         {
           "id": 9,
           "isHq": false,
-          "weight": 1
+          "weight": 1,
+          "quantity": { "min": 5, "max": 5 }
         },
         {
           "id": 8,
           "isHq": false,
-          "weight": 1
+          "weight": 1,
+          "quantity": { "min": 5, "max": 5 }
         }
       ],
       "name": "Test #1 (Standard)",
-      "pickMax": 1,
-      "pickMin": 1
+      "pick": { "min": 1, "max": 1 }
     },
     {
       "duplicates": false,
@@ -27,17 +28,18 @@
         {
           "id": 5016,
           "isHq": false,
-          "weight": 1
+          "weight": 1,
+          "quantity": { "min": 1, "max": 1 }
         },
         {
           "id": 12728,
           "isHq": false,
-          "weight": 1
+          "weight": 1,
+          "quantity": { "min": 1, "max": 1 }
         }
       ],
       "name": "Test #2 (Duplicates disabled)",
-      "pickMax": 2,
-      "pickMin": 2
+      "pick": { "min": 2, "max": 2 }
     },
     {
       "duplicates": false,
@@ -46,12 +48,12 @@
         {
           "id": 4551,
           "isHq": true,
-          "weight": 1
+          "weight": 1,
+          "quantity": { "min": 1, "max": 3 }
         }
       ],
-      "name": "Test #3 (HQ Item Test)",
-      "pickMax": 1,
-      "pickMin": 1
+      "name": "Test #3 (HQ Quantity Item Test)",
+      "pick": { "min": 1, "max": 1 }
     },
     {
       "duplicates": true,
@@ -60,12 +62,12 @@
         {
           "id": 13229,
           "isHq": false,
-          "weight": 1
+          "weight": 1,
+          "quantity": { "min": 1, "max": 1 }
         }
       ],
       "name": "Test #4 (Disabled Pool)",
-      "pickMax": 1,
-      "pickMin": 1
+      "pick": { "min": 1, "max": 1 }
     }
   ],
   "type": "bNPC"

--- a/src/world/Manager/LootTableMgr.cpp
+++ b/src/world/Manager/LootTableMgr.cpp
@@ -64,7 +64,7 @@ LootTableResult LootTableMgr::rollLoot( const std::string& name )
       if( !pool.enabled )
         continue;
 
-      auto pickCountGen = RNGMgr.getRandGenerator< uint32_t >( pool.pickMin, pool.pickMax );
+      auto pickCountGen = RNGMgr.getRandGenerator< uint32_t >( pool.pick.min, pool.pick.max );
       uint32_t picks = pickCountGen.next();
 
       std::vector< LootTableItem > available = pool.items;
@@ -73,7 +73,10 @@ LootTableResult LootTableMgr::rollLoot( const std::string& name )
       {
         const auto& item = pickWeightedItem( available );
 
-        result.items.push_back( { item.id, 1, item.isHq } );
+        auto itemCountGen = RNGMgr.getRandGenerator< uint32_t >( item.quantity.min, item.quantity.max );
+        uint32_t qty = itemCountGen.next();
+
+        result.items.push_back( { item.id, qty, item.isHq } );
 
         if( !pool.duplicates )
         {
@@ -84,7 +87,7 @@ LootTableResult LootTableMgr::rollLoot( const std::string& name )
       }
     }
 
-    Logger::debug( "LootTableMgr: Rolled total of {0} items", result.count() );
+    Logger::debug( "LootTableMgr: Rolled total of {0} item results", result.count() );
   }
     
   return result;

--- a/src/world/Manager/LootTableMgr.h
+++ b/src/world/Manager/LootTableMgr.h
@@ -9,23 +9,30 @@
 
 namespace Sapphire::World::Loot
 {
+  struct LootTableRange {
+    uint32_t min;
+    uint32_t max;
+
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE( LootTableRange, min, max )
+  };
+
   struct LootTableItem {
     uint32_t id;
     uint32_t weight;
     bool isHq;
+    LootTableRange quantity;
 
-    NLOHMANN_DEFINE_TYPE_INTRUSIVE( LootTableItem, id, weight, isHq )
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE( LootTableItem, id, weight, isHq, quantity )
   };
 
   struct LootTablePool {
     std::string name;
     bool enabled;
     bool duplicates;
-    uint32_t pickMin;
-    uint32_t pickMax;
+    LootTableRange pick;
     std::vector< LootTableItem > items;
 
-    NLOHMANN_DEFINE_TYPE_INTRUSIVE( LootTablePool, name, enabled, duplicates, pickMin, pickMax, items )
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE( LootTablePool, name, enabled, duplicates, pick, items )
   };
 
   struct LootTable {


### PR DESCRIPTION
Loot data isn't that great quality but this is a start.
It's split by Genus, and I used a scale 1000 for weights, but can be any sufficient scale.

Some loot tables have 0 weight in them due to incomplete or lacking data. It might be worth re-checking.
There's more 3.x BNPCs I could have added but have missing entries added from 4.x+ items. Will think of what to do about them.

Quantity was added to make the thinking process easier.