### PR TITLE
WarpTaxi logic improve

### DIFF
--- a/src/scripts/common/warptaxi/WarpInnLimsa.cpp
+++ b/src/scripts/common/warptaxi/WarpInnLimsa.cpp
@@ -1,0 +1,61 @@
+#include <ScriptObject.h>
+#include <Actor/Player.h>
+
+#include <datReader/DatCategories/bg/LgbTypes.h>
+#include <datReader/DatCategories/bg/lgb.h>
+
+#include "Territory/InstanceObjectCache.h"
+#include "Territory/Territory.h"
+
+#include <Exd/ExdData.h>
+#include <Manager/PlayerMgr.h>
+#include <Service.h>
+
+using namespace Sapphire;
+
+class WarpInnLimsa : public Sapphire::ScriptAPI::EventScript
+{
+public:
+  constexpr static auto InnTerritoryType = 179;
+
+  WarpInnLimsa() :
+    Sapphire::ScriptAPI::EventScript( 131079 )
+  {
+  }
+
+  void onTalk( uint32_t eventId, Entity::Player& player, uint64_t actorId ) override
+  {
+   auto& exdData = Common::Service< Sapphire::Data::ExdData >::ref();
+
+    auto warp = exdData.getRow< Excel::Warp >( eventId );
+    if( !warp )
+      return;
+
+    auto qualifiedPreResult = [ this ]( Entity::Player& player, const Event::SceneResult& result )
+    {
+      auto warpChoice = [ this ]( Entity::Player& player, const Event::SceneResult& result )
+      {
+        auto warp = this->exdData().getRow< Excel::Warp >( result.eventId );
+        if( warp )
+        {
+          auto popRangeInfo = instanceObjectCache().getPopRangeInfo( warp->data().PopRange );
+          if( popRangeInfo )
+          {
+            auto pTeri = teriMgr().getTerritoryByTypeId( popRangeInfo->m_territoryTypeId );
+            warpMgr().requestMoveTerritory( player, Sapphire::Common::WARP_TYPE_TOWN_TRANSLATE,
+                                            pTeri->getGuId(), popRangeInfo->m_pos, popRangeInfo->m_rotation );
+          }
+        }
+      };
+
+      eventMgr().playScene( player, result.eventId, 1, HIDE_HOTBAR, { 1 }, warpChoice );
+    };
+
+    if( player.hasReward( Common::UnlockEntry::InnRoom ) )
+      eventMgr().playScene( player, eventId, 0, HIDE_HOTBAR, { 1 }, qualifiedPreResult );
+    else
+      eventMgr().playScene( player, eventId, 2, HIDE_HOTBAR, { 1 }, nullptr );
+  }
+};
+
+EXPOSE_SCRIPT( WarpInnLimsa );

--- a/src/scripts/common/warptaxi/WarpInnUldah.cpp
+++ b/src/scripts/common/warptaxi/WarpInnUldah.cpp
@@ -13,11 +13,13 @@
 
 using namespace Sapphire;
 
-class WarpTaxi : public Sapphire::ScriptAPI::EventScript
+class WarpInnUldah : public Sapphire::ScriptAPI::EventScript
 {
 public:
-  WarpTaxi() :
-    Sapphire::ScriptAPI::EventScript( 0x00020000 )
+  constexpr static auto InnTerritoryType = 179;
+
+  WarpInnUldah() :
+    Sapphire::ScriptAPI::EventScript( 131081 )
   {
   }
 
@@ -31,8 +33,7 @@ public:
 
     auto qualifiedPreResult = [ this ]( Entity::Player& player, const Event::SceneResult& result )
     {
-      //eventMgr().playScene( player, result.eventId, 1, HIDE_HOTBAR, { 1 }, nullptr );
-      if( result.getResult( 0 ) == 1 && result.errorCode != Common::EventSceneError::EVENT_SCENE_ERROR_LUA_ERRRUN )
+      auto warpChoice = [ this ]( Entity::Player& player, const Event::SceneResult& result )
       {
         auto warp = this->exdData().getRow< Excel::Warp >( result.eventId );
         if( warp )
@@ -45,11 +46,16 @@ public:
                                             pTeri->getGuId(), popRangeInfo->m_pos, popRangeInfo->m_rotation );
           }
         }
-      }
+      };
+
+      eventMgr().playScene( player, result.eventId, 1, HIDE_HOTBAR, { 1 }, warpChoice );
     };
 
-    eventMgr().playScene( player, eventId, 0, HIDE_HOTBAR, { 1 }, qualifiedPreResult );
+    if( player.hasReward( Common::UnlockEntry::InnRoom ) )
+      eventMgr().playScene( player, eventId, 0, HIDE_HOTBAR, { 1 }, qualifiedPreResult );
+    else
+      eventMgr().playScene( player, eventId, 2, HIDE_HOTBAR, { 1 }, nullptr );
   }
 };
 
-EXPOSE_SCRIPT( WarpTaxi );
+EXPOSE_SCRIPT( WarpInnUldah );


### PR DESCRIPTION
I have decided to remove the individual script dedicated to WarpTaxi in order to manage the event directly within the scriptMgr.
In addition, I have started to implement the logic to evaluate the unlocking conditions for a warpTaxi.
Currently, it is only possible to evaluate the completion of the necessary quests indicated in the exdData WarpCondition.

**Pros**
- There is no more need to LUA_ERROR check;
- Now Reject event will be triggered 


**What's missing?**
- [ ] Checks on the various independent scripts dedicated to Warp (WarpInn for example);
- [ ] Check on the level indicated in WarpCondition.

