### PR TITLE
Item fixes

### DIFF
--- a/src/scripts/common/GilShop.cpp
+++ b/src/scripts/common/GilShop.cpp
@@ -30,23 +30,27 @@ private:
     {
       // buy
       if( result.getResult( 1 ) == 1 )
-      {
-        auto& shopMgr = Common::Service< Sapphire::World::Manager::ShopMgr >::ref();
-        shopMgr.purchaseGilShopItem( player, result.getResult( 4 ), result.getResult( 6 ), result.getResult( 5 ) );
-      }
+        shopMgr().purchaseGilShopItem( player, result.getResult( 4 ), result.getResult( 6 ), result.getResult( 5 ) );
 
       // sell
       // can't sell if the vendor is yourself (eg, housing permit shop)
       else if( result.getResult( 1 ) == 2 && result.actorId != player.getId() )
-      {
-        auto& shopMgr = Common::Service< Sapphire::World::Manager::ShopMgr >::ref();
-        shopMgr.sellGilShopItem( player, result.getResult( 2 ), result.getResult( 3 ), result.getResult( 6 ), result.getResult( 5 ) );
-      }
+        shopMgr().sellGilShopItem( player, result.getResult( 2 ), result.getResult( 3 ), result.getResult( 6 ), result.getResult( 5 ) );
 
       eventMgr().playGilShop( player, result.eventId, SCENE_FLAGS, result.getResult( 0 ), [ & ]( Entity::Player& player, const Event::SceneResult& result )
       {
         shopInteractionCallback( player, result );
       });
+      return;
+    }
+    else if( result.numOfResults == 5 )
+    {
+      shopMgr().purchaseBuybackItem( player, result.getResult( 2 ), result.getResult( 3 ), result.getResult( 4 ) );
+
+      eventMgr().playGilShop( player, result.eventId, SCENE_FLAGS, result.getResult( 0 ), [ & ]( Entity::Player& player, const Event::SceneResult& result )
+      {
+        shopInteractionCallback( player, result );
+      } );
       return;
     }
 

--- a/src/world/Actor/Player.h
+++ b/src/world/Actor/Player.h
@@ -191,6 +191,7 @@ namespace Sapphire::Entity
     bool collectHandInItems( std::vector< uint32_t > itemIds );
 
     void addSoldItem( uint32_t itemId, uint8_t stackSize );
+    void rebaseSoldItems( size_t idx );
 
     std::deque< std::pair< uint32_t, uint8_t > > *getSoldItems();
 

--- a/src/world/Actor/PlayerInventory.cpp
+++ b/src/world/Actor/PlayerInventory.cpp
@@ -1153,6 +1153,12 @@ std::deque< std::pair< uint32_t, uint8_t > >* Player::getSoldItems()
   return &m_soldItems;
 }
 
+void Player::rebaseSoldItems( size_t idx )
+{
+  auto it = m_soldItems.begin() + idx;
+  m_soldItems.erase( it );
+}
+
 void Player::clearSoldItems()
 {
   m_soldItems.clear();

--- a/src/world/Manager/EventMgr.cpp
+++ b/src/world/Manager/EventMgr.cpp
@@ -252,7 +252,7 @@ void EventMgr::handleReturnEventScene( Entity::Player& player, uint32_t eventId,
   uint8_t index = 0;
   for( auto r : results )
   {
-    PlayerMgr::sendDebug( player, "arg#{0}: {1} ({1:08X})", index++, r );
+    if( r ) PlayerMgr::sendDebug( player, "arg#{0}: {1} ({1:08X})", index++, r );
   }
 
   auto eventType = static_cast< uint16_t >( eventId >> 16 );
@@ -660,7 +660,7 @@ void EventMgr::playGilShop( Entity::Player& player, uint32_t eventId, uint32_t f
       auto item = exdData.getRow< Excel::Item >( it.first );
       params.push_back( it.first );          //itemCatalogId
       params.push_back( it.second );         //stack
-      params.push_back( item->data().Price );//price
+      params.push_back( item->data().PriceMin );//price
       params.push_back( 0 );                 //flag isHQ
       params.push_back( 0 );                 //numOfMateria
       params.push_back( eventId );           //shopId

--- a/src/world/Manager/ShopMgr.cpp
+++ b/src/world/Manager/ShopMgr.cpp
@@ -55,6 +55,30 @@ uint32_t ShopMgr::getShopItemPrices( uint32_t shopId, uint8_t index )
 
 }
 
+bool ShopMgr::purchaseBuybackItem( Entity::Player& player, uint32_t soldItemSlot, uint32_t quantity, uint32_t basePrice )
+{
+  auto soldItems = player.getSoldItems();
+
+  if( !soldItems || soldItems->size() < soldItemSlot )
+    return false;
+
+  auto refund = basePrice * quantity;
+
+  if( player.getCurrency( Common::CurrencyType::Gil ) < refund )
+    return false;
+
+  auto itemId = soldItems->at( soldItemSlot ).first;
+
+  if( !player.addItem( itemId, quantity ) )
+    return false;
+
+  player.removeCurrency( Common::CurrencyType::Gil, refund );
+
+  player.rebaseSoldItems( static_cast< size_t >( soldItemSlot ) );
+
+  return true;
+}
+
 bool ShopMgr::purchaseGilShopItem( Entity::Player& player, uint32_t shopId, uint16_t itemId, uint32_t quantity )
 {
   auto& exdData = Common::Service< Data::ExdData >::ref();
@@ -84,13 +108,13 @@ bool ShopMgr::sellGilShopItem( Entity::Player& player, uint16_t container, uint8
   if( !item )
     return false;
 
-  auto payback = ( item->data().Price ) * quantity;
+  auto payback = ( item->data().PriceMin ) * quantity;
 
   auto inventoryItem = player.getItemAt( container, fromSlot );
 
   // todo: adding stack remove
-  if( quantity > 1 )
-    return false;
+  //if( quantity > 1 )
+  //  return false;
 
   player.discardItem( ( Common::InventoryType )container, fromSlot );
   player.addSoldItem( itemId, quantity );

--- a/src/world/Manager/ShopMgr.h
+++ b/src/world/Manager/ShopMgr.h
@@ -14,6 +14,7 @@ namespace Sapphire::World::Manager
 
     uint32_t getShopItemPrices( uint32_t shopId, uint8_t index );
 
+    bool purchaseBuybackItem( Sapphire::Entity::Player& player, uint32_t soldItemSlot, uint32_t quantity, uint32_t refund );
     bool purchaseGilShopItem( Sapphire::Entity::Player& player, uint32_t shopId, uint16_t itemId, uint32_t quantity );
     bool sellGilShopItem( Sapphire::Entity::Player & player, uint16_t container, uint8_t fromSlot, uint16_t item, uint32_t quantity );
   };

--- a/src/world/Script/NativeScriptApi.h
+++ b/src/world/Script/NativeScriptApi.h
@@ -10,6 +10,7 @@
 #include "Manager/StatusEffectMgr.h"
 #include "Manager/TerritoryMgr.h"
 #include "Manager/WarpMgr.h"
+#include "Manager/ShopMgr.h"
 #include "Exd/ExdData.h"
 #include "Territory/InstanceContent.h"
 #include "Territory/InstanceObjectCache.h"
@@ -240,6 +241,11 @@ namespace Sapphire::ScriptAPI
     World::Manager::TerritoryMgr& teriMgr()
     {
       return Common::Service< World::Manager::TerritoryMgr >::ref();
+    }
+
+    World::Manager::ShopMgr& shopMgr()
+    {
+      return Common::Service< World::Manager::ShopMgr >::ref();
     }
   };
 


### PR DESCRIPTION
The gilshops were ending the event prematurely in the case of a buyback, blocking the shop's event.
With this addition, it is now possible to repurchase sold items.

- **TODO**: Re-check the functions for adding/removing and merging items (strange things are happening).

