### PR TITLE
aggro crash fix & dummy aggro fix

### DIFF
--- a/src/world/Action/ActionResult.cpp
+++ b/src/world/Action/ActionResult.cpp
@@ -280,6 +280,9 @@ void ActionResult::splitAggroApplication( float aggro )
   aggro = aggro / hateList.size();
   for( auto entry : hateList )
   {
-    entry->onActionHostile( m_source, aggro );
+    if( entry && entry->isAlive() )
+    {
+      entry->onActionHostile( m_source, aggro );
+    }
   }
 }

--- a/src/world/Manager/StatusEffectMgr.cpp
+++ b/src/world/Manager/StatusEffectMgr.cpp
@@ -152,6 +152,9 @@ void StatusEffectMgr::splitAggroApplication( Entity::CharaPtr pSource, Entity::C
   aggro = aggro / hateList.size();
   for( auto entry : hateList )
   {
-    entry->onActionHostile( pSource, aggro );
+    if( entry && entry->isAlive() )
+    {
+      entry->onActionHostile( pSource, aggro );
+    }
   }
 }

--- a/src/world/Territory/Territory.cpp
+++ b/src/world/Territory/Territory.cpp
@@ -259,7 +259,7 @@ void Territory::pushActor( const Entity::GameObjectPtr& pActor )
   {
     auto pBNpc = pActor->getAsBNpc();
 
-    if( m_pNaviProvider && !pBNpc->hasFlag( Entity::Immobile ) )
+    if( m_pNaviProvider )
     {
       agentId = m_pNaviProvider->addAgent( pBNpc->getPos(), pBNpc->getRadius() );
       pBNpc->setAgentId( agentId );


### PR DESCRIPTION
Crash fix when using supportive actions while the target is in combat with a dead bnpc & stopped target dummies from counter attacking once at any range and then losing aggro forever