### PR TITLE
Add missing cstdint includes for the MySql/Database headers

### DIFF
--- a/deps/mysqlConnector/Connection.h
+++ b/deps/mysqlConnector/Connection.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <memory>
 #include <map>
+#include <cstdint>
 #include "MysqlCommon.h"
 
 typedef struct st_mysql MYSQL;

--- a/deps/mysqlConnector/MySqlBase.h
+++ b/deps/mysqlConnector/MySqlBase.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <string>
 #include <map>
+#include <cstdint>
 #include "MysqlCommon.h"
 
 

--- a/src/common/Database/DbCommon.h
+++ b/src/common/Database/DbCommon.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <cstdint>
 
 namespace Sapphire::Db
 {

--- a/src/common/Navi/NaviMgr.h
+++ b/src/common/Navi/NaviMgr.h
@@ -4,6 +4,7 @@
 
 #include <string>
 #include <unordered_map>
+#include <cstdint>
 
 namespace Sapphire::Common::Navi
 {


### PR DESCRIPTION
This fixes builds on recent enough GCC versions where they culled whatever <cstdint> include was hiding in an already-included header.